### PR TITLE
Remove specific input providers

### DIFF
--- a/src/Stack.Tests/Commands/Stack/NewStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/NewStackCommandHandlerTests.cs
@@ -1,8 +1,10 @@
 using FluentAssertions;
 using NSubstitute;
 using Stack.Commands;
+using Stack.Commands.Helpers;
 using Stack.Config;
 using Stack.Git;
+using Stack.Infrastructure;
 using Stack.Tests.Helpers;
 
 namespace Stack.Tests.Commands.Stack;
@@ -15,7 +17,7 @@ public class NewStackCommandHandlerTests
         // Arrange
         var gitOperations = Substitute.For<IGitOperations>();
         var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<INewStackCommandInputProvider>();
+        var inputProvider = Substitute.For<IInputProvider>();
         var handler = new NewStackCommandHandler(inputProvider, gitOperations, stackConfig);
 
         var remoteUri = Some.HttpsUri().ToString();
@@ -29,12 +31,12 @@ public class NewStackCommandHandlerTests
             .WhenForAnyArgs(s => s.Save(Arg.Any<List<Config.Stack>>()))
             .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
 
-        inputProvider.GetStackName().Returns("Stack1");
-        inputProvider.GetSourceBranch(Arg.Any<string[]>()).Returns("branch-1");
-        inputProvider.ConfirmAddOrCreateBranch().Returns(true);
-        inputProvider.SelectAddOrCreateBranch().Returns(BranchAction.Create);
-        inputProvider.GetNewBranchName().Returns("new-branch");
-        inputProvider.ConfirmSwitchToBranch().Returns(true);
+        inputProvider.Text(Questions.StackName).Returns("Stack1");
+        inputProvider.Select(Questions.SelectSourceBranch, Arg.Any<string[]>()).Returns("branch-1");
+        inputProvider.Confirm(Questions.ConfirmAddOrCreateBranch).Returns(true);
+        inputProvider.Select(Questions.AddOrCreateBranch, Arg.Any<BranchAction[]>(), Arg.Any<Func<BranchAction, string>>()).Returns(BranchAction.Create);
+        inputProvider.Text(Questions.BranchName).Returns("new-branch");
+        inputProvider.Confirm(Questions.ConfirmSwitchToBranch).Returns(true);
 
         // Act
         var response = await handler.Handle(NewStackCommandInputs.Empty);
@@ -55,7 +57,7 @@ public class NewStackCommandHandlerTests
         // Arrange
         var gitOperations = Substitute.For<IGitOperations>();
         var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<INewStackCommandInputProvider>();
+        var inputProvider = Substitute.For<IInputProvider>();
         var handler = new NewStackCommandHandler(inputProvider, gitOperations, stackConfig);
 
         var remoteUri = Some.HttpsUri().ToString();
@@ -69,12 +71,12 @@ public class NewStackCommandHandlerTests
             .WhenForAnyArgs(s => s.Save(Arg.Any<List<Config.Stack>>()))
             .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
 
-        inputProvider.GetStackName().Returns("Stack1");
-        inputProvider.GetSourceBranch(Arg.Any<string[]>()).Returns("branch-1");
-        inputProvider.ConfirmAddOrCreateBranch().Returns(true);
-        inputProvider.SelectAddOrCreateBranch().Returns(BranchAction.Add);
-        inputProvider.GetBranchToAdd(Arg.Any<string[]>()).Returns("branch-2");
-        inputProvider.ConfirmSwitchToBranch().Returns(true);
+        inputProvider.Text(Questions.StackName).Returns("Stack1");
+        inputProvider.Select(Questions.SelectSourceBranch, Arg.Any<string[]>()).Returns("branch-1");
+        inputProvider.Confirm(Questions.ConfirmAddOrCreateBranch).Returns(true);
+        inputProvider.Select(Questions.AddOrCreateBranch, Arg.Any<BranchAction[]>(), Arg.Any<Func<BranchAction, string>>()).Returns(BranchAction.Add);
+        inputProvider.Select(Questions.SelectBranch, Arg.Any<string[]>()).Returns("branch-2");
+        inputProvider.Confirm(Questions.ConfirmSwitchToBranch).Returns(true);
 
         // Act
         var response = await handler.Handle(NewStackCommandInputs.Empty);
