### PR TITLE
Makes versioning PR job run after publish

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -238,7 +238,7 @@ jobs:
 
   versioning_pr:
     name: Create versioning pull request
-    needs: [version]
+    needs: [version, publish]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
The versioning PR job added in #86 currently only waits for the `version` job to finish, which means it could run and create a PR for something that doesn't build or publish successfully. This PR moves it to after the `publish` job so that we can have confidence in the PR being created.