### PR TITLE
Add support for creating pull requests as drafts

### DIFF
--- a/src/Stack.Tests/Commands/PullRequests/CreatePullRequestsCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/PullRequests/CreatePullRequestsCommandHandlerTests.cs
@@ -53,22 +53,22 @@ public class CreatePullRequestsCommandHandlerTests
         inputProvider.Text(Questions.PullRequestTitle("branch-3", "branch-1")).Returns("PR Title for branch-3");
         inputProvider.Text(Questions.PullRequestTitle("branch-5", "branch-3")).Returns("PR Title for branch-5");
 
-        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri());
+        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubOperations
-            .CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty)
+            .CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty, false)
             .Returns(prForBranch3);
 
-        var prForBranch5 = new GitHubPullRequest(2, "PR Title for branch-5", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri());
+        var prForBranch5 = new GitHubPullRequest(2, "PR Title for branch-5", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubOperations
-            .CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty)
+            .CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty, false)
             .Returns(prForBranch5);
 
         // Act
         await handler.Handle(CreatePullRequestsCommandInputs.Empty);
 
         // Assert        
-        gitHubOperations.Received().CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty);
-        gitHubOperations.Received().CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty);
+        gitHubOperations.Received().CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty, false);
+        gitHubOperations.Received().CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty, false);
     }
 
     [Fact]
@@ -114,14 +114,14 @@ public class CreatePullRequestsCommandHandlerTests
         inputProvider.Text(Questions.PullRequestTitle("branch-5", "branch-3")).Returns("PR Title for branch-5");
         inputProvider.Text(Questions.PullRequestStackDescription, Arg.Any<string>()).Returns("A custom description");
 
-        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri());
+        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubOperations
-            .CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty)
+            .CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty, false)
             .Returns(prForBranch3);
 
-        var prForBranch5 = new GitHubPullRequest(2, "PR Title for branch-5", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri());
+        var prForBranch5 = new GitHubPullRequest(2, "PR Title for branch-5", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubOperations
-            .CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty)
+            .CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty, false)
             .Returns(prForBranch5);
 
         gitHubOperations
@@ -189,12 +189,12 @@ A custom description
         inputProvider.Text(Questions.PullRequestTitle("branch-5", "branch-3")).Returns("PR Title for branch-5");
         inputProvider.Text(Questions.PullRequestStackDescription, Arg.Any<string>()).Returns("A custom description");
 
-        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri());
+        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubOperations.GetPullRequest("branch-3").Returns(prForBranch3);
 
-        var prForBranch5 = new GitHubPullRequest(2, "PR Title for branch-5", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri());
+        var prForBranch5 = new GitHubPullRequest(2, "PR Title for branch-5", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubOperations
-            .CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty)
+            .CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty, false)
             .Returns(prForBranch5);
 
         gitHubOperations
@@ -209,8 +209,8 @@ A custom description
         await handler.Handle(CreatePullRequestsCommandInputs.Empty);
 
         // Assert        
-        gitHubOperations.DidNotReceive().CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty);
-        gitHubOperations.Received().CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty);
+        gitHubOperations.DidNotReceive().CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty, false);
+        gitHubOperations.Received().CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty, false);
         var expectedStackDescription = $@"<!-- stack-pr-list -->
 A custom description
 
@@ -264,22 +264,22 @@ A custom description
         inputProvider.Text(Questions.PullRequestTitle("branch-3", "branch-1")).Returns("PR Title for branch-3");
         inputProvider.Text(Questions.PullRequestTitle("branch-5", "branch-3")).Returns("PR Title for branch-5");
 
-        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri());
+        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubOperations
-            .CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty)
+            .CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty, false)
             .Returns(prForBranch3);
 
-        var prForBranch5 = new GitHubPullRequest(2, "PR Title for branch-5", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri());
+        var prForBranch5 = new GitHubPullRequest(2, "PR Title for branch-5", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubOperations
-            .CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty)
+            .CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty, false)
             .Returns(prForBranch5);
 
         // Act
-        await handler.Handle(new CreatePullRequestsCommandInputs("Stack1"));
+        await handler.Handle(new CreatePullRequestsCommandInputs("Stack1", null));
 
         // Assert        
-        gitHubOperations.Received().CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty);
-        gitHubOperations.Received().CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty);
+        gitHubOperations.Received().CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty, false);
+        gitHubOperations.Received().CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty, false);
     }
 
     [Fact]
