### PR TITLE
Use `IAnsiConsole` interface instead of `AnsiConsole`

### DIFF
--- a/src/Stack/Commands/Branch/AddBranchCommand.cs
+++ b/src/Stack/Commands/Branch/AddBranchCommand.cs
@@ -17,7 +17,7 @@ internal class AddBranchCommandSettings : DryRunCommandSettingsBase
     public string? Name { get; init; }
 }
 
-internal class AddBranchCommand : AsyncCommand<AddBranchCommandSettings>
+internal class AddBranchCommand(IAnsiConsole console) : AsyncCommand<AddBranchCommandSettings>
 {
     public override async Task<int> ExecuteAsync(CommandContext context, AddBranchCommandSettings settings)
     {
@@ -34,24 +34,24 @@ internal class AddBranchCommand : AsyncCommand<AddBranchCommandSettings>
 
         if (stacksForRemote.Count == 0)
         {
-            AnsiConsole.WriteLine("No stacks found for current repository.");
+            console.WriteLine("No stacks found for current repository.");
             return 0;
         }
 
-        var stackSelection = settings.Stack ?? AnsiConsole.Prompt(Prompts.Stack(stacksForRemote, currentBranch));
+        var stackSelection = settings.Stack ?? console.Prompt(Prompts.Stack(stacksForRemote, currentBranch));
         var stack = stacksForRemote.First(s => s.Name.Equals(stackSelection, StringComparison.OrdinalIgnoreCase));
 
         var sourceBranch = stack.Branches.LastOrDefault() ?? stack.SourceBranch;
 
-        var branchName = settings.Name ?? AnsiConsole.Prompt(Prompts.Branch(branches));
+        var branchName = settings.Name ?? console.Prompt(Prompts.Branch(branches));
 
-        AnsiConsole.WriteLine($"Adding branch '{branchName}' to stack '{stack.Name}'");
+        console.WriteLine($"Adding branch '{branchName}' to stack '{stack.Name}'");
 
         stack.Branches.Add(branchName);
 
         StackConfig.Save(stacks);
 
-        AnsiConsole.WriteLine($"Branch added");
+        console.WriteLine($"Branch added");
         return 0;
     }
 }

--- a/src/Stack/Commands/Branch/BranchCommand.cs
+++ b/src/Stack/Commands/Branch/BranchCommand.cs
@@ -32,7 +32,7 @@ internal enum BranchAction
     Create
 }
 
-internal class BranchCommand : AsyncCommand<BranchCommandSettings>
+internal class BranchCommand(IAnsiConsole console) : AsyncCommand<BranchCommandSettings>
 {
     public override async Task<int> ExecuteAsync(CommandContext context, BranchCommandSettings settings)
     {
@@ -49,11 +49,11 @@ internal class BranchCommand : AsyncCommand<BranchCommandSettings>
 
         if (stacksForRemote.Count == 0)
         {
-            AnsiConsole.WriteLine("No stacks found for current repository.");
+            console.WriteLine("No stacks found for current repository.");
             return 0;
         }
 
-        var stackSelection = settings.Stack ?? AnsiConsole.Prompt(Prompts.Stack(stacksForRemote, currentBranch));
+        var stackSelection = settings.Stack ?? console.Prompt(Prompts.Stack(stacksForRemote, currentBranch));
         var stack = stacksForRemote.First(s => s.Name.Equals(stackSelection, StringComparison.OrdinalIgnoreCase));
 
         var actionPromptOption = new SelectionPrompt<BranchAction>()
@@ -61,15 +61,15 @@ internal class BranchCommand : AsyncCommand<BranchCommandSettings>
             .AddChoices([BranchAction.Create, BranchAction.Add])
             .UseConverter(action => action.Humanize());
 
-        var action = AnsiConsole.Prompt(actionPromptOption);
+        var action = console.Prompt(actionPromptOption);
 
         if (action == BranchAction.Add)
         {
-            return await new AddBranchCommand().ExecuteAsync(context, new AddBranchCommandSettings { Stack = stack.Name, Name = settings.Name, DryRun = settings.DryRun, Verbose = settings.Verbose });
+            return await new AddBranchCommand(console).ExecuteAsync(context, new AddBranchCommandSettings { Stack = stack.Name, Name = settings.Name, DryRun = settings.DryRun, Verbose = settings.Verbose });
         }
         else
         {
-            return await new NewBranchCommand().ExecuteAsync(context, new NewBranchCommandSettings { Stack = stack.Name, Name = settings.Name, DryRun = settings.DryRun, Verbose = settings.Verbose });
+            return await new NewBranchCommand(console).ExecuteAsync(context, new NewBranchCommandSettings { Stack = stack.Name, Name = settings.Name, DryRun = settings.DryRun, Verbose = settings.Verbose });
         }
     }
 }

