### PR TITLE
Move branch related commands together

### DIFF
--- a/src/Stack/Program.cs
+++ b/src/Stack/Program.cs
@@ -23,13 +23,13 @@ app.Configure(configure =>
 
     // Stack commands
     configure.AddCommand<NewStackCommand>("new").WithDescription("Creates a new stack.");
-    configure.AddCommand<ListStacksCommand>("list").WithDescription("Lists all stacks.");
+    configure.AddCommand<ListStacksCommand>("list").WithDescription("List stacks.");
     configure.AddCommand<StackStatusCommand>("status").WithDescription("Shows the status of a stack.");
-    configure.AddCommand<StackSwitchCommand>("switch").WithDescription("Switches to a branch in a stack.");
     configure.AddCommand<DeleteStackCommand>("delete").WithDescription("Deletes a stack.");
-    configure.AddCommand<UpdateStackCommand>("update").WithDescription("Updates the branches in a stack.");
 
     // Branch commands
+    configure.AddCommand<StackSwitchCommand>("switch").WithDescription("Switches to a branch in a stack.");
+    configure.AddCommand<UpdateStackCommand>("update").WithDescription("Updates the branches in a stack.");
     configure.AddBranch("branch", branch =>
         {
             branch.SetDescription("Manages branches in a stack.");


### PR DESCRIPTION
This PR moves the `stack switch` and `stack update` commands down to alongside the `stack branch` command as these logically all operate on branches within a stack.