@@ -319,22 +319,22 @@ A custom description
         inputProvider.Text(Questions.PullRequestTitle("branch-3", "branch-1")).Returns("PR Title for branch-3");
         inputProvider.Text(Questions.PullRequestTitle("branch-5", "branch-3")).Returns("PR Title for branch-5");
 
-        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri());
+        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubOperations
-            .CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty)
+            .CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty, false)
             .Returns(prForBranch3);
 
-        var prForBranch5 = new GitHubPullRequest(2, "PR Title for branch-5", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri());
+        var prForBranch5 = new GitHubPullRequest(2, "PR Title for branch-5", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubOperations
-            .CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty)
+            .CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty, false)
             .Returns(prForBranch5);
 
         // Act
         await handler.Handle(CreatePullRequestsCommandInputs.Empty);
 
         // Assert        
-        gitHubOperations.Received().CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty);
-        gitHubOperations.Received().CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty);
+        gitHubOperations.Received().CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty, false);
+        gitHubOperations.Received().CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty, false);
     }
 
     [Fact]
@@ -362,7 +362,7 @@ A custom description
 
         // Act and assert
         var invalidStackName = Some.Name();
-        await handler.Invoking(h => h.Handle(new CreatePullRequestsCommandInputs(invalidStackName)))
+        await handler.Invoking(h => h.Handle(new CreatePullRequestsCommandInputs(invalidStackName, null)))
             .Should()
             .ThrowAsync<InvalidOperationException>()
             .WithMessage($"Stack '{invalidStackName}' not found.");
@@ -410,12 +410,12 @@ A custom description
         inputProvider.Text(Questions.PullRequestTitle("branch-5", "branch-1")).Returns("PR Title for branch-5");
         inputProvider.Text(Questions.PullRequestStackDescription, Arg.Any<string>()).Returns("A custom description");
 
-        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", string.Empty, GitHubPullRequestStates.Merged, Some.HttpsUri());
+        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", string.Empty, GitHubPullRequestStates.Merged, Some.HttpsUri(), false);
         gitHubOperations.GetPullRequest("branch-3").Returns(prForBranch3);
 
-        var prForBranch5 = new GitHubPullRequest(2, "PR Title for branch-5", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri());
+        var prForBranch5 = new GitHubPullRequest(2, "PR Title for branch-5", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubOperations
-            .CreatePullRequest("branch-5", "branch-1", "PR Title for branch-5", string.Empty)
+            .CreatePullRequest("branch-5", "branch-1", "PR Title for branch-5", string.Empty, false)
             .Returns(prForBranch5);
 
         gitHubOperations
@@ -430,8 +430,8 @@ A custom description
         await handler.Handle(CreatePullRequestsCommandInputs.Empty);
 
         // Assert        
-        gitHubOperations.DidNotReceive().CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty);
-        gitHubOperations.Received().CreatePullRequest("branch-5", "branch-1", "PR Title for branch-5", string.Empty);
+        gitHubOperations.DidNotReceive().CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty, false);
+        gitHubOperations.Received().CreatePullRequest("branch-5", "branch-1", "PR Title for branch-5", string.Empty, false);
         var expectedStackDescription = $@"<!-- stack-pr-list -->
 A custom description
 
@@ -441,5 +441,127 @@ A custom description
 
         prForBranch3.Body.Should().Be(expectedStackDescription);
         prForBranch5.Body.Should().Be(expectedStackDescription);
