### PR TITLE
Move `branch` command to top level and introduce `branches` group

### DIFF
--- a/src/Stack/Program.cs
+++ b/src/Stack/Program.cs
@@ -33,10 +33,10 @@ app.Configure(configure =>
     configure.AddCommand<OpenConfigCommand>("config").WithDescription("Opens the configuration file in the default editor.");
 
     // Branch commands
-    configure.AddBranch("branch", branch =>
+    configure.AddCommand<BranchCommand>("branch").WithDescription("Create or add a new branch to a stack.");
+    configure.AddBranch("branches", branch =>
         {
             branch.SetDescription("Manages branches in a stack.");
-            branch.SetDefaultCommand<BranchCommand>();
             branch.AddCommand<NewBranchCommand>("new").WithDescription("Creates a new branch in a stack.");
             branch.AddCommand<AddBranchCommand>("add").WithDescription("Adds an existing branch in a stack.");
         });


### PR DESCRIPTION
This PR adds a separate `branches` command group to manage branches, moving the `branch` command to the top level, else prob no-one would find the sub-commands.