--- a/src/Stack/Commands/Branch/NewBranchCommand.cs
+++ b/src/Stack/Commands/Branch/NewBranchCommand.cs
@@ -17,7 +17,7 @@ internal class NewBranchCommandSettings : DryRunCommandSettingsBase
     public string? Name { get; init; }
 }
 
-internal class NewBranchCommand : AsyncCommand<NewBranchCommandSettings>
+internal class NewBranchCommand(IAnsiConsole console) : AsyncCommand<NewBranchCommandSettings>
 {
     public override async Task<int> ExecuteAsync(CommandContext context, NewBranchCommandSettings settings)
     {
@@ -33,18 +33,18 @@ internal class NewBranchCommand : AsyncCommand<NewBranchCommandSettings>
 
         if (stacksForRemote.Count == 0)
         {
-            AnsiConsole.WriteLine("No stacks found for current repository.");
+            console.WriteLine("No stacks found for current repository.");
             return 0;
         }
 
-        var stackSelection = settings.Stack ?? AnsiConsole.Prompt(Prompts.Stack(stacksForRemote, currentBranch));
+        var stackSelection = settings.Stack ?? console.Prompt(Prompts.Stack(stacksForRemote, currentBranch));
         var stack = stacksForRemote.First(s => s.Name.Equals(stackSelection, StringComparison.OrdinalIgnoreCase));
 
         var sourceBranch = stack.Branches.LastOrDefault() ?? stack.SourceBranch;
 
-        var branchName = settings.Name ?? AnsiConsole.Prompt(new TextPrompt<string>("Branch name:"));
+        var branchName = settings.Name ?? console.Prompt(new TextPrompt<string>("Branch name:"));
 
-        AnsiConsole.WriteLine($"Creating branch '{branchName}' from '{sourceBranch}' in stack '{stack.Name}'");
+        console.WriteLine($"Creating branch '{branchName}' from '{sourceBranch}' in stack '{stack.Name}'");
 
         GitOperations.CreateNewBranch(branchName, sourceBranch, settings.GetGitOperationSettings());
         GitOperations.PushNewBranch(branchName, settings.GetGitOperationSettings());
@@ -53,9 +53,9 @@ internal class NewBranchCommand : AsyncCommand<NewBranchCommandSettings>
 
         StackConfig.Save(stacks);
 
-        AnsiConsole.WriteLine($"Branch created");
+        console.WriteLine($"Branch created");
 
-        var switchToNewBranch = AnsiConsole.Prompt(new ConfirmationPrompt("Do you want to switch to the new branch?"));
+        var switchToNewBranch = console.Prompt(new ConfirmationPrompt("Do you want to switch to the new branch?"));
 
         if (switchToNewBranch)
         {

--- a/src/Stack/Commands/Config/OpenConfigCommand.cs
+++ b/src/Stack/Commands/Config/OpenConfigCommand.cs
@@ -9,7 +9,7 @@ internal class OpenConfigCommandSettings : CommandSettingsBase
 {
 }
 
-internal class OpenConfigCommand : AsyncCommand<CommandSettingsBase>
+internal class OpenConfigCommand(IAnsiConsole console) : AsyncCommand<CommandSettingsBase>
 {
     public override async Task<int> ExecuteAsync(CommandContext context, CommandSettingsBase settings)
     {
@@ -19,7 +19,7 @@ internal class OpenConfigCommand : AsyncCommand<CommandSettingsBase>
 
         if (!File.Exists(configPath))
         {
-            AnsiConsole.WriteLine("No config file found.");
+            console.WriteLine("No config file found.");
             return 0;
         }
 

--- a/src/Stack/Commands/Stack/DeleteStackCommand.cs
+++ b/src/Stack/Commands/Stack/DeleteStackCommand.cs
@@ -14,7 +14,7 @@ internal class DeleteStackCommandSettings : CommandSettingsBase
     public string? Name { get; init; }
 }
 
-internal class DeleteStackCommand : AsyncCommand<DeleteStackCommandSettings>
+internal class DeleteStackCommand(IAnsiConsole console) : AsyncCommand<DeleteStackCommandSettings>
 {
     public override async Task<int> ExecuteAsync(CommandContext context, DeleteStackCommandSettings settings)
     {
@@ -29,18 +29,18 @@ internal class DeleteStackCommand : AsyncCommand<DeleteStackCommandSettings>
 
         if (stacksForRemote.Count == 0)
         {
-            AnsiConsole.WriteLine("No stacks found for current repository.");
+            console.WriteLine("No stacks found for current repository.");
             return 0;
         }
 
-        var stackSelection = settings.Name ?? AnsiConsole.Prompt(Prompts.Stack(stacksForRemote, currentBranch));
+        var stackSelection = settings.Name ?? console.Prompt(Prompts.Stack(stacksForRemote, currentBranch));
         var stack = stacksForRemote.First(s => s.Name.Equals(stackSelection, StringComparison.OrdinalIgnoreCase));
 
-        if (AnsiConsole.Prompt(new ConfirmationPrompt("Are you sure you want to delete this stack?")))
+        if (console.Prompt(new ConfirmationPrompt("Are you sure you want to delete this stack?")))
         {
             stacks.Remove(stack);
             StackConfig.Save(stacks);
-            AnsiConsole.WriteLine($"Stack deleted");
+            console.WriteLine($"Stack deleted");
         }
 
         return 0;

--- a/src/Stack/Commands/Stack/ListStacksCommand.cs
+++ b/src/Stack/Commands/Stack/ListStacksCommand.cs
@@ -8,7 +8,7 @@ namespace Stack.Commands;
 
 internal class ListStacksCommandSettings : CommandSettingsBase;
 
-internal class ListStacksCommand : AsyncCommand<ListStacksCommandSettings>
+internal class ListStacksCommand(IAnsiConsole console) : AsyncCommand<ListStacksCommandSettings>
 {
     public override async Task<int> ExecuteAsync(CommandContext context, ListStacksCommandSettings settings)
     {
@@ -19,7 +19,7 @@ internal class ListStacksCommand : AsyncCommand<ListStacksCommandSettings>
 
         if (remoteUri is null)
         {
-            AnsiConsole.WriteLine("No stacks found for current repository.");
+            console.WriteLine("No stacks found for current repository.");
             return 0;
         }
 
@@ -27,13 +27,13 @@ internal class ListStacksCommand : AsyncCommand<ListStacksCommandSettings>
 
         if (stacksForRemote.Count == 0)
         {
-            AnsiConsole.WriteLine("No stacks found for current repository.");
+            console.WriteLine("No stacks found for current repository.");
             return 0;
         }
 
         foreach (var stack in stacksForRemote)
         {
-            AnsiConsole.MarkupLine($"[yellow]{stack.Name}[/] [grey]({stack.SourceBranch})[/] {"branch".ToQuantity(stack.Branches.Count)}");
+            console.MarkupLine($"[yellow]{stack.Name}[/] [grey]({stack.SourceBranch})[/] {"branch".ToQuantity(stack.Branches.Count)}");
         }
 
         return 0;

--- a/src/Stack/Commands/Stack/StackStatusCommand.cs
+++ b/src/Stack/Commands/Stack/StackStatusCommand.cs
@@ -20,7 +20,7 @@ internal class StackStatusCommandSettings : CommandSettingsBase
 
 record BranchStatus(bool ExistsInRemote, int Ahead, int Behind);
 
-internal class StackStatusCommand : AsyncCommand<StackStatusCommandSettings>
+internal class StackStatusCommand(IAnsiConsole console) : AsyncCommand<StackStatusCommandSettings>
 {
     record StackStatus(Dictionary<string, BranchStatus> BranchStatuses, Dictionary<string, GitHubPullRequest> PullRequests);
 
@@ -33,7 +33,7 @@ internal class StackStatusCommand : AsyncCommand<StackStatusCommandSettings>
 
         if (remoteUri is null)
         {
-            AnsiConsole.WriteLine("No stacks found for current repository.");
+            console.WriteLine("No stacks found for current repository.");
             return 0;
         }
 
@@ -41,7 +41,7 @@ internal class StackStatusCommand : AsyncCommand<StackStatusCommandSettings>
 
         if (stacksForRemote.Count == 0)
         {
-            AnsiConsole.WriteLine("No stacks found for current repository.");
+            console.WriteLine("No stacks found for current repository.");
             return 0;
         }
 
@@ -55,12 +55,12 @@ internal class StackStatusCommand : AsyncCommand<StackStatusCommandSettings>
         }
         else
         {
-            var stackSelection = settings.Name ?? AnsiConsole.Prompt(Prompts.Stack(stacksForRemote, currentBranch));
+            var stackSelection = settings.Name ?? console.Prompt(Prompts.Stack(stacksForRemote, currentBranch));
             var stack = stacksForRemote.First(s => s.Name.Equals(stackSelection, StringComparison.OrdinalIgnoreCase));
             stacksToCheckStatusFor.Add(stack, new StackStatus([], []));
         }
 
-        AnsiConsole.Status()
+        console.Status()
             .Start("Checking status of remote branches...", ctx =>
             {
                 foreach (var (stack, status) in stacksToCheckStatusFor
@@ -95,7 +95,7 @@ internal class StackStatusCommand : AsyncCommand<StackStatusCommandSettings>
                 }
             });
 
-        AnsiConsole.Status()
+        console.Status()
             .Start("Checking status of GitHub pull requests...", ctx =>
             {
                 foreach (var (stack, status) in stacksToCheckStatusFor)
@@ -114,7 +114,7 @@ internal class StackStatusCommand : AsyncCommand<StackStatusCommandSettings>
                     }
                     catch (Exception ex)
                     {
-                        AnsiConsole.MarkupLine($"[orange1]Error checking GitHub pull requests: {ex.Message}[/]");
+                        console.MarkupLine($"[orange1]Error checking GitHub pull requests: {ex.Message}[/]");
                     }
                 }
             });
@@ -190,7 +190,7 @@ internal class StackStatusCommand : AsyncCommand<StackStatusCommandSettings>
                 }
             }
 
-            AnsiConsole.Write(stackRoot);
+            console.Write(stackRoot);
         }
 
         return 0;

--- a/src/Stack/Commands/Stack/StackSwitchCommand.cs
+++ b/src/Stack/Commands/Stack/StackSwitchCommand.cs
@@ -18,7 +18,7 @@ internal class StackSwitchCommandSettings : CommandSettingsBase
     public string? Branch { get; init; }
 }
 
-internal class StackSwitchCommand : AsyncCommand<StackStatusCommandSettings>
+internal class StackSwitchCommand(IAnsiConsole console) : AsyncCommand<StackStatusCommandSettings>
 {
     public override async Task<int> ExecuteAsync(CommandContext context, StackStatusCommandSettings settings)
     {
@@ -29,7 +29,7 @@ internal class StackSwitchCommand : AsyncCommand<StackStatusCommandSettings>
 
         if (remoteUri is null)
         {
-            AnsiConsole.WriteLine("No stacks found for current repository.");
+            console.WriteLine("No stacks found for current repository.");
             return 0;
         }
 
@@ -37,7 +37,7 @@ internal class StackSwitchCommand : AsyncCommand<StackStatusCommandSettings>
 
         if (stacksForRemote.Count == 0)
         {
-            AnsiConsole.WriteLine("No stacks found for current repository.");
+            console.WriteLine("No stacks found for current repository.");
             return 0;
         }
 
@@ -54,7 +54,7 @@ internal class StackSwitchCommand : AsyncCommand<StackStatusCommandSettings>
             branchSelectionPrompt.AddChoiceGroup(stack.Name, branchesThatExistLocally);
         }
 
-        var selectedBranch = AnsiConsole.Prompt(branchSelectionPrompt);
+        var selectedBranch = console.Prompt(branchSelectionPrompt);
 
         GitOperations.ChangeBranch(selectedBranch, settings.GetGitOperationSettings());
 

--- a/src/Stack/Commands/Stack/UpdateStackCommand.cs
+++ b/src/Stack/Commands/Stack/UpdateStackCommand.cs
@@ -13,7 +13,7 @@ internal class UpdateStackCommandSettings : DryRunCommandSettingsBase
     public string? Name { get; init; }
 }
 
-internal class UpdateStackCommand : AsyncCommand<UpdateStackCommandSettings>
+internal class UpdateStackCommand(IAnsiConsole console) : AsyncCommand<UpdateStackCommandSettings>
 {
     public override async Task<int> ExecuteAsync(CommandContext context, UpdateStackCommandSettings settings)
     {
@@ -27,7 +27,7 @@ internal class UpdateStackCommand : AsyncCommand<UpdateStackCommandSettings>
 
         if (stacksForRemote.Count == 0)
         {
-            AnsiConsole.WriteLine("No stacks found for current repository.");
+            console.WriteLine("No stacks found for current repository.");
             return 0;
         }
 
@@ -35,13 +35,13 @@ internal class UpdateStackCommand : AsyncCommand<UpdateStackCommandSettings>
         var stackSelection = settings.Name ?? AnsiConsole.Prompt(Prompts.Stack(stacksForRemote, currentBranch));
         var stack = stacksForRemote.First(s => s.Name.Equals(stackSelection, StringComparison.OrdinalIgnoreCase));
 
-        AnsiConsole.MarkupLine($"Stack: {stack.Name}");
+        console.MarkupLine($"Stack: {stack.Name}");
 
-        if (AnsiConsole.Prompt(new ConfirmationPrompt("Are you sure you want to update the branches in this stack?")))
+        if (console.Prompt(new ConfirmationPrompt("Are you sure you want to update the branches in this stack?")))
         {
             void MergeFromSourceBranch(string branch, string sourceBranchName)
             {
-                AnsiConsole.MarkupLine($"Merging [blue]{sourceBranchName}[/] into [blue]{branch}[/]");
+                console.MarkupLine($"Merging [blue]{sourceBranchName}[/] into [blue]{branch}[/]");
 
                 GitOperations.UpdateBranch(sourceBranchName, settings.GetGitOperationSettings());
                 GitOperations.UpdateBranch(branch, settings.GetGitOperationSettings());
@@ -61,7 +61,7 @@ internal class UpdateStackCommand : AsyncCommand<UpdateStackCommandSettings>
                 else
                 {
                     // Remote branch no longer exists, skip over
-                    AnsiConsole.MarkupLine($"[red]Branch '{branch}' no longer exists on the remote repository. Skipping...[/]");
+                    console.MarkupLine($"[red]Branch '{branch}' no longer exists on the remote repository. Skipping...[/]");
                 }
             }
 

--- a/src/Stack/Program.cs
+++ b/src/Stack/Program.cs
@@ -1,14 +1,15 @@
 ﻿
 using Microsoft.Extensions.DependencyInjection;
+using Spectre.Console;
 using Spectre.Console.Cli;
 using Stack.Commands;
 using Stack.Help;
 using Stack.Infrastructure;
 
 var services = new ServiceCollection();
-var registrar = new ServiceCollectionTypeRegistrar(services);
+services.AddSingleton(AnsiConsole.Console);
 
-var app = new CommandApp(registrar);
+var app = new CommandApp(new ServiceCollectionTypeRegistrar(services));
 app.Configure(configure =>
 {
     configure.SetApplicationName("stack");


### PR DESCRIPTION
This PR is part of a stack that refactors from static classes to interfaces for testability and maintainability:
- https://github.com/geofflamrock/stack/pull/9
- https://github.com/geofflamrock/stack/pull/10
- https://github.com/geofflamrock/stack/pull/11
- https://github.com/geofflamrock/stack/pull/12
- https://github.com/geofflamrock/stack/pull/13

This PR changes most usages of `AnsiConsole` to use the `IAnsiConsole` interface and inject it into components.