+    }
+
+    [Fact]
+    public async Task WhenAskedWhetherToCreateAPullRequestAsADraft_AndTheAnswerIsYes_PullRequestsCreatedAsADraft()
+    {
+        // Arrange
+        var gitOperations = Substitute.For<IGitOperations>();
+        var gitHubOperations = Substitute.For<IGitHubOperations>();
+        var stackConfig = Substitute.For<IStackConfig>();
+        var inputProvider = Substitute.For<IInputProvider>();
+        var outputProvider = Substitute.For<IOutputProvider>();
+        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+
+        var remoteUri = Some.HttpsUri().ToString();
+        outputProvider
+            .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
+            .Do(ci => ci.ArgAt<Action>(1)());
+
+        gitOperations.GetRemoteUri().Returns(remoteUri);
+        gitOperations.GetCurrentBranch().Returns("branch-1");
+        gitOperations
+            .GetBranchesThatExistInRemote(Arg.Any<string[]>())
+            .Returns(["branch-1", "branch-3", "branch-5"]);
+
+        gitOperations
+            .GetBranchesThatExistLocally(Arg.Any<string[]>())
+            .Returns(["branch-1", "branch-3", "branch-5"]);
+
+        var stacks = new List<Config.Stack>(
+        [
+            new("Stack1", remoteUri, "branch-1", ["branch-3", "branch-5"]),
+            new("Stack2", remoteUri, "branch-2", ["branch-4"])
+        ]);
+        stackConfig.Load().Returns(stacks);
+        stackConfig
+            .WhenForAnyArgs(s => s.Save(Arg.Any<List<Config.Stack>>()))
+            .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
+
+        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
+        inputProvider.Confirm(Questions.ConfirmStartCreatePullRequests(2)).Returns(true);
+        inputProvider.Confirm(Questions.ConfirmCreatePullRequests).Returns(true);
+        inputProvider.Confirm(Questions.CreatePullRequestsAsDrafts, false).Returns(true);
+        inputProvider.Text(Questions.PullRequestTitle("branch-3", "branch-1")).Returns("PR Title for branch-3");
+        inputProvider.Text(Questions.PullRequestTitle("branch-5", "branch-3")).Returns("PR Title for branch-5");
+
+        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), true);
+        gitHubOperations
+            .CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty, true)
+            .Returns(prForBranch3);
+
+        var prForBranch5 = new GitHubPullRequest(2, "PR Title for branch-5", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), true);
+        gitHubOperations
+            .CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty, true)
+            .Returns(prForBranch5);
+
+        // Act
+        await handler.Handle(CreatePullRequestsCommandInputs.Empty);
+
+        // Assert        
+        gitHubOperations.Received().CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty, true);
+        gitHubOperations.Received().CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty, true);
+    }
+
+    [Fact]
+    public async Task WhenDraftIsProvided_PullRequestsAreCreatedAsDrafts()
+    {
+        // Arrange
+        var gitOperations = Substitute.For<IGitOperations>();
+        var gitHubOperations = Substitute.For<IGitHubOperations>();
+        var stackConfig = Substitute.For<IStackConfig>();
+        var inputProvider = Substitute.For<IInputProvider>();
+        var outputProvider = Substitute.For<IOutputProvider>();
+        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+
+        var remoteUri = Some.HttpsUri().ToString();
+        outputProvider
+            .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
+            .Do(ci => ci.ArgAt<Action>(1)());
+
+        gitOperations.GetRemoteUri().Returns(remoteUri);
+        gitOperations.GetCurrentBranch().Returns("branch-1");
+        gitOperations
+            .GetBranchesThatExistInRemote(Arg.Any<string[]>())
+            .Returns(["branch-1", "branch-3", "branch-5"]);
+
+        gitOperations
+            .GetBranchesThatExistLocally(Arg.Any<string[]>())
+            .Returns(["branch-1", "branch-3", "branch-5"]);
+
+        var stacks = new List<Config.Stack>(
+        [
+            new("Stack1", remoteUri, "branch-1", ["branch-3", "branch-5"]),
+            new("Stack2", remoteUri, "branch-2", ["branch-4"])
+        ]);
+        stackConfig.Load().Returns(stacks);
+        stackConfig
+            .WhenForAnyArgs(s => s.Save(Arg.Any<List<Config.Stack>>()))
+            .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
+
+        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
+        inputProvider.Confirm(Questions.ConfirmStartCreatePullRequests(2)).Returns(true);
+        inputProvider.Confirm(Questions.ConfirmCreatePullRequests).Returns(true);
+        inputProvider.Text(Questions.PullRequestTitle("branch-3", "branch-1")).Returns("PR Title for branch-3");
+        inputProvider.Text(Questions.PullRequestTitle("branch-5", "branch-3")).Returns("PR Title for branch-5");
+
+        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), true);
+        gitHubOperations
+            .CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty, true)
+            .Returns(prForBranch3);
+
+        var prForBranch5 = new GitHubPullRequest(2, "PR Title for branch-5", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), true);
+        gitHubOperations
+            .CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty, true)
+            .Returns(prForBranch5);
+
+        // Act
+        await handler.Handle(new CreatePullRequestsCommandInputs(null, true));
+
+        // Assert        
+        gitHubOperations.Received().CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty, true);
+        gitHubOperations.Received().CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty, true);
+        inputProvider.DidNotReceive().Confirm(Questions.CreatePullRequestsAsDrafts, false);
     }
 }

