### PR TITLE
Add CI build

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -25,6 +25,9 @@ jobs:
             artifact-name: osx
 
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: src
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -16,13 +16,13 @@ jobs:
         include:
           - os: ubuntu-latest
             runtime-id: linux-x64
-            artifact-name: linux
+            artifact-name: linux-x64.zip
           - os: windows-latest
             runtime-id: win-x64
-            artifact-name: windows
+            artifact-name: windows-x64.zip
           - os: macos-latest
             runtime-id: osx-x64
-            artifact-name: osx
+            artifact-name: osx-x64.zip
 
     runs-on: ${{ matrix.os }}
     defaults:
@@ -37,6 +37,28 @@ jobs:
         with:
           dotnet-version: 8.0.x
 
+      - name: Get release version
+        id: get_release_version
+        uses: paulhatch/semantic-version@v5.4.0
+        with:
+          tag_prefix: "v"
+          version_format: "${major}.${minor}.${patch}"
+
+      - name: Get branch names
+        id: branch_names
+        uses: OctopusDeploy/util-actions/current-branch-name@current-branch-name.0.1.0
+
+      - name: Get pre-release version
+        id: get_pre_release_version
+        uses: paulhatch/semantic-version@v5.4.0
+        with:
+          tag_prefix: "v"
+          version_format: "${major}.${minor}.${patch}-${{ steps.branch_names.outputs.branch_name }}.${{ github.run_number }}-${{ github.run_attempt }}"
+
+      - name: Get version
+        id: get_version
+        run: echo "version=${{ github.ref == 'refs/heads/main' && github.event_name == 'push' && steps.get_release_version.outputs.version || steps.get_pre_release_version.outputs.version }}" >> $GITHUB_OUTPUT
+
       - name: Restore dependencies
         run: dotnet restore
 
@@ -47,7 +69,7 @@ jobs:
         run: dotnet test --no-build -c Release --verbosity normal
 
       - name: Publish
