### PR TITLE
Fix formatting of stack list when there is existing description

### DIFF
--- a/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
+++ b/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
@@ -124,7 +124,15 @@ internal class CreatePullRequestsCommand(
                         prListStart = 0;
                     }
 
-                    prBody = prBody.Insert(prListStart, prBodyMarkdown);
+                    if (prBody.Length > 0 && prListStart == 0)
+                    {
+                        // Add some newlines so that the PR list is separated from the rest of the PR body
+                        prBody = prBody.Insert(prListStart, prBodyMarkdown + "\n\n");
+                    }
+                    else
+                    {
+                        prBody = prBody.Insert(prListStart, prBodyMarkdown);
+                    }
 
                     gitHubOperations.EditPullRequest(pullRequest.Number, prBody, settings.GetGitHubOperationSettings());
                 }


### PR DESCRIPTION
This PR fixes the formatting of the stack list for a PR when there is an existing body by adding some extra newlines so things format correctly.