--- a/src/Stack.Tests/Commands/PullRequests/OpenPullRequestsCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/PullRequests/OpenPullRequestsCommandHandlerTests.cs
@@ -39,12 +39,12 @@ public class OpenPullRequestsCommandHandlerTests
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
 
-        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri());
+        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubOperations
             .GetPullRequest("branch-3")
             .Returns(prForBranch3);
 
-        var prForBranch5 = new GitHubPullRequest(2, "PR Title for branch-5", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri());
+        var prForBranch5 = new GitHubPullRequest(2, "PR Title for branch-5", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubOperations
             .GetPullRequest("branch-5")
             .Returns(prForBranch5);
@@ -85,12 +85,12 @@ public class OpenPullRequestsCommandHandlerTests
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
 
-        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri());
+        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubOperations
             .GetPullRequest("branch-3")
             .Returns(prForBranch3);
 
-        var prForBranch5 = new GitHubPullRequest(2, "PR Title for branch-5", string.Empty, GitHubPullRequestStates.Closed, Some.HttpsUri());
+        var prForBranch5 = new GitHubPullRequest(2, "PR Title for branch-5", string.Empty, GitHubPullRequestStates.Closed, Some.HttpsUri(), false);
 
         // Act
         await handler.Handle(OpenPullRequestsCommandInputs.Empty);
@@ -123,12 +123,12 @@ public class OpenPullRequestsCommandHandlerTests
         ]);
         stackConfig.Load().Returns(stacks);
 
-        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri());
+        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubOperations
             .GetPullRequest("branch-3")
             .Returns(prForBranch3);
 
-        var prForBranch5 = new GitHubPullRequest(2, "PR Title for branch-5", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri());
+        var prForBranch5 = new GitHubPullRequest(2, "PR Title for branch-5", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubOperations
             .GetPullRequest("branch-5")
             .Returns(prForBranch5);
@@ -163,12 +163,12 @@ public class OpenPullRequestsCommandHandlerTests
         ]);
         stackConfig.Load().Returns(stacks);
 
-        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri());
+        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubOperations
             .GetPullRequest("branch-3")
             .Returns(prForBranch3);
 
-        var prForBranch5 = new GitHubPullRequest(2, "PR Title for branch-5", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri());
+        var prForBranch5 = new GitHubPullRequest(2, "PR Title for branch-5", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubOperations
             .GetPullRequest("branch-5")
             .Returns(prForBranch5);
@@ -204,12 +204,12 @@ public class OpenPullRequestsCommandHandlerTests
         ]);
         stackConfig.Load().Returns(stacks);
 
-        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri());
+        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubOperations
             .GetPullRequest("branch-3")
             .Returns(prForBranch3);
 
