### PR TITLE
Adds `--working-dir` option

### DIFF
--- a/src/Stack/Commands/Branch/BranchCommand.cs
+++ b/src/Stack/Commands/Branch/BranchCommand.cs
@@ -68,11 +68,25 @@ internal class BranchCommand(
 
         if (action == BranchAction.Add)
         {
-            return await new AddBranchCommand(console, gitOperations, stackConfig).ExecuteAsync(context, new AddBranchCommandSettings { Stack = stack.Name, Name = settings.Name, DryRun = settings.DryRun, Verbose = settings.Verbose });
+            return await new AddBranchCommand(console, gitOperations, stackConfig).ExecuteAsync(context, new AddBranchCommandSettings
+            {
+                Stack = stack.Name,
+                Name = settings.Name,
+                DryRun = settings.DryRun,
+                Verbose = settings.Verbose,
+                WorkingDirectory = settings.WorkingDirectory
+            });
         }
         else
         {
-            return await new NewBranchCommand(console, gitOperations, stackConfig).ExecuteAsync(context, new NewBranchCommandSettings { Stack = stack.Name, Name = settings.Name, DryRun = settings.DryRun, Verbose = settings.Verbose });
+            return await new NewBranchCommand(console, gitOperations, stackConfig).ExecuteAsync(context, new NewBranchCommandSettings
+            {
+                Stack = stack.Name,
+                Name = settings.Name,
+                DryRun = settings.DryRun,
+                Verbose = settings.Verbose,
+                WorkingDirectory = settings.WorkingDirectory
+            });
         }
     }
 }

--- a/src/Stack/Commands/Helpers/CommandSettingsBase.cs
+++ b/src/Stack/Commands/Helpers/CommandSettingsBase.cs
@@ -11,6 +11,10 @@ internal class CommandSettingsBase : CommandSettings
     [DefaultValue(false)]
     public bool Verbose { get; init; }
 
-    public virtual GitOperationSettings GetGitOperationSettings() => new(false, Verbose);
-    public virtual GitHubOperationSettings GetGitHubOperationSettings() => new(false, Verbose);
+    [Description("The path to the directory containing the git repository. Defaults to the current directory.")]
+    [CommandOption("--working-dir")]
+    public string? WorkingDirectory { get; init; }
+
+    public virtual GitOperationSettings GetGitOperationSettings() => new(false, Verbose, WorkingDirectory);
+    public virtual GitHubOperationSettings GetGitHubOperationSettings() => new(false, Verbose, WorkingDirectory);
 }

--- a/src/Stack/Commands/Helpers/DryRunCommandSettingsBase.cs
+++ b/src/Stack/Commands/Helpers/DryRunCommandSettingsBase.cs
@@ -12,5 +12,5 @@ internal class DryRunCommandSettingsBase : CommandSettingsBase
     [DefaultValue(false)]
     public bool DryRun { get; init; }
 
-    public override GitOperationSettings GetGitOperationSettings() => new(DryRun, Verbose);
+    public override GitOperationSettings GetGitOperationSettings() => new(DryRun, Verbose, WorkingDirectory);
 }

