### PR TITLE
Add PR check jobs

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -4,12 +4,14 @@ on:
   push:
     branches: ["main"]
     paths-ignore:
-      - "README.md"
+      - README.md
+      - .github/workflows/docs-only.yaml
 
   pull_request:
     branches: ["main"]
     paths-ignore:
-      - "README.md"
+      - README.md
+      - .github/workflows/docs-only.yaml
 
 jobs:
   version:
@@ -190,6 +192,14 @@ jobs:
           overwrite: true
           name: ${{ matrix.artifact-name }}
           path: ${{ github.workspace }}/artifacts/*
+
+  pr_complete:
+    name: PR checks complete
+    runs-on: ubuntu-latest
+    needs: [publish]
+    if: github.event_name == 'pull_request'
+    steps:
+      - run: echo "PR required checks complete"
 
   release:
     name: Release

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -5,13 +5,11 @@ on:
     branches: ["main"]
     paths-ignore:
       - README.md
-      - .github/workflows/docs-only.yaml
 
   pull_request:
     branches: ["main"]
     paths-ignore:
       - README.md
-      - .github/workflows/docs-only.yaml
 
 jobs:
   version:

--- a/.github/workflows/docs-only.yaml
+++ b/.github/workflows/docs-only.yaml
@@ -1,0 +1,16 @@
+name: Docs only (PR)
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "!**" # Exclude every file
+      - ".github/workflows/docs-only.yaml" # Except only this file
+      - "README.md" # Except only readme changes
+
+jobs:
+  pr_complete:
+    name: PR checks complete
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "PR required checks complete"

--- a/.github/workflows/docs-only.yaml
+++ b/.github/workflows/docs-only.yaml
@@ -5,7 +5,6 @@ on:
     branches: ["main"]
     paths:
       - "!**" # Exclude every file
-      - ".github/workflows/docs-only.yaml" # Except only this file
       - "README.md" # Except only readme changes
 
 jobs:


### PR DESCRIPTION
This PR adds:
- A new job to the build and test workflow that runs after publishing of artifacts for PRs only. It doesn't do anything, but exists purely for branch protections.
- A new workflow that only runs for doc-only PRs which has the same job name as the one above. It also doesn't do anything, but exists purely for branch protections.