### PR TITLE
Make external process output grey

### DIFF
--- a/src/Stack/Git/GitHubOperations.cs
+++ b/src/Stack/Git/GitHubOperations.cs
@@ -96,7 +96,7 @@ public class GitHubOperations(IAnsiConsole console) : IGitHubOperations
 
         if (settings.Verbose && infoBuilder.Length > 0)
         {
-            console.WriteLine(infoBuilder.ToString());
+            console.MarkupLine($"[grey]{infoBuilder}[/]");
         }
 
         return infoBuilder.ToString();
@@ -135,7 +135,7 @@ public class GitHubOperations(IAnsiConsole console) : IGitHubOperations
         {
             if (infoBuilder.Length > 0)
             {
-                console.WriteLine(infoBuilder.ToString());
+                console.MarkupLine($"[grey]{infoBuilder}[/]");
             }
         }
     }

--- a/src/Stack/Git/GitOperations.cs
+++ b/src/Stack/Git/GitOperations.cs
@@ -170,7 +170,7 @@ public class GitOperations(IAnsiConsole console) : IGitOperations
 
         if (settings.Verbose && infoBuilder.Length > 0)
         {
-            console.WriteLine(infoBuilder.ToString());
+            console.MarkupLine($"[grey]{infoBuilder}[/]");
         }
 
         return infoBuilder.ToString();
@@ -193,7 +193,7 @@ public class GitOperations(IAnsiConsole console) : IGitOperations
                 // changes to the Git repository as the output might be important.
                 // In verbose mode we would have already written the output
                 // of the command so don't write it again.
-                console.WriteLine(output);
+                console.MarkupLine($"[grey]{output}[/]");
             }
         }
     }


### PR DESCRIPTION
This PR makes the stdout of external processes grey to differentiate it from the direct command output.

Fixes #44.