### PR TITLE
Fixes issue with double stack name output

### DIFF
--- a/src/Stack/Commands/Helpers/InputProviderExtensionMethods.cs
+++ b/src/Stack/Commands/Helpers/InputProviderExtensionMethods.cs
@@ -54,7 +54,7 @@ public static class InputProviderExtensionMethods
 
         if (stack is not null)
         {
-            outputProvider.Information($"{Questions.SelectStack} {stack.Name.Stack()}");
+            outputProvider.Information($"{Questions.SelectStack} {stack.Name.ToInputDisplay()}");
         }
 
         return stack;

--- a/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
+++ b/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
@@ -73,14 +73,13 @@ public class CreatePullRequestsCommandHandler(
             throw new InvalidOperationException($"Stack '{inputs.StackName}' not found.");
         }
 
-        var stackStatusCommandHandler = new StackStatusCommandHandler(
-            inputProvider,
+        StackStatusHelpers.CheckStackStatus(
+            [stack],
+            currentBranch,
             outputProvider,
             gitOperations,
             gitHubOperations,
-            stackConfig);
-
-        await stackStatusCommandHandler.Handle(new StackStatusCommandInputs(stack.Name, false));
+            false);
 
         outputProvider.NewLine();
 

--- a/src/Stack/Commands/Stack/StackStatusCommand.cs
+++ b/src/Stack/Commands/Stack/StackStatusCommand.cs
@@ -66,14 +66,11 @@ public class StackStatusCommandHandler(
         var stacksForRemote = stacks.Where(s => s.RemoteUri.Equals(remoteUri, StringComparison.OrdinalIgnoreCase)).ToList();
         var currentBranch = gitOperations.GetCurrentBranch();
 
-        var stacksToCheckStatusFor = new Dictionary<Config.Stack, StackStatus>();
+        var stacksToCheckStatusFor = new List<Config.Stack>();
 
         if (inputs.All)
         {
-            stacksForRemote
-                .OrderByCurrentStackThenByName(currentBranch)
-                .ToList()
-                .ForEach(stack => stacksToCheckStatusFor.Add(stack, new StackStatus([])));
+            stacksToCheckStatusFor.AddRange(stacks);
         }
         else
         {
@@ -84,8 +81,37 @@ public class StackStatusCommandHandler(
                 throw new InvalidOperationException($"Stack '{inputs.Name}' not found.");
             }
 
-            stacksToCheckStatusFor.Add(stack, new StackStatus([]));
+            stacksToCheckStatusFor.Add(stack);
         }
+
+        var stackStatusResults = StackStatusHelpers.CheckStackStatus(
+            stacksToCheckStatusFor,
+            currentBranch,
+            outputProvider,
+            gitOperations,
+            gitHubOperations,
+            true);
+
+        return new StackStatusCommandResponse(stackStatusResults);
+    }
+}
+
+public static class StackStatusHelpers
+{
+    public static Dictionary<Config.Stack, StackStatus> CheckStackStatus(
+        List<Config.Stack> stacks,
+        string currentBranch,
+        IOutputProvider outputProvider,
+        IGitOperations gitOperations,
+        IGitHubOperations gitHubOperations,
+        bool checkBranchAndStackCleanup)
+    {
+        var stacksToCheckStatusFor = new Dictionary<Config.Stack, StackStatus>();
+
+        stacks
+            .OrderByCurrentStackThenByName(currentBranch)
+            .ToList()
+            .ForEach(stack => stacksToCheckStatusFor.Add(stack, new StackStatus([])));
 
         outputProvider.Status("Checking status of remote branches...", () =>
         {
@@ -214,7 +240,7 @@ public class StackStatusCommandHandler(
             outputProvider.Tree(header, items.ToArray());
         }
 
-        if (stacksToCheckStatusFor.Count == 1)
+        if (checkBranchAndStackCleanup && stacksToCheckStatusFor.Count == 1)
         {
             var (stack, status) = stacksToCheckStatusFor.First();
 
@@ -256,6 +282,6 @@ public class StackStatusCommandHandler(
             }
         }
 
-        return new StackStatusCommandResponse(stacksToCheckStatusFor);
+        return stacksToCheckStatusFor;
     }
 }


### PR DESCRIPTION
This PR fixes an issue where the stack name would be printed twice when using the `pr create` command.