@@ -95,7 +97,7 @@ public class NewStackCommandHandlerTests
         // Arrange
         var gitOperations = Substitute.For<IGitOperations>();
         var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<INewStackCommandInputProvider>();
+        var inputProvider = Substitute.For<IInputProvider>();
         var handler = new NewStackCommandHandler(inputProvider, gitOperations, stackConfig);
 
         var remoteUri = Some.HttpsUri().ToString();
@@ -109,9 +111,10 @@ public class NewStackCommandHandlerTests
             .WhenForAnyArgs(s => s.Save(Arg.Any<List<Config.Stack>>()))
             .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
 
-        inputProvider.GetStackName().Returns("Stack1");
-        inputProvider.GetSourceBranch(Arg.Any<string[]>()).Returns("branch-1");
-        inputProvider.ConfirmAddOrCreateBranch().Returns(false);
+
+        inputProvider.Text(Questions.StackName).Returns("Stack1");
+        inputProvider.Select(Questions.SelectSourceBranch, Arg.Any<string[]>()).Returns("branch-1");
+        inputProvider.Confirm(Questions.ConfirmAddOrCreateBranch).Returns(false);
 
         // Act
         var response = await handler.Handle(NewStackCommandInputs.Empty);
@@ -132,7 +135,7 @@ public class NewStackCommandHandlerTests
         // Arrange
         var gitOperations = Substitute.For<IGitOperations>();
         var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<INewStackCommandInputProvider>();
+        var inputProvider = Substitute.For<IInputProvider>();
         var handler = new NewStackCommandHandler(inputProvider, gitOperations, stackConfig);
 
         var remoteUri = Some.HttpsUri().ToString();
@@ -146,12 +149,13 @@ public class NewStackCommandHandlerTests
             .WhenForAnyArgs(s => s.Save(Arg.Any<List<Config.Stack>>()))
             .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
 
-        inputProvider.GetStackName().Returns("Stack1");
-        inputProvider.GetSourceBranch(Arg.Any<string[]>()).Returns("branch-1");
-        inputProvider.ConfirmAddOrCreateBranch().Returns(true);
-        inputProvider.SelectAddOrCreateBranch().Returns(BranchAction.Create);
-        inputProvider.GetNewBranchName().Returns("new-branch-1");
-        inputProvider.ConfirmSwitchToBranch().Returns(false);
+
+        inputProvider.Text(Questions.StackName).Returns("Stack1");
+        inputProvider.Select(Questions.SelectSourceBranch, Arg.Any<string[]>()).Returns("branch-1");
+        inputProvider.Confirm(Questions.ConfirmAddOrCreateBranch).Returns(true);
+        inputProvider.Select(Questions.AddOrCreateBranch, Arg.Any<BranchAction[]>(), Arg.Any<Func<BranchAction, string>>()).Returns(BranchAction.Create);
+        inputProvider.Text(Questions.BranchName).Returns("new-branch-1");
+        inputProvider.Confirm(Questions.ConfirmSwitchToBranch).Returns(false);
 
         // Act
         var response = await handler.Handle(NewStackCommandInputs.Empty);
@@ -172,7 +176,7 @@ public class NewStackCommandHandlerTests
         // Arrange
         var gitOperations = Substitute.For<IGitOperations>();
         var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<INewStackCommandInputProvider>();
+        var inputProvider = Substitute.For<IInputProvider>();
         var handler = new NewStackCommandHandler(inputProvider, gitOperations, stackConfig);
 
         var remoteUri = Some.HttpsUri().ToString();
@@ -186,12 +190,12 @@ public class NewStackCommandHandlerTests
             .WhenForAnyArgs(s => s.Save(Arg.Any<List<Config.Stack>>()))
             .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
 
