### PR TITLE
Fix directories for nuget updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,3 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,7 +1,8 @@
 version: 2
 updates:
   - package-ecosystem: "nuget"
-    directory: "/"
+    directories:
+      - "/src/*"
     schedule:
       interval: "daily"
 


### PR DESCRIPTION
<!-- stack-pr-list -->
This PR is part of a series adding automated dependency updates using dependabot:

- https://github.com/geofflamrock/stack/pull/105
- https://github.com/geofflamrock/stack/pull/106
<!-- /stack-pr-list -->

When the [dependabot updates ran](https://github.com/geofflamrock/stack/actions/runs/12188585626) they didn't find , this PR changes to search inside `/src/*` to hopefully find all the projects.