### PR TITLE
Fix issue where `config` command would not run

### DIFF
--- a/src/Stack/Commands/Config/OpenConfigCommand.cs
+++ b/src/Stack/Commands/Config/OpenConfigCommand.cs
@@ -9,11 +9,13 @@ public class OpenConfigCommandSettings : CommandSettingsBase
 {
 }
 
-public class OpenConfigCommand(IAnsiConsole console, IStackConfig stackConfig) : AsyncCommand<CommandSettingsBase>
+public class OpenConfigCommand : AsyncCommand<CommandSettingsBase>
 {
     public override async Task<int> ExecuteAsync(CommandContext context, CommandSettingsBase settings)
     {
         await Task.CompletedTask;
+        var console = AnsiConsole.Console;
+        var stackConfig = new StackConfig();
 
         var configPath = stackConfig.GetConfigPath();
 


### PR DESCRIPTION
This PR fixes an issue introduced in #52 where the `config` command would not run because it could not be resolved.