-        inputProvider.GetStackName().Returns("Stack1");
-        inputProvider.GetSourceBranch(Arg.Any<string[]>()).Returns("branch-1");
-        inputProvider.ConfirmAddOrCreateBranch().Returns(true);
-        inputProvider.SelectAddOrCreateBranch().Returns(BranchAction.Add);
-        inputProvider.GetBranchToAdd(Arg.Any<string[]>()).Returns("branch-2");
-        inputProvider.ConfirmSwitchToBranch().Returns(false);
+        inputProvider.Text(Questions.StackName).Returns("Stack1");
+        inputProvider.Select(Questions.SelectSourceBranch, Arg.Any<string[]>()).Returns("branch-1");
+        inputProvider.Confirm(Questions.ConfirmAddOrCreateBranch).Returns(true);
+        inputProvider.Select(Questions.AddOrCreateBranch, Arg.Any<BranchAction[]>(), Arg.Any<Func<BranchAction, string>>()).Returns(BranchAction.Add);
+        inputProvider.Select(Questions.SelectBranch, Arg.Any<string[]>()).Returns("branch-2");
+        inputProvider.Confirm(Questions.ConfirmSwitchToBranch).Returns(false);
 
         // Act
         var response = await handler.Handle(NewStackCommandInputs.Empty);
@@ -212,7 +216,7 @@ public class NewStackCommandHandlerTests
         // Arrange
         var gitOperations = Substitute.For<IGitOperations>();
         var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<INewStackCommandInputProvider>();
+        var inputProvider = Substitute.For<IInputProvider>();
         var handler = new NewStackCommandHandler(inputProvider, gitOperations, stackConfig);
 
         var remoteUri = Some.HttpsUri().ToString();
@@ -226,8 +230,8 @@ public class NewStackCommandHandlerTests
             .WhenForAnyArgs(s => s.Save(Arg.Any<List<Config.Stack>>()))
             .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
 
-        inputProvider.GetSourceBranch(Arg.Any<string[]>()).Returns("branch-1");
-        inputProvider.ConfirmAddOrCreateBranch().Returns(false);
+        inputProvider.Select(Questions.SelectSourceBranch, Arg.Any<string[]>()).Returns("branch-1");
+        inputProvider.Confirm(Questions.ConfirmAddOrCreateBranch).Returns(false);
 
         var inputs = new NewStackCommandInputs("Stack1", null, null);
 
@@ -241,7 +245,7 @@ public class NewStackCommandHandlerTests
             new("Stack1", remoteUri, "branch-1", [])
         });
 
-        inputProvider.DidNotReceive().GetStackName();
+        inputProvider.DidNotReceive().Text(Questions.StackName);
     }
 
     [Fact]
@@ -250,7 +254,7 @@ public class NewStackCommandHandlerTests
         // Arrange
         var gitOperations = Substitute.For<IGitOperations>();
         var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<INewStackCommandInputProvider>();
+        var inputProvider = Substitute.For<IInputProvider>();
         var handler = new NewStackCommandHandler(inputProvider, gitOperations, stackConfig);
 
         var remoteUri = Some.HttpsUri().ToString();
@@ -264,8 +268,8 @@ public class NewStackCommandHandlerTests
             .WhenForAnyArgs(s => s.Save(Arg.Any<List<Config.Stack>>()))
             .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
 
-        inputProvider.GetStackName().Returns("Stack1");
-        inputProvider.ConfirmAddOrCreateBranch().Returns(false);
+        inputProvider.Text(Questions.StackName).Returns("Stack1");
+        inputProvider.Confirm(Questions.ConfirmAddOrCreateBranch).Returns(false);
 
         var inputs = new NewStackCommandInputs(null, "branch-1", null);
 
@@ -279,7 +283,7 @@ public class NewStackCommandHandlerTests
             new("Stack1", remoteUri, "branch-1", [])
         });
 
-        inputProvider.DidNotReceive().GetSourceBranch(Arg.Any<string[]>());
+        inputProvider.DidNotReceive().Select(Questions.SelectBranch, Arg.Any<string[]>());
     }
 
     [Fact]