-        run: dotnet publish Stack/Stack.csproj -c Release -r ${{ matrix.runtime-id }} -o ${{ github.workspace }}/publish
+        run: dotnet publish Stack/Stack.csproj -c Release -r ${{ matrix.runtime-id }} -o ${{ github.workspace }}/publish -p:Version=${{ steps.get_version.outputs.version }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -55,3 +77,43 @@ jobs:
           overwrite: true
           name: ${{ matrix.artifact-name }}
           path: ${{ github.workspace }}/publish
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ${{ github.workspace }}/publish
+
+      - name: Get release version
+        id: get_release_version
+        uses: paulhatch/semantic-version@v5.4.0
+        with:
+          tag_prefix: "v"
+          version_format: "${major}.${minor}.${patch}"
+
+      - name: Create tag
+        uses: actions/github-script@v6.3.3
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/v${{ steps.get_release_version.outputs.version }}',
+              sha: context.sha
+            })
+
+      - name: Create release
+        id: create_release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.get_release_version.outputs.version }}
+          draft: false
+          prerelease: false
+          files: ${{ github.workspace }}/publish/*

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -10,7 +10,35 @@ on:
     branches: ["main"]
 
 jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+    steps:
+      - name: Get release version
+        id: get_release_version
+        uses: paulhatch/semantic-version@v5.4.0
+        with:
+          tag_prefix: "v"
+          version_format: "${major}.${minor}.${patch}"
+
+      - name: Get branch names
+        id: branch_names
+        uses: OctopusDeploy/util-actions/current-branch-name@current-branch-name.0.1.0
+
+      - name: Get pre-release version
+        id: get_pre_release_version
+        uses: paulhatch/semantic-version@v5.4.0
+        with:
+          tag_prefix: "v"
+          version_format: "${major}.${minor}.${patch}-${{ steps.branch_names.outputs.branch_name }}.${{ github.run_number }}-${{ github.run_attempt }}"
+
+      - name: Get version
+        id: get_version
+        run: echo "version=${{ github.ref == 'refs/heads/main' && github.event_name == 'push' && steps.get_release_version.outputs.version || steps.get_pre_release_version.outputs.version }}" >> $GITHUB_OUTPUT
+
   build:
+    needs: version
     strategy:
       matrix:
         include:
@@ -37,28 +65,6 @@ jobs:
         with:
           dotnet-version: 8.0.x
 
-      - name: Get release version
-        id: get_release_version
-        uses: paulhatch/semantic-version@v5.4.0
-        with:
-          tag_prefix: "v"
-          version_format: "${major}.${minor}.${patch}"
-
-      - name: Get branch names
-        id: branch_names
-        uses: OctopusDeploy/util-actions/current-branch-name@current-branch-name.0.1.0
-
-      - name: Get pre-release version
-        id: get_pre_release_version
-        uses: paulhatch/semantic-version@v5.4.0
-        with:
-          tag_prefix: "v"
-          version_format: "${major}.${minor}.${patch}-${{ steps.branch_names.outputs.branch_name }}.${{ github.run_number }}-${{ github.run_attempt }}"
-
-      - name: Get version
-        id: get_version
-        run: echo "version=${{ github.ref == 'refs/heads/main' && github.event_name == 'push' && steps.get_release_version.outputs.version || steps.get_pre_release_version.outputs.version }}" >> $GITHUB_OUTPUT
-
       - name: Restore dependencies
         run: dotnet restore
 
@@ -69,7 +75,7 @@ jobs:
         run: dotnet test --no-build -c Release --verbosity normal
 
       - name: Publish
-        run: dotnet publish Stack/Stack.csproj -p:Version=${{ steps.get_version.outputs.version }} -c Release -r ${{ matrix.runtime-id }} -o ${{ github.workspace }}/publish
+        run: dotnet publish Stack/Stack.csproj -c Release -r ${{ matrix.runtime-id }} -p:Version=${{ needs.version.outputs.version }} -o ${{ github.workspace }}/publish
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -79,7 +85,7 @@ jobs:
           path: ${{ github.workspace }}/publish
 
   publish:
-    needs: build
+    needs: [version, build]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
@@ -91,13 +97,6 @@ jobs:
         with:
           pattern: ${{ github.workspace }}/publish
 
-      - name: Get release version
-        id: get_release_version
-        uses: paulhatch/semantic-version@v5.4.0
-        with:
-          tag_prefix: "v"
-          version_format: "${major}.${minor}.${patch}"
-
       - name: Create tag
         uses: actions/github-script@v6.3.3
         with:
@@ -105,7 +104,7 @@ jobs:
             github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: 'refs/tags/v${{ steps.get_release_version.outputs.version }}',
+              ref: 'refs/tags/v${{ needs.version.outputs.version }}',
               sha: context.sha
             })
 
@@ -113,7 +112,7 @@ jobs:
         id: create_release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: v${{ steps.get_release_version.outputs.version }}
+          tag_name: v${{ needs.version.outputs.version }}
           draft: false
           prerelease: false
           files: ${{ github.workspace }}/publish/*

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,0 +1,53 @@
+# This workflow will build a .NET project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
+
+name: Build and test
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            runtime-id: ubuntu.20.04-x64
+            artifact-name: linux
+          - os: windows-latest
+            runtime-id: win-x64
+            artifact-name: windows
+          - os: macos-latest
+            runtime-id: osx-x64
+            artifact-name: osx
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore
+
+      - name: Test
+        run: dotnet test --no-build --verbosity normal
+
+      - name: Publish
+        run: dotnet publish -c Release -r ${{ matrix.runtime-id }} -o ${{ github.workspace }}/publish
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.artifact-name }}
+          path: ${{ github.workspace }}/publish

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -69,7 +69,7 @@ jobs:
         run: dotnet test --no-build -c Release --verbosity normal
 
       - name: Publish
-        run: dotnet publish Stack/Stack.csproj -c Release -r ${{ matrix.runtime-id }} -o ${{ github.workspace }}/publish -p:Version=${{ steps.get_version.outputs.version }}
+        run: dotnet publish Stack/Stack.csproj -p:Version=${{ steps.get_version.outputs.version }} -c Release -r ${{ matrix.runtime-id }} -o ${{ github.workspace }}/publish
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -47,7 +47,8 @@ jobs:
         run: dotnet publish -c Release -r ${{ matrix.runtime-id }} -o ${{ github.workspace }}/publish
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
+          overwrite: true
           name: ${{ matrix.artifact-name }}
           path: ${{ github.workspace }}/publish

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -16,13 +16,13 @@ jobs:
         include:
           - os: ubuntu-latest
             runtime-id: linux-x64
-            artifact-name: linux-x64.zip
+            artifact-name: linux-x64
           - os: windows-latest
             runtime-id: win-x64
-            artifact-name: windows-x64.zip
+            artifact-name: windows-x64
           - os: macos-latest
             runtime-id: osx-x64
-            artifact-name: osx-x64.zip
+            artifact-name: osx-x64
 
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -47,7 +47,7 @@ jobs:
         run: dotnet test --no-build --verbosity normal
 
       - name: Publish
-        run: dotnet publish -c Release -r ${{ matrix.runtime-id }} -o ${{ github.workspace }}/publish
+        run: dotnet publish Stack/Stack.csproj --no-build -c Release -r ${{ matrix.runtime-id }} -o ${{ github.workspace }}/publish
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -41,10 +41,10 @@ jobs:
         run: dotnet restore
 
       - name: Build
-        run: dotnet build --no-restore
+        run: dotnet build --no-restore -c Release
 
       - name: Test
-        run: dotnet test --no-build --verbosity normal
+        run: dotnet test --no-build -c Release --verbosity normal
 
       - name: Publish
         run: dotnet publish Stack/Stack.csproj --no-build -c Release -r ${{ matrix.runtime-id }} -o ${{ github.workspace }}/publish

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -47,7 +47,7 @@ jobs:
         run: dotnet test --no-build -c Release --verbosity normal
 
       - name: Publish
-        run: dotnet publish Stack/Stack.csproj --no-build -c Release -r ${{ matrix.runtime-id }} -o ${{ github.workspace }}/publish
+        run: dotnet publish Stack/Stack.csproj -c Release -r ${{ matrix.runtime-id }} -o ${{ github.workspace }}/publish
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            runtime-id: ubuntu.20.04-x64
+            runtime-id: linux-x64
             artifact-name: linux
           - os: windows-latest
             runtime-id: win-x64

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   version:
+    name: Get version
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get_version.outputs.version }}
@@ -42,15 +43,20 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
+          - name: Linux
+            os: ubuntu-latest
             runtime-id: linux-x64
             artifact-name: linux-x64
-          - os: windows-latest
+          - name: Windows
+            os: windows-latest
             runtime-id: win-x64
             artifact-name: windows-x64
-          - os: macos-latest
+          - name: macOS
+            os: macos-latest
             runtime-id: osx-x64
             artifact-name: osx-x64
+
+    name: Build and test on ${{ matrix.name }}
 
     runs-on: ${{ matrix.os }}
     defaults:
@@ -85,6 +91,7 @@ jobs:
           path: ${{ github.workspace }}/publish
 
   publish:
+    name: Publish release version
     needs: [version, build]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
Adds a CI build for Linux, Windows and MacOS with a publish step for pushes to main to tag repo and create a release with assets.