### PR TITLE
Improve stack cleanup and delete

### DIFF
--- a/src/Stack.Tests/Commands/Stack/DeleteStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/DeleteStackCommandHandlerTests.cs
@@ -38,7 +38,7 @@ public class DeleteStackCommandHandlerTests
             .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
-        inputProvider.Confirm(Questions.ConfirmDeleteStack).Returns(true);
+        inputProvider.Confirm(Questions.ConfirmDeleteStack("Stack1")).Returns(true);
 
         // Act
         var response = await handler.Handle(DeleteStackCommandInputs.Empty);
@@ -78,7 +78,7 @@ public class DeleteStackCommandHandlerTests
             .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
-        inputProvider.Confirm(Questions.ConfirmDeleteStack).Returns(false);
+        inputProvider.Confirm(Questions.ConfirmDeleteStack("Stack1")).Returns(false);
 
         // Act
         var response = await handler.Handle(DeleteStackCommandInputs.Empty);
@@ -118,7 +118,7 @@ public class DeleteStackCommandHandlerTests
             .WhenForAnyArgs(s => s.Save(Arg.Any<List<Config.Stack>>()))
             .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
 
-        inputProvider.Confirm(Questions.ConfirmDeleteStack).Returns(true);
+        inputProvider.Confirm(Questions.ConfirmDeleteStack("Stack1")).Returns(true);
 
         // Act
         var response = await handler.Handle(new DeleteStackCommandInputs("Stack1", false));
@@ -171,7 +171,7 @@ public class DeleteStackCommandHandlerTests
             new("Stack2", remoteUri, "branch-2", [])
         });
 
-        inputProvider.DidNotReceive().Confirm(Questions.ConfirmDeleteStack);
+        inputProvider.DidNotReceive().Confirm(Questions.ConfirmDeleteStack("Stack1"));
     }
 
     [Fact]
@@ -239,7 +239,7 @@ public class DeleteStackCommandHandlerTests
             .WhenForAnyArgs(s => s.Save(Arg.Any<List<Config.Stack>>()))
             .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
 
-        inputProvider.Confirm(Questions.ConfirmDeleteStack).Returns(true);
+        inputProvider.Confirm(Questions.ConfirmDeleteStack("Stack1")).Returns(true);
 
         // Act and assert
         await handler
@@ -278,7 +278,7 @@ public class DeleteStackCommandHandlerTests
             .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
-        inputProvider.Confirm(Questions.ConfirmDeleteStack).Returns(true);
+        inputProvider.Confirm(Questions.ConfirmDeleteStack("Stack1")).Returns(true);
         inputProvider.Confirm(Questions.ConfirmDeleteBranches).Returns(true);
 
         // Act

--- a/src/Stack/Commands/Helpers/Questions.cs
+++ b/src/Stack/Commands/Helpers/Questions.cs
@@ -1,11 +1,10 @@
-using Spectre.Console;
-using Stack.Config;
+using Stack.Infrastructure;
 
 namespace Stack.Commands.Helpers;
 
 public static class Questions
 {
     public const string SelectStack = "Select stack:";
-    public const string ConfirmDeleteStack = "Are you sure you want to delete this stack?";
+    public static string ConfirmDeleteStack(string name) => $"Are you sure you want to delete stack {name.Stack()}?";
     public const string ConfirmDeleteBranches = "Are you sure you want to delete these local branches?";
 }