@@ -288,7 +292,7 @@ public class NewStackCommandHandlerTests
         // Arrange
         var gitOperations = Substitute.For<IGitOperations>();
         var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<INewStackCommandInputProvider>();
+        var inputProvider = Substitute.For<IInputProvider>();
         var handler = new NewStackCommandHandler(inputProvider, gitOperations, stackConfig);
 
         var remoteUri = Some.HttpsUri().ToString();
@@ -302,8 +306,8 @@ public class NewStackCommandHandlerTests
             .WhenForAnyArgs(s => s.Save(Arg.Any<List<Config.Stack>>()))
             .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
 
-        inputProvider.GetStackName().Returns("Stack1");
-        inputProvider.GetSourceBranch(Arg.Any<string[]>()).Returns("branch-1");
+        inputProvider.Text(Questions.StackName).Returns("Stack1");
+        inputProvider.Select(Questions.SelectSourceBranch, Arg.Any<string[]>()).Returns("branch-1");
         // Note there shouldn't be any more inputs required at all
 
         var inputs = new NewStackCommandInputs(null, null, "new-branch");
@@ -318,8 +322,8 @@ public class NewStackCommandHandlerTests
             new("Stack1", remoteUri, "branch-1", ["new-branch"])
         });
 
-        inputProvider.Received().GetStackName();
-        inputProvider.Received().GetSourceBranch(Arg.Any<string[]>());
+        inputProvider.Received().Text(Questions.StackName);
+        inputProvider.Received().Select(Questions.SelectSourceBranch, Arg.Any<string[]>());
         inputProvider.ClearReceivedCalls();
         inputProvider.ReceivedCalls().Should().BeEmpty();
     }
@@ -330,7 +334,7 @@ public class NewStackCommandHandlerTests
         // Arrange
         var gitOperations = Substitute.For<IGitOperations>();
         var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<INewStackCommandInputProvider>();
+        var inputProvider = Substitute.For<IInputProvider>();
         var handler = new NewStackCommandHandler(inputProvider, gitOperations, stackConfig);
 
         var remoteUri = Some.HttpsUri().ToString();
@@ -343,10 +347,6 @@ public class NewStackCommandHandlerTests
         stackConfig
             .WhenForAnyArgs(s => s.Save(Arg.Any<List<Config.Stack>>()))
             .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
-
-        inputProvider.GetStackName().Returns("Stack1");
-        inputProvider.GetSourceBranch(Arg.Any<string[]>()).Returns("branch-1");
-        // Note there shouldn't be any more inputs required at all
 
         var inputs = new NewStackCommandInputs("Stack1", "branch-1", "new-branch");
 

--- a/src/Stack.Tests/Commands/Stack/StackStatusCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/StackStatusCommandHandlerTests.cs
@@ -5,6 +5,7 @@ using Stack.Config;
 using Stack.Git;
 using Stack.Tests.Helpers;
 using Stack.Infrastructure;
+using Stack.Commands.Helpers;
 
 namespace Stack.Tests.Commands.Stack;
 
@@ -17,7 +18,7 @@ public class StackStatusCommandHandlerTests
         var gitOperations = Substitute.For<IGitOperations>();
         var gitHubOperations = Substitute.For<IGitHubOperations>();
         var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<IStackStatusCommandInputProvider>();
+        var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
         var handler = new StackStatusCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
 
@@ -31,7 +32,7 @@ public class StackStatusCommandHandlerTests
         var stacks = new List<Config.Stack>([stack1, stack2]);
         stackConfig.Load().Returns(stacks);
 
-        inputProvider.SelectStack(Arg.Any<List<Config.Stack>>(), Arg.Any<string>()).Returns("Stack1");
+        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
         outputProvider
             .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
             .Do(ci => ci.ArgAt<Action>(1)());
@@ -82,7 +83,7 @@ public class StackStatusCommandHandlerTests
         var gitOperations = Substitute.For<IGitOperations>();
         var gitHubOperations = Substitute.For<IGitHubOperations>();
         var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<IStackStatusCommandInputProvider>();
