### PR TITLE
Removes styling of input

### DIFF
--- a/src/Stack/Commands/Helpers/InputProviderExtensionMethods.cs
+++ b/src/Stack/Commands/Helpers/InputProviderExtensionMethods.cs
@@ -16,7 +16,7 @@ public static class InputProviderExtensionMethods
     {
         if (presetValue is not null)
         {
-            outputProvider.Information($"{prompt} {presetValue.ToInputDisplay()}");
+            outputProvider.Information($"{prompt} {presetValue}");
 
             return presetValue;
         }
@@ -33,7 +33,7 @@ public static class InputProviderExtensionMethods
     {
         var selection = presetValue ?? inputProvider.Select(prompt, choices);
 
-        outputProvider.Information($"{prompt} {selection.ToInputDisplay()}");
+        outputProvider.Information($"{prompt} {selection}");
 
         return selection;
     }
@@ -54,7 +54,7 @@ public static class InputProviderExtensionMethods
 
         if (stack is not null)
         {
-            outputProvider.Information($"{Questions.SelectStack} {stack.Name.ToInputDisplay()}");
+            outputProvider.Information($"{Questions.SelectStack} {stack.Name}");
         }
 
         return stack;

--- a/src/Stack/Infrastructure/ConsoleInputProvider.cs
+++ b/src/Stack/Infrastructure/ConsoleInputProvider.cs
@@ -19,7 +19,7 @@ public class ConsoleInputProvider(IAnsiConsole console) : IInputProvider
 
     public string Text(string prompt, string? defaultValue = null)
     {
-        var textPrompt = new TextPrompt<string>(prompt).PromptStyle(Style.Parse("blue"));
+        var textPrompt = new TextPrompt<string>(prompt);
 
         if (defaultValue is not null)
             textPrompt.DefaultValue(defaultValue);

--- a/src/Stack/Infrastructure/ConsoleOutputProvider.cs
+++ b/src/Stack/Infrastructure/ConsoleOutputProvider.cs
@@ -46,5 +46,5 @@ public static class OutputStyleExtensionMethods
     public static string Branch(this string name) => $"[blue]{name}[/]";
     public static string Muted(this string name) => $"[grey]{name}[/]";
     public static string Example(this string name) => $"[aqua]{name}[/]";
-    public static string ToInputDisplay(this string input) => $"[blue]{input}[/]";
+    public static string ToInputDisplay(this string input) => input;
 }

--- a/src/Stack/Infrastructure/ConsoleOutputProvider.cs
+++ b/src/Stack/Infrastructure/ConsoleOutputProvider.cs
@@ -46,5 +46,4 @@ public static class OutputStyleExtensionMethods
     public static string Branch(this string name) => $"[blue]{name}[/]";
     public static string Muted(this string name) => $"[grey]{name}[/]";
     public static string Example(this string name) => $"[aqua]{name}[/]";
-    public static string ToInputDisplay(this string input) => input;
 }


### PR DESCRIPTION
Styling of inputs was added in #82, after some usage I'm finding it distracting and not helpful. It also doesn't apply to all forms of input e.g. confirmations, so this PR removes it.