--- a/src/Stack/Commands/Stack/NewStackCommand.cs
+++ b/src/Stack/Commands/Stack/NewStackCommand.cs
@@ -53,7 +53,7 @@ internal class NewStackCommand(
 
         if (console.Prompt(new ConfirmationPrompt("Do you want to add an existing branch or create a new branch and add it to the stack?")))
         {
-            return await new BranchCommand(console, gitOperations, stackConfig).ExecuteAsync(context, new BranchCommandSettings { Stack = name, Verbose = settings.Verbose });
+            return await new BranchCommand(console, gitOperations, stackConfig).ExecuteAsync(context, new BranchCommandSettings { Stack = name, Verbose = settings.Verbose, WorkingDirectory = settings.WorkingDirectory });
         }
 
         return 0;

--- a/src/Stack/Git/GitHubOperations.cs
+++ b/src/Stack/Git/GitHubOperations.cs
@@ -4,9 +4,9 @@ using Spectre.Console;
 
 namespace Stack.Git;
 
-internal record GitHubOperationSettings(bool DryRun, bool Verbose)
+internal record GitHubOperationSettings(bool DryRun, bool Verbose, string? WorkingDirectory)
 {
-    public static GitHubOperationSettings Default => new GitHubOperationSettings(false, false);
+    public static GitHubOperationSettings Default => new(false, false, null);
 }
 
 internal static class GitHubPullRequestStates
@@ -45,7 +45,7 @@ internal class GitHubOperations(IAnsiConsole console) : IGitHubOperations
         var result = ShellExecutor.ExecuteCommand(
             "gh",
             command,
-            ".",
+            settings.WorkingDirectory ?? ".",
             (_) => { },
             (info) => infoBuilder.AppendLine(info),
             (error) => errorBuilder.AppendLine(error));

--- a/src/Stack/Git/GitOperations.cs
+++ b/src/Stack/Git/GitOperations.cs
@@ -179,7 +179,16 @@ internal class GitOperations(IAnsiConsole console) : IGitOperations
         }
         else
         {
-            ExecuteGitCommandAndReturnOutput(command, settings);
+            var output = ExecuteGitCommandAndReturnOutput(command, settings);
+
+            if (!settings.Verbose && output.Length > 0)
+            {
+                // We want to write the output of commands that perform
+                // changes to the Git repository as the output might be important.
+                // In verbose mode we would have already written the output
+                // of the command so don't write it again.
+                console.WriteLine(output);
+            }
         }
     }
 }

--- a/src/Stack/Git/GitOperations.cs
+++ b/src/Stack/Git/GitOperations.cs
@@ -4,9 +4,9 @@ using Spectre.Console;
 
 namespace Stack.Git;
 
-internal record GitOperationSettings(bool DryRun, bool Verbose)
+internal record GitOperationSettings(bool DryRun, bool Verbose, string? WorkingDirectory)
 {
-    public static GitOperationSettings Default => new GitOperationSettings(false, false);
+    public static GitOperationSettings Default => new(false, false, null);
 }
 
 
@@ -151,7 +151,7 @@ internal class GitOperations(IAnsiConsole console) : IGitOperations
         var result = ShellExecutor.ExecuteCommand(
             "git",
             command,
-            ".",
+            settings.WorkingDirectory ?? ".",
             (_) => { },
             (info) => infoBuilder.AppendLine(info),
             (error) => errorBuilder.AppendLine(error));
@@ -172,39 +172,14 @@ internal class GitOperations(IAnsiConsole console) : IGitOperations
 
     private void ExecuteGitCommand(string command, GitOperationSettings settings)
     {
-        if (settings.Verbose)
-            console.MarkupLine($"[grey]git {command}[/]");
-
-        if (!settings.DryRun)
+        if (settings.DryRun)
         {
-            ExecuteGitCommandInternal(command);
-        }
-    }
-
-    private void ExecuteGitCommandInternal(string command)
-    {
-        var infoBuilder = new StringBuilder();
-        var errorBuilder = new StringBuilder();
-
-        var result = ShellExecutor.ExecuteCommand(
-            "git",
-            command,
-            ".",
-            (_) => { },
-            (info) => infoBuilder.AppendLine(info),
-            (error) => errorBuilder.AppendLine(error));
-
-        if (result != 0)
-        {
-            console.MarkupLine($"[red]{errorBuilder}[/]");
-            throw new Exception("Failed to execute git command.");
+            if (settings.Verbose)
+                console.MarkupLine($"[grey]git {command}[/]");
         }
         else
         {
-            if (infoBuilder.Length > 0)
-            {
-                console.WriteLine(infoBuilder.ToString());
-            }
+            ExecuteGitCommandAndReturnOutput(command, settings);
         }
     }
 }


### PR DESCRIPTION
This PR adds a `--working-dir` option to all commands to allow operating on a different repository from the directory you are currently in.