+        var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
         var handler = new StackStatusCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
 
@@ -148,7 +149,7 @@ public class StackStatusCommandHandlerTests
         var gitOperations = Substitute.For<IGitOperations>();
         var gitHubOperations = Substitute.For<IGitHubOperations>();
         var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<IStackStatusCommandInputProvider>();
+        var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
         var handler = new StackStatusCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
 
@@ -223,7 +224,7 @@ public class StackStatusCommandHandlerTests
         var gitOperations = Substitute.For<IGitOperations>();
         var gitHubOperations = Substitute.For<IGitHubOperations>();
         var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<IStackStatusCommandInputProvider>();
+        var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
         var handler = new StackStatusCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
 
@@ -252,7 +253,7 @@ public class StackStatusCommandHandlerTests
         var gitOperations = Substitute.For<IGitOperations>();
         var gitHubOperations = Substitute.For<IGitHubOperations>();
         var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<IStackStatusCommandInputProvider>();
+        var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
         var handler = new StackStatusCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
 
@@ -266,7 +267,7 @@ public class StackStatusCommandHandlerTests
         var stacks = new List<Config.Stack>([stack1, stack2]);
         stackConfig.Load().Returns(stacks);
 
-        inputProvider.SelectStack(Arg.Any<List<Config.Stack>>(), Arg.Any<string>()).Returns("Stack1");
+        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
         outputProvider
             .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
             .Do(ci => ci.ArgAt<Action>(1)());
@@ -313,7 +314,7 @@ public class StackStatusCommandHandlerTests
         var gitOperations = Substitute.For<IGitOperations>();
         var gitHubOperations = Substitute.For<IGitHubOperations>();
         var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<IStackStatusCommandInputProvider>();
+        var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
         var handler = new StackStatusCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
 
@@ -327,7 +328,7 @@ public class StackStatusCommandHandlerTests
         var stacks = new List<Config.Stack>([stack1, stack2]);
         stackConfig.Load().Returns(stacks);
 
-        inputProvider.SelectStack(Arg.Any<List<Config.Stack>>(), Arg.Any<string>()).Returns("Stack1");
+        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
         outputProvider
             .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
             .Do(ci => ci.ArgAt<Action>(1)());

--- a/src/Stack.Tests/Commands/Stack/StackSwitchCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/StackSwitchCommandHandlerTests.cs
@@ -1,8 +1,10 @@
 using FluentAssertions;
 using NSubstitute;
 using Stack.Commands;
+using Stack.Commands.Helpers;
 using Stack.Config;
 using Stack.Git;
+using Stack.Infrastructure;
 using Stack.Tests.Helpers;
 
 namespace Stack.Tests.Commands.Stack;
@@ -15,7 +17,7 @@ public class StackSwitchCommandHandlerTests
         // Arrange
         var gitOperations = Substitute.For<IGitOperations>();
         var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<IStackSwitchCommandInputProvider>();
+        var inputProvider = Substitute.For<IInputProvider>();
         var handler = new StackSwitchCommandHandler(inputProvider, gitOperations, stackConfig);
 
         var remoteUri = Some.HttpsUri().ToString();
@@ -30,7 +32,7 @@ public class StackSwitchCommandHandlerTests
         ]);
         stackConfig.Load().Returns(stacks);
 
-        inputProvider.SelectBranch(Arg.Any<List<Config.Stack>>(), Arg.Any<string>()).Returns("branch-3");
+        inputProvider.SelectGrouped(Questions.SelectBranch, Arg.Any<ChoiceGroup<string>[]>()).Returns("branch-3");
 
         // Act
         await handler.Handle(new StackSwitchCommandInputs(null));
@@ -45,7 +47,7 @@ public class StackSwitchCommandHandlerTests
         // Arrange
         var gitOperations = Substitute.For<IGitOperations>();
         var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<IStackSwitchCommandInputProvider>();
+        var inputProvider = Substitute.For<IInputProvider>();
         var handler = new StackSwitchCommandHandler(inputProvider, gitOperations, stackConfig);
 
         var remoteUri = Some.HttpsUri().ToString();
