### PR TITLE
Removes ignore of changelog file from build

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -5,13 +5,11 @@ on:
     branches: ["main"]
     paths-ignore:
       - "README.md"
-      - "CHANGELOG.md"
 
   pull_request:
     branches: ["main"]
     paths-ignore:
       - "README.md"
-      - "CHANGELOG.md"
 
 jobs:
   version:


### PR DESCRIPTION
This PR fixes up the build workflow so that it runs when only changes to `CHANGELOG.md` are present, for example it should run when #89 is merged but it isn't currently.