-        var prForBranch5 = new GitHubPullRequest(2, "PR Title for branch-5", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri());
+        var prForBranch5 = new GitHubPullRequest(2, "PR Title for branch-5", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubOperations
             .GetPullRequest("branch-5")
             .Returns(prForBranch5);

--- a/src/Stack.Tests/Commands/Stack/StackStatusCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/StackStatusCommandHandlerTests.cs
@@ -53,7 +53,7 @@ public class StackStatusCommandHandlerTests
             .GetStatusOfRemoteBranch("branch-5", "branch-3")
             .Returns((1, 0));
 
-        var pr = new GitHubPullRequest(1, "PR title", "PR body", GitHubPullRequestStates.Open, Some.HttpsUri());
+        var pr = new GitHubPullRequest(1, "PR title", "PR body", GitHubPullRequestStates.Open, Some.HttpsUri(), false);
 
         gitHubOperations
             .GetPullRequest("branch-3")
@@ -117,7 +117,7 @@ public class StackStatusCommandHandlerTests
             .GetStatusOfRemoteBranch("branch-5", "branch-3")
             .Returns((1, 0));
 
-        var pr = new GitHubPullRequest(1, "PR title", "PR body", GitHubPullRequestStates.Open, Some.HttpsUri());
+        var pr = new GitHubPullRequest(1, "PR title", "PR body", GitHubPullRequestStates.Open, Some.HttpsUri(), false);
 
         gitHubOperations
             .GetPullRequest("branch-3")
@@ -187,7 +187,7 @@ public class StackStatusCommandHandlerTests
             .GetStatusOfRemoteBranch("branch-4", "branch-2")
             .Returns((3, 1));
 
-        var pr = new GitHubPullRequest(1, "PR title", "PR body", GitHubPullRequestStates.Open, Some.HttpsUri());
+        var pr = new GitHubPullRequest(1, "PR title", "PR body", GitHubPullRequestStates.Open, Some.HttpsUri(), false);
 
         gitHubOperations
             .GetPullRequest("branch-3")
@@ -263,7 +263,7 @@ public class StackStatusCommandHandlerTests
             .GetStatusOfRemoteBranch("branch-4", "branch-2")
             .Returns((3, 1));
 
-        var pr = new GitHubPullRequest(1, "PR title", "PR body", GitHubPullRequestStates.Open, Some.HttpsUri());
+        var pr = new GitHubPullRequest(1, "PR title", "PR body", GitHubPullRequestStates.Open, Some.HttpsUri(), false);
 
         gitHubOperations
             .GetPullRequest("branch-3")
@@ -360,7 +360,7 @@ public class StackStatusCommandHandlerTests
             .GetStatusOfRemoteBranch("branch-5", "branch-1")
             .Returns((1, 0));
 
-        var pr = new GitHubPullRequest(1, "PR title", "PR body", GitHubPullRequestStates.Open, Some.HttpsUri());
+        var pr = new GitHubPullRequest(1, "PR title", "PR body", GitHubPullRequestStates.Open, Some.HttpsUri(), false);
 
         gitHubOperations
             .GetPullRequest("branch-5")
@@ -421,7 +421,7 @@ public class StackStatusCommandHandlerTests
             .GetStatusOfRemoteBranch("branch-5", "branch-1")
             .Returns((1, 0));
 
-        var pr = new GitHubPullRequest(1, "PR title", "PR body", GitHubPullRequestStates.Open, Some.HttpsUri());
+        var pr = new GitHubPullRequest(1, "PR title", "PR body", GitHubPullRequestStates.Open, Some.HttpsUri(), false);
 
         gitHubOperations
             .GetPullRequest("branch-5")
@@ -484,7 +484,7 @@ public class StackStatusCommandHandlerTests
             .GetStatusOfRemoteBranch("branch-5", "branch-3")
             .Returns((1, 0));
 
-        var pr = new GitHubPullRequest(1, "PR title", "PR body", GitHubPullRequestStates.Open, Some.HttpsUri());
+        var pr = new GitHubPullRequest(1, "PR title", "PR body", GitHubPullRequestStates.Open, Some.HttpsUri(), false);
 
         gitHubOperations
             .GetPullRequest("branch-3")

--- a/src/Stack.Tests/Commands/Stack/UpdateStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/UpdateStackCommandHandlerTests.cs
@@ -119,7 +119,7 @@ public class UpdateStackCommandHandlerTests
         var branchesThatExistInRemote = new List<string>(["branch-1", "branch-2", "branch-3"]);
 
         gitOperations.DoesRemoteBranchExist(Arg.Is<string>(b => branchesThatExistInRemote.Contains(b))).Returns(true);
-        gitHubOperations.GetPullRequest("branch-2").Returns(new GitHubPullRequest(1, Some.Name(), Some.Name(), GitHubPullRequestStates.Merged, Some.HttpsUri()));
+        gitHubOperations.GetPullRequest("branch-2").Returns(new GitHubPullRequest(1, Some.Name(), Some.Name(), GitHubPullRequestStates.Merged, Some.HttpsUri(), false));
 
         // Act
         await handler.Handle(new UpdateStackCommandInputs(null, false));

--- a/src/Stack/Commands/Helpers/Questions.cs
+++ b/src/Stack/Commands/Helpers/Questions.cs
@@ -22,4 +22,5 @@ public static class Questions
     public static string PullRequestTitle(string sourceBranch, string targetBranch) => $"Title for pull request from {sourceBranch.Branch()} -> {targetBranch.Branch()}:";
     public const string PullRequestStackDescription = "Stack description for pull request:";
     public const string OpenPullRequests = "Open the pull requests in the browser?";
+    public const string CreatePullRequestsAsDrafts = "Create pull requests as drafts?";
 }

--- a/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
+++ b/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
@@ -127,8 +127,7 @@ public class CreatePullRequestsCommandHandler(
                     {
                         draft = inputProvider.Confirm(Questions.CreatePullRequestsAsDrafts, false);
                     }
-
-                    if (inputs.Draft == true)
+                    else if (draft)
                     {
                         outputProvider.Information("Creating pull requests as drafts.");
                     }

--- a/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
+++ b/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
@@ -15,6 +15,10 @@ public class CreatePullRequestsCommandSettings : DryRunCommandSettingsBase
     [Description("The name of the stack to create pull requests for.")]
     [CommandOption("-n|--name")]
     public string? Name { get; init; }
+
+    [Description("Create pull requests as drafts.")]
+    [CommandOption("--draft")]
+    public bool? Draft { get; init; }
 }
 
 public class CreatePullRequestsCommand : AsyncCommand<CreatePullRequestsCommandSettings>
@@ -30,15 +34,15 @@ public class CreatePullRequestsCommand : AsyncCommand<CreatePullRequestsCommandS
             new GitHubOperations(console, settings.GetGitHubOperationSettings()),
             new StackConfig());
 
-        await handler.Handle(new CreatePullRequestsCommandInputs(settings.Name));
+        await handler.Handle(new CreatePullRequestsCommandInputs(settings.Name, settings.Draft));
 
         return 0;
     }
 }
 
-public record CreatePullRequestsCommandInputs(string? StackName)
+public record CreatePullRequestsCommandInputs(string? StackName, bool? Draft)
 {
-    public static CreatePullRequestsCommandInputs Empty => new((string?)null);
+    public static CreatePullRequestsCommandInputs Empty => new(null, null);
 }
 
 public record CreatePullRequestsCommandResponse();
@@ -117,7 +121,19 @@ public class CreatePullRequestsCommandHandler(
 
                 if (inputProvider.Confirm(Questions.ConfirmCreatePullRequests))
                 {
-                    CreatePullRequests(outputProvider, gitHubOperations, status, pullRequestCreateActions);
+                    var draft = inputs.Draft ?? false;
+
+                    if (inputs.Draft is null)
+                    {
+                        draft = inputProvider.Confirm(Questions.CreatePullRequestsAsDrafts, false);
+                    }
+
+                    if (inputs.Draft == true)
+                    {
+                        outputProvider.Information("Creating pull requests as drafts.");
+                    }
+
+                    CreatePullRequests(outputProvider, gitHubOperations, status, pullRequestCreateActions, draft);
 
                     var pullRequestsInStack = status.Branches.Values
                         .Where(branch => branch.HasPullRequest)
@@ -204,13 +220,18 @@ public class CreatePullRequestsCommandHandler(
         }
     }
 
-    private static void CreatePullRequests(IOutputProvider outputProvider, IGitHubOperations gitHubOperations, StackStatus status, List<GitHubPullRequestCreateAction> pullRequestCreateActions)
+    private static void CreatePullRequests(
+        IOutputProvider outputProvider,
+        IGitHubOperations gitHubOperations,
+        StackStatus status,
+        List<GitHubPullRequestCreateAction> pullRequestCreateActions,
+        bool draft)
     {
         foreach (var action in pullRequestCreateActions)
         {
             var branchDetail = status.Branches[action.HeadBranch];
             outputProvider.Information($"Creating pull request for branch {action.HeadBranch.Branch()} to {action.BaseBranch.Branch()}");
-            var pullRequest = gitHubOperations.CreatePullRequest(action.HeadBranch, action.BaseBranch, action.Title!, "");
+            var pullRequest = gitHubOperations.CreatePullRequest(action.HeadBranch, action.BaseBranch, action.Title!, "", draft);
 
             if (pullRequest is not null)
             {

--- a/src/Stack/Infrastructure/ConsoleInputProvider.cs
+++ b/src/Stack/Infrastructure/ConsoleInputProvider.cs
@@ -10,7 +10,7 @@ public interface IInputProvider
     string Select(string prompt, string[] choices);
     T Select<T>(string prompt, T[] choices, Func<T, string>? converter = null) where T : notnull;
     T SelectGrouped<T>(string prompt, ChoiceGroup<T>[] choices, Func<T, string>? converter = null) where T : notnull;
-    bool Confirm(string prompt);
+    bool Confirm(string prompt, bool defaultValue = true);
 }
 
 public class ConsoleInputProvider(IAnsiConsole console) : IInputProvider
@@ -65,7 +65,15 @@ public class ConsoleInputProvider(IAnsiConsole console) : IInputProvider
         return console.Prompt(select);
     }
 
-    public bool Confirm(string prompt) => console.Prompt(new ConfirmationPrompt(prompt));
+    public bool Confirm(string prompt, bool defaultValue = true)
+    {
+        var confirmationPrompt = new ConfirmationPrompt(prompt)
+        {
+            DefaultValue = defaultValue
+        };
+
+        return console.Prompt(confirmationPrompt);
+    }
 }
 
 


### PR DESCRIPTION
This PR adds support for creating pull requests as drafts, by asking a question during creation or using a new option `--draft`.

Fixes #120 