--- a/src/Stack/Commands/Stack/CleanupStackCommand.cs
+++ b/src/Stack/Commands/Stack/CleanupStackCommand.cs
@@ -120,7 +120,7 @@ public class CleanupStackCommandHandler(
 
     public static void OutputBranchesNeedingCleanup(IOutputProvider outputProvider, string[] branches)
     {
-        outputProvider.Information("The following branches exist locally but not on the remote or pull request associated with the branch is no longer open:");
+        outputProvider.Information("The following branches exist locally but are either not in the remote repository or the pull request associated with the branch is no longer open:");
 
         foreach (var branch in branches)
         {

--- a/src/Stack/Commands/Stack/DeleteStackCommand.cs
+++ b/src/Stack/Commands/Stack/DeleteStackCommand.cs
@@ -37,7 +37,7 @@ public class DeleteStackCommand : AsyncCommand<DeleteStackCommandSettings>
         var response = await handler.Handle(new DeleteStackCommandInputs(settings.Name, settings.Force));
 
         if (response.DeletedStackName is not null)
-            console.MarkupLine($"Stack {response.DeletedStackName.Branch()} deleted");
+            console.MarkupLine($"Stack {response.DeletedStackName.Stack()} deleted");
 
         return 0;
     }
@@ -76,7 +76,7 @@ public class DeleteStackCommandHandler(
             throw new InvalidOperationException("Stack not found.");
         }
 
-        if (inputs.Force || inputProvider.Confirm(Questions.ConfirmDeleteStack))
+        if (inputs.Force || inputProvider.Confirm(Questions.ConfirmDeleteStack(stack.Name)))
         {
             var branchesNeedingCleanup = CleanupStackCommandHandler.GetBranchesNeedingCleanup(stack, gitOperations, gitHubOperations);
 

--- a/src/Stack/Commands/Stack/StackStatusCommand.cs
+++ b/src/Stack/Commands/Stack/StackStatusCommand.cs
@@ -56,7 +56,7 @@ public class StackStatusCommand : AsyncCommand<StackStatusCommandSettings>
                 var branchNameBuilder = new StringBuilder();
 
                 var color = branchDetail?.Status.ExistsInRemote == false ? "grey" : isSourceBranchForStack ? "grey" : branch.Equals(currentBranch, StringComparison.OrdinalIgnoreCase) ? "blue" : null;
-                Decoration? decoration = branchDetail?.Status.ExistsInRemote == false ? Decoration.Strikethrough : null;
+                Decoration? decoration = branchDetail?.Status.ExistsInRemote == false || branchDetail?.Status.ExistsLocally == false ? Decoration.Strikethrough : null;
 
                 if (color is not null && decoration is not null)
                 {
@@ -117,23 +117,31 @@ public class StackStatusCommand : AsyncCommand<StackStatusCommandSettings>
 
             bool BranchCouldBeCleanedUp(BranchDetail branchDetail)
             {
-                return branchDetail.Status.ExistsLocally && !branchDetail.Status.ExistsInRemote ||
-                    branchDetail.PullRequest is not null && branchDetail.PullRequest.State != GitHubPullRequestStates.Open;
+                return branchDetail.Status.ExistsLocally &&
+                        (!branchDetail.Status.ExistsInRemote ||
+                        branchDetail.PullRequest is not null && branchDetail.PullRequest.State != GitHubPullRequestStates.Open);
             }
 
             if (status.Branches.Values.All(branch => BranchCouldBeCleanedUp(branch)))
             {
                 console.WriteLine();
-                console.MarkupLine("All branches exist locally but not in the remote repository or the pull request associated with the branch is no longer open. This stack might be able to be deleted.");
+                console.MarkupLine("All branches exist locally but are either not in the remote repository or the pull request associated with the branch is no longer open. This stack might be able to be deleted.");
                 console.WriteLine();
-                console.MarkupLine($"Run [purple]stack delete --name \"{stack.Name}\"[/] to delete the stack if it's no longer needed.");
+                console.MarkupLine($"Run [aqua]stack delete --name \"{stack.Name}\"[/] to delete the stack if it's no longer needed.");
             }
             else if (status.Branches.Values.Any(branch => BranchCouldBeCleanedUp(branch)))
             {
                 console.WriteLine();
-                console.MarkupLine("Some branches exist locally but not in the remote repository or the pull request associated with the branch is no longer open.");
+                console.MarkupLine("Some branches exist locally but are either not in the remote repository or the pull request associated with the branch is no longer open.");
                 console.WriteLine();
-                console.MarkupLine($"Run [purple]stack cleanup --name \"{stack.Name}\"[/] to clean up local branches.");
+                console.MarkupLine($"Run [aqua]stack cleanup --name \"{stack.Name}\"[/] to clean up local branches.");
+            }
+            else if (status.Branches.Values.All(branch => !branch.Status.ExistsLocally))
+            {
+                console.WriteLine();
+                console.MarkupLine("No branches exist locally. This stack might be able to be deleted.");
+                console.WriteLine();
+                console.MarkupLine($"Run [aqua]stack delete --name \"{stack.Name}\"[/] to delete the stack.");
             }
         }
 

--- a/src/Stack/Commands/Stack/StackStatusCommand.cs
+++ b/src/Stack/Commands/Stack/StackStatusCommand.cs
@@ -143,6 +143,14 @@ public class StackStatusCommand : AsyncCommand<StackStatusCommandSettings>
                 console.WriteLine();
                 console.MarkupLine($"Run [aqua]stack delete --name \"{stack.Name}\"[/] to delete the stack.");
             }
+
+            if (status.Branches.Values.Any(branch => branch.Status.ExistsInRemote && branch.Status.ExistsLocally && branch.Status.Behind > 0))
+            {
+                console.WriteLine();
+                console.MarkupLine("There are changes in source branches that have not been applied to the stack.");
+                console.WriteLine();
+                console.MarkupLine($"Run [aqua]stack update --name \"{stack.Name}\"[/] to update the stack.");
+            }
         }
 
         return 0;


### PR DESCRIPTION
This PR makes a few small improvements:
- Show the name of the stack when prompting for confirmation during `delete` command
- Improve the copy when prompting for cleanup during `status` command
- Show `delete` command example during `status` command when all branches are deleted locally
- Show `update` command example during `status` command when source branches are ahead