@@ -75,7 +77,7 @@ public class StackSwitchCommandHandlerTests
         // Arrange
         var gitOperations = Substitute.For<IGitOperations>();
         var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<IStackSwitchCommandInputProvider>();
+        var inputProvider = Substitute.For<IInputProvider>();
         var handler = new StackSwitchCommandHandler(inputProvider, gitOperations, stackConfig);
 
         var remoteUri = Some.HttpsUri().ToString();

--- a/src/Stack.Tests/Commands/Stack/UpdateStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/UpdateStackCommandHandlerTests.cs
@@ -5,6 +5,7 @@ using Stack.Config;
 using Stack.Git;
 using Stack.Tests.Helpers;
 using Stack.Infrastructure;
+using Stack.Commands.Helpers;
 
 namespace Stack.Tests.Commands.Stack;
 
@@ -16,7 +17,7 @@ public class UpdateStackCommandHandlerTests
         // Arrange
         var gitOperations = Substitute.For<IGitOperations>();
         var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<IUpdateStackCommandInputProvider>();
+        var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
         var handler = new UpdateStackCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
 
@@ -29,8 +30,8 @@ public class UpdateStackCommandHandlerTests
         var stacks = new List<Config.Stack>([stack1]);
         stackConfig.Load().Returns(stacks);
 
-        inputProvider.SelectStack(Arg.Any<List<Config.Stack>>(), Arg.Any<string>()).Returns("Stack1");
-        inputProvider.ConfirmUpdate().Returns(true);
+        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
+        inputProvider.Confirm(Questions.ConfirmUpdateStack).Returns(true);
 
         gitOperations.DoesRemoteBranchExist(Arg.Any<string>()).Returns(true);
 
@@ -55,7 +56,7 @@ public class UpdateStackCommandHandlerTests
         // Arrange
         var gitOperations = Substitute.For<IGitOperations>();
         var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<IUpdateStackCommandInputProvider>();
+        var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
         var handler = new UpdateStackCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
 
@@ -68,8 +69,8 @@ public class UpdateStackCommandHandlerTests
         var stacks = new List<Config.Stack>([stack1]);
         stackConfig.Load().Returns(stacks);
 
-        inputProvider.SelectStack(Arg.Any<List<Config.Stack>>(), Arg.Any<string>()).Returns("Stack1");
-        inputProvider.ConfirmUpdate().Returns(true);
+        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
+        inputProvider.Confirm(Questions.ConfirmUpdateStack).Returns(true);
 
         var branchesThatExistInRemote = new List<string>(["branch-1", "branch-3"]);
 
@@ -93,7 +94,7 @@ public class UpdateStackCommandHandlerTests
         // Arrange
         var gitOperations = Substitute.For<IGitOperations>();
         var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<IUpdateStackCommandInputProvider>();
+        var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
         var handler = new UpdateStackCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
 
@@ -106,7 +107,7 @@ public class UpdateStackCommandHandlerTests
         var stacks = new List<Config.Stack>([stack1]);
         stackConfig.Load().Returns(stacks);
 
-        inputProvider.ConfirmUpdate().Returns(true);
+        inputProvider.Confirm(Questions.ConfirmUpdateStack).Returns(true);
 
         gitOperations.DoesRemoteBranchExist(Arg.Any<string>()).Returns(true);
 
@@ -124,7 +125,7 @@ public class UpdateStackCommandHandlerTests
         gitOperations.Received().MergeFromLocalSourceBranch("branch-2");
         gitOperations.Received().PushBranch("branch-3");
 
-        inputProvider.DidNotReceive().SelectStack(Arg.Any<List<Config.Stack>>(), Arg.Any<string>());
+        inputProvider.DidNotReceive().Select(Questions.SelectStack, Arg.Any<string[]>());
     }
 
     [Fact]
@@ -133,7 +134,7 @@ public class UpdateStackCommandHandlerTests
         // Arrange
         var gitOperations = Substitute.For<IGitOperations>();
         var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<IUpdateStackCommandInputProvider>();
