### PR TITLE
Remove versioning PR

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -3,12 +3,6 @@
     "git-tag",
     "released",
     [
-      "omit-release-notes",
-      {
-        "labels": "release"
-      }
-    ],
-    [
       "upload-assets",
       [
         "./artifacts/**/*.zip",
@@ -17,11 +11,69 @@
     ]
   ],
   "onlyPublishWithReleaseLabel": false,
+  "noDefaultLabels": true,
   "labels": [
     {
-      "name": "skip-release",
-      "releaseType": "skip",
+      "name": "major",
+      "changelogTitle": "💥 Breaking Change",
+      "description": "Increment the major version when merged",
+      "releaseType": "major",
+      "color": "#C5000B"
+    },
+    {
+      "name": "minor",
+      "changelogTitle": "🚀 New Feature",
+      "description": "Increment the minor version when merged",
+      "releaseType": "minor",
+      "color": "#F1A60E"
+    },
+    {
+      "name": "patch",
+      "changelogTitle": "🐛 Bug Fix",
+      "description": "Increment the patch version when merged",
+      "releaseType": "patch",
+      "color": "#870048",
       "default": true
+    },
+    {
+      "name": "dependencies",
+      "changelogTitle": "🔩 Dependency Updates",
+      "description": "Update one or more dependencies version",
+      "releaseType": "patch",
+      "color": "#8732bc"
+    },
+    {
+      "name": "skip-release",
+      "description": "Preserve the current version when merged",
+      "releaseType": "skip",
+      "color": "#bf5416"
+    },
+    {
+      "name": "internal",
+      "changelogTitle": "🏠 Internal",
+      "description": "Changes only affect the internal API",
+      "releaseType": "none",
+      "color": "#696969"
+    },
+    {
+      "name": "documentation",
+      "changelogTitle": "📝 Documentation",
+      "description": "Changes only affect the documentation",
+      "releaseType": "none",
+      "color": "#cfd3d7"
+    },
+    {
+      "name": "tests",
+      "changelogTitle": "🧪 Tests",
+      "description": "Add or improve existing tests",
+      "releaseType": "none",
+      "color": "#ffd3cc"
+    },
+    {
+      "name": "automation",
+      "changelogTitle": "🤖 Automation",
+      "description": "Changes to automation such as CI",
+      "releaseType": "none"
     }
   ]
 }

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -14,12 +14,8 @@ jobs:
       version: ${{ steps.get_version.outputs.version }}
       next_release_version: ${{ steps.get_next_release_version.outputs.version }}
       create_release: ${{ steps.set_create_release.outputs.create_release }}
-      has_unreleased_changes: ${{ steps.set_has_unreleased_changes.outputs.has_unreleased_changes }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -39,37 +35,33 @@ jobs:
 
       - name: Get next release semver bump type
         id: get_next_release_semver_bump_type
-        run: echo "bump_type=$(${{ runner.temp }}/auto version --only-publish-with-release-label)" >> $GITHUB_OUTPUT
+        run: echo "bump_type=$(${{ runner.temp }}/auto version)" >> $GITHUB_OUTPUT
 
       - name: Print next release semver bump type
         run: echo "${{ steps.get_next_release_semver_bump_type.outputs.bump_type }}"
+
+      - name: Get next pre-release version for when next release version does not exist
+        id: get_next_pre_release_version
+        uses: paulhatch/semantic-version@v5.4.0
+        with:
+          tag_prefix: "v"
+          version_format: "${major}.${minor}.${patch}"
 
       - name: Get branch names
         id: branch_names
         uses: OctopusDeploy/util-actions/current-branch-name@current-branch-name.0.1.0
 
-      - name: Get pre-release version when next release version does not exist
+      - name: Get pre-release version
         id: get_pre_release_version
-        uses: paulhatch/semantic-version@v5.4.0
-        with:
-          tag_prefix: "v"
-          version_format: "${major}.${minor}.${patch}-${{ steps.branch_names.outputs.branch_name }}.${{ github.run_number }}-${{ github.run_attempt }}"
-
-      - name: Get pre-release version when next release version exists
-        id: get_specific_pre_release_version
-        run: echo "version=${{ steps.get_next_release_version.outputs.version }}-${{ steps.branch_names.outputs.branch_name }}.${{ github.run_number }}-${{ github.run_attempt }}" >> $GITHUB_OUTPUT
+        run: echo "version=${{ steps.get_next_release_version.outputs.version || steps.get_next_pre_release_version.outputs.version }}-${{ steps.branch_names.outputs.branch_name }}.${{ github.run_number }}-${{ github.run_attempt }}" >> $GITHUB_OUTPUT
 
       - name: Set whether to create a release
         id: set_create_release
         run: echo "create_release=${{ steps.get_next_release_semver_bump_type.outputs.bump_type != '' }}" >> $GITHUB_OUTPUT
 
-      - name: Set whether there are unreleased changes
-        id: set_has_unreleased_changes
-        run: echo "has_unreleased_changes=${{ steps.get_next_release_semver_bump_type.outputs.bump_type == '' && steps.get_next_release_version.outputs.version != '' }}" >> $GITHUB_OUTPUT
-
       - name: Get version
         id: get_version
-        run: echo "version=${{ steps.set_create_release.outputs.create_release == 'true' && steps.get_next_release_version.outputs.version || steps.get_next_release_version.outputs.version != '' && steps.get_specific_pre_release_version.outputs.version || steps.get_pre_release_version.outputs.version }}" >> $GITHUB_OUTPUT
+        run: echo "version=${{ github.ref == 'refs/heads/main' && steps.get_next_release_semver_bump_type.outputs.bump_type != '' && steps.get_next_release_version.outputs.version || steps.get_pre_release_version.outputs.version }}" >> $GITHUB_OUTPUT
 
       - name: Print version
         run: echo "Version ${{ steps.get_version.outputs.version }}"
@@ -191,7 +183,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     needs: [version, publish]
-    if: github.ref == 'refs/heads/main' && needs.version.outputs.create_release == 'true'
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push' && needs.version.outputs.create_release == 'true'
     permissions:
       contents: write
     env:
@@ -215,51 +207,4 @@ jobs:
           chmod +x ${{ runner.temp }}/auto
 
       - name: Release
-        run: ${{ runner.temp }}/auto shipit --only-publish-with-release-label --no-changelog --name github-actions[bot] --email github-actions[bot]@users.noreply.github.com
-
-  versioning_pr:
-    name: Create versioning pull request
-    needs: [version, publish]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    if: github.ref == 'refs/heads/main' && needs.version.outputs.has_unreleased_changes == 'true'
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # Get all tags
-
-      - name: Download auto
-        run: |
-          curl -kL -o - https://github.com/intuit/auto/releases/download/v11.3.0/auto-linux.gz | gunzip > ${{ runner.temp }}/auto
-          chmod +x ${{ runner.temp }}/auto
-
-      - name: Update changelog
-        id: update_changelog
-        run: |
-          echo "changes<<EOF" >> $GITHUB_ENV
-          echo "$(${{ runner.temp }}/auto changelog --quiet --no-git-commit --name github-actions[bot] --email github-actions[bot]@users.noreply.github.com)" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
-
-      - name: Create versioning pull request
-        uses: peter-evans/create-pull-request@v7
-        with:
-          branch: auto/release
-          title: Release version `${{ needs.get_version.outputs.next_release_version }}`
-          commit-message: Release version `${{ needs.get_version.outputs.next_release_version }}`
-          labels: release
-          body: |
-            This PR will release version `${{ needs.get_version.outputs.next_release_version }}`
-
-            ## Changes
-
-            ${{ env.changes }}
-
-            ## Releasing a new version
-
-            To release the version when you are ready, merge this PR. The new version will then be built and published to a GitHub release.
-
-            If you don't see your changes in the list above, please check your PR is tagged with an appropriate label to include your change in the release notes.
+        run: ${{ runner.temp }}/auto shipit --name github-actions[bot] --email github-actions[bot]@users.noreply.github.com


### PR DESCRIPTION
This PR removes the versioning workflow where a PR would be created to "version" the application. This was proving difficult to wrangle, with extra notes going into the GitHub release when they shouldn't, plus it relied on the default label being set to one that didn't bump a version which felt wrong.

When a PR is merged that will bump a new version this will happen straight away and the changelog will be updated in a commit as part of that workflow. Not _quiet_ ideal, but ok for the moment. Could always force the use of a `release` label on a PR if needed but will see how it goes.