### PR TITLE
Change back to `branch` command

### DIFF
--- a/src/Stack/Program.cs
+++ b/src/Stack/Program.cs
@@ -29,18 +29,16 @@ app.Configure(configure =>
     configure.AddCommand<DeleteStackCommand>("delete").WithDescription("Deletes a stack.");
     configure.AddCommand<UpdateStackCommand>("update").WithDescription("Updates the branches in a stack.");
 
-    // Config commands
-    configure.AddCommand<OpenConfigCommand>("config").WithDescription("Opens the configuration file in the default editor.");
-
     // Branch commands
-    configure.AddCommand<BranchCommand>("branch").WithDescription("Create or add a new branch to a stack.");
-    configure.AddBranch("branches", branch =>
+    configure.AddBranch("branch", branch =>
         {
             branch.SetDescription("Manages branches in a stack.");
             branch.AddCommand<NewBranchCommand>("new").WithDescription("Creates a new branch in a stack.");
             branch.AddCommand<AddBranchCommand>("add").WithDescription("Adds an existing branch in a stack.");
         });
 
+    // Config commands
+    configure.AddCommand<OpenConfigCommand>("config").WithDescription("Opens the configuration file in the default editor.");
 });
 
 await app.RunAsync(args);


### PR DESCRIPTION
This PR changes the `branches` command back to `branch`, I decided I like that more looking at other CLI tooling and it matches `git branch`. It also removes the default command so that help appears by default, to create or add a new branch you now need to use the sub-commands.