+        var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
         var handler = new UpdateStackCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
 
@@ -146,13 +147,13 @@ public class UpdateStackCommandHandlerTests
         var stacks = new List<Config.Stack>([stack1]);
         stackConfig.Load().Returns(stacks);
 
-        inputProvider.SelectStack(Arg.Any<List<Config.Stack>>(), Arg.Any<string>()).Returns("Stack1");
+        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
 
         // Act
         await handler.Handle(new UpdateStackCommandInputs(null, true));
 
         // Assert
-        inputProvider.DidNotReceive().ConfirmUpdate();
+        inputProvider.DidNotReceive().Confirm(Questions.ConfirmUpdateStack);
     }
 
     [Fact]
@@ -161,7 +162,7 @@ public class UpdateStackCommandHandlerTests
         // Arrange
         var gitOperations = Substitute.For<IGitOperations>();
         var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<IUpdateStackCommandInputProvider>();
+        var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
         var handler = new UpdateStackCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
 
@@ -187,7 +188,7 @@ public class UpdateStackCommandHandlerTests
         // Arrange
         var gitOperations = Substitute.For<IGitOperations>();
         var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<IUpdateStackCommandInputProvider>();
+        var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
         var handler = new UpdateStackCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
 
@@ -202,8 +203,8 @@ public class UpdateStackCommandHandlerTests
         var stacks = new List<Config.Stack>([stack1]);
         stackConfig.Load().Returns(stacks);
 
-        inputProvider.SelectStack(Arg.Any<List<Config.Stack>>(), Arg.Any<string>()).Returns("Stack1");
-        inputProvider.ConfirmUpdate().Returns(true);
+        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
+        inputProvider.Confirm(Questions.ConfirmUpdateStack).Returns(true);
 
         gitOperations.DoesRemoteBranchExist(Arg.Any<string>()).Returns(true);
 

--- a/src/Stack/Commands/Helpers/Questions.cs
+++ b/src/Stack/Commands/Helpers/Questions.cs
@@ -6,6 +6,7 @@ public static class Questions
 {
     public const string SelectStack = "Select stack:";
     public const string SelectBranch = "Select branch:";
+    public const string ConfirmUpdateStack = "Are you sure you want to update this stack?";
     public static string ConfirmDeleteStack(string name) => $"Are you sure you want to delete stack {name.Stack()}?";
     public const string ConfirmDeleteBranches = "Are you sure you want to delete these local branches?";
     public static string ConfirmRemoveBranch(string stackName, string branchName) => $"Are you sure you want to remove branch {branchName.Branch()} from stack {stackName.Stack()}?";

--- a/src/Stack/Commands/Helpers/Questions.cs
+++ b/src/Stack/Commands/Helpers/Questions.cs
@@ -5,9 +5,15 @@ namespace Stack.Commands.Helpers;
 public static class Questions
 {
     public const string SelectStack = "Select stack:";
+    public const string StackName = "Stack name:";
     public const string SelectBranch = "Select branch:";
+    public const string BranchName = "Branch name:";
+    public const string SelectSourceBranch = "Select a branch to start your stack from:";
     public const string ConfirmUpdateStack = "Are you sure you want to update this stack?";
     public static string ConfirmDeleteStack(string name) => $"Are you sure you want to delete stack {name.Stack()}?";
     public const string ConfirmDeleteBranches = "Are you sure you want to delete these local branches?";
     public static string ConfirmRemoveBranch(string stackName, string branchName) => $"Are you sure you want to remove branch {branchName.Branch()} from stack {stackName.Stack()}?";
+    public const string ConfirmAddOrCreateBranch = "Do you want to add an existing branch or create a new branch and add it to the stack?";
+    public const string AddOrCreateBranch = "Add or create a branch:";
+    public const string ConfirmSwitchToBranch = "Do you want to switch to the new branch?";
 }


### PR DESCRIPTION
This PR removes specific input providers in favour of using the base `IInputProvider` everywhere, making this consistent and easier to share across commands.