### PR TITLE
More improvements to pull request creation

### DIFF
--- a/src/Stack.Tests/Commands/PullRequests/CreatePullRequestsCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/PullRequests/CreatePullRequestsCommandHandlerTests.cs
@@ -20,7 +20,8 @@ public class CreatePullRequestsCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var fileOperations = Substitute.For<IFileOperations>();
+        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, fileOperations, stackConfig);
 
         var remoteUri = Some.HttpsUri().ToString();
         outputProvider
@@ -50,25 +51,24 @@ public class CreatePullRequestsCommandHandlerTests
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
         inputProvider.Confirm(Questions.ConfirmStartCreatePullRequests(2)).Returns(true);
         inputProvider.Confirm(Questions.ConfirmCreatePullRequests).Returns(true);
-        inputProvider.Text(Questions.PullRequestTitle("branch-3", "branch-1")).Returns("PR Title for branch-3");
-        inputProvider.Text(Questions.PullRequestTitle("branch-5", "branch-3")).Returns("PR Title for branch-5");
+        inputProvider.Text(Questions.PullRequestTitle).Returns("PR Title");
 
-        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
+        var prForBranch3 = new GitHubPullRequest(1, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubOperations
-            .CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty, false)
+            .CreatePullRequest("branch-3", "branch-1", "PR Title", Arg.Any<string>(), false)
             .Returns(prForBranch3);
 
-        var prForBranch5 = new GitHubPullRequest(2, "PR Title for branch-5", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
+        var prForBranch5 = new GitHubPullRequest(2, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubOperations
-            .CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty, false)
+            .CreatePullRequest("branch-5", "branch-3", "PR Title", Arg.Any<string>(), false)
             .Returns(prForBranch5);
 
         // Act
         await handler.Handle(CreatePullRequestsCommandInputs.Empty);
 
         // Assert        
-        gitHubOperations.Received().CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty, false);
-        gitHubOperations.Received().CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty, false);
+        gitHubOperations.Received().CreatePullRequest("branch-3", "branch-1", "PR Title", Arg.Any<string>(), false);
+        gitHubOperations.Received().CreatePullRequest("branch-5", "branch-3", "PR Title", Arg.Any<string>(), false);
     }
 
     [Fact]
@@ -80,7 +80,8 @@ public class CreatePullRequestsCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var fileOperations = Substitute.For<IFileOperations>();
+        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, fileOperations, stackConfig);
 
         var remoteUri = Some.HttpsUri().ToString();
         outputProvider
@@ -110,18 +111,17 @@ public class CreatePullRequestsCommandHandlerTests
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
         inputProvider.Confirm(Questions.ConfirmStartCreatePullRequests(2)).Returns(true);
         inputProvider.Confirm(Questions.ConfirmCreatePullRequests).Returns(true);
-        inputProvider.Text(Questions.PullRequestTitle("branch-3", "branch-1")).Returns("PR Title for branch-3");
-        inputProvider.Text(Questions.PullRequestTitle("branch-5", "branch-3")).Returns("PR Title for branch-5");
+        inputProvider.Text(Questions.PullRequestTitle).Returns("PR Title");
         inputProvider.Text(Questions.PullRequestStackDescription, Arg.Any<string>()).Returns("A custom description");
 
-        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
+        var prForBranch3 = new GitHubPullRequest(1, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubOperations
-            .CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty, false)
+            .CreatePullRequest("branch-3", "branch-1", "PR Title", Arg.Any<string>(), false)
             .Returns(prForBranch3);
 
-        var prForBranch5 = new GitHubPullRequest(2, "PR Title for branch-5", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
+        var prForBranch5 = new GitHubPullRequest(2, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubOperations
-            .CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty, false)
+            .CreatePullRequest("branch-5", "branch-3", "PR Title", Arg.Any<string>(), false)
             .Returns(prForBranch5);
 
         gitHubOperations
@@ -156,7 +156,8 @@ A custom description
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var fileOperations = Substitute.For<IFileOperations>();
+        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, fileOperations, stackConfig);
 
         var remoteUri = Some.HttpsUri().ToString();
         outputProvider
@@ -186,15 +187,15 @@ A custom description
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
         inputProvider.Confirm(Questions.ConfirmStartCreatePullRequests(1)).Returns(true);
         inputProvider.Confirm(Questions.ConfirmCreatePullRequests).Returns(true);
-        inputProvider.Text(Questions.PullRequestTitle("branch-5", "branch-3")).Returns("PR Title for branch-5");
+        inputProvider.Text(Questions.PullRequestTitle).Returns("PR Title");
         inputProvider.Text(Questions.PullRequestStackDescription, Arg.Any<string>()).Returns("A custom description");
 
-        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
+        var prForBranch3 = new GitHubPullRequest(1, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubOperations.GetPullRequest("branch-3").Returns(prForBranch3);
 
-        var prForBranch5 = new GitHubPullRequest(2, "PR Title for branch-5", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
+        var prForBranch5 = new GitHubPullRequest(2, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubOperations
-            .CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty, false)
+            .CreatePullRequest("branch-5", "branch-3", "PR Title", Arg.Any<string>(), false)
             .Returns(prForBranch5);
 
         gitHubOperations
@@ -209,8 +210,8 @@ A custom description
         await handler.Handle(CreatePullRequestsCommandInputs.Empty);
 
         // Assert        
-        gitHubOperations.DidNotReceive().CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty, false);
-        gitHubOperations.Received().CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty, false);
+        gitHubOperations.DidNotReceive().CreatePullRequest("branch-3", "branch-1", "PR Title", Arg.Any<string>(), false);
+        gitHubOperations.Received().CreatePullRequest("branch-5", "branch-3", "PR Title", Arg.Any<string>(), false);
         var expectedStackDescription = $@"<!-- stack-pr-list -->
 A custom description
 
@@ -231,7 +232,8 @@ A custom description
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var fileOperations = Substitute.For<IFileOperations>();
+        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, fileOperations, stackConfig);
 
         var remoteUri = Some.HttpsUri().ToString();
         outputProvider
@@ -261,25 +263,24 @@ A custom description
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
         inputProvider.Confirm(Questions.ConfirmStartCreatePullRequests(2)).Returns(true);
         inputProvider.Confirm(Questions.ConfirmCreatePullRequests).Returns(true);
-        inputProvider.Text(Questions.PullRequestTitle("branch-3", "branch-1")).Returns("PR Title for branch-3");
-        inputProvider.Text(Questions.PullRequestTitle("branch-5", "branch-3")).Returns("PR Title for branch-5");
+        inputProvider.Text(Questions.PullRequestTitle).Returns("PR Title");
 
-        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
+        var prForBranch3 = new GitHubPullRequest(1, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubOperations
-            .CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty, false)
+            .CreatePullRequest("branch-3", "branch-1", "PR Title", Arg.Any<string>(), false)
             .Returns(prForBranch3);
 
-        var prForBranch5 = new GitHubPullRequest(2, "PR Title for branch-5", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
+        var prForBranch5 = new GitHubPullRequest(2, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubOperations
-            .CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty, false)
+            .CreatePullRequest("branch-5", "branch-3", "PR Title", Arg.Any<string>(), false)
             .Returns(prForBranch5);
 
         // Act
-        await handler.Handle(new CreatePullRequestsCommandInputs("Stack1", null));
+        await handler.Handle(new CreatePullRequestsCommandInputs("Stack1"));
 
         // Assert        
-        gitHubOperations.Received().CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty, false);
-        gitHubOperations.Received().CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty, false);
+        gitHubOperations.Received().CreatePullRequest("branch-3", "branch-1", "PR Title", Arg.Any<string>(), false);
+        gitHubOperations.Received().CreatePullRequest("branch-5", "branch-3", "PR Title", Arg.Any<string>(), false);
     }
 
     [Fact]
@@ -291,7 +292,8 @@ A custom description
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var fileOperations = Substitute.For<IFileOperations>();
+        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, fileOperations, stackConfig);
 
         var remoteUri = Some.HttpsUri().ToString();
         outputProvider
@@ -316,25 +318,24 @@ A custom description
 
         inputProvider.Confirm(Questions.ConfirmStartCreatePullRequests(2)).Returns(true);
         inputProvider.Confirm(Questions.ConfirmCreatePullRequests).Returns(true);
-        inputProvider.Text(Questions.PullRequestTitle("branch-3", "branch-1")).Returns("PR Title for branch-3");
-        inputProvider.Text(Questions.PullRequestTitle("branch-5", "branch-3")).Returns("PR Title for branch-5");
+        inputProvider.Text(Questions.PullRequestTitle).Returns("PR Title");
 
-        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
+        var prForBranch3 = new GitHubPullRequest(1, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubOperations
-            .CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty, false)
+            .CreatePullRequest("branch-3", "branch-1", "PR Title", Arg.Any<string>(), false)
             .Returns(prForBranch3);
 
-        var prForBranch5 = new GitHubPullRequest(2, "PR Title for branch-5", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
+        var prForBranch5 = new GitHubPullRequest(2, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubOperations
-            .CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty, false)
+            .CreatePullRequest("branch-5", "branch-3", "PR Title", Arg.Any<string>(), false)
             .Returns(prForBranch5);
 
         // Act
         await handler.Handle(CreatePullRequestsCommandInputs.Empty);
 
         // Assert        
-        gitHubOperations.Received().CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty, false);
-        gitHubOperations.Received().CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty, false);
+        gitHubOperations.Received().CreatePullRequest("branch-3", "branch-1", "PR Title", Arg.Any<string>(), false);
+        gitHubOperations.Received().CreatePullRequest("branch-5", "branch-3", "PR Title", Arg.Any<string>(), false);
     }
 
     [Fact]
@@ -346,7 +347,8 @@ A custom description
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var fileOperations = Substitute.For<IFileOperations>();
+        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, fileOperations, stackConfig);
 
         var remoteUri = Some.HttpsUri().ToString();
 
@@ -362,7 +364,7 @@ A custom description
 
         // Act and assert
         var invalidStackName = Some.Name();
-        await handler.Invoking(h => h.Handle(new CreatePullRequestsCommandInputs(invalidStackName, null)))
+        await handler.Invoking(h => h.Handle(new CreatePullRequestsCommandInputs(invalidStackName)))
             .Should()
             .ThrowAsync<InvalidOperationException>()
             .WithMessage($"Stack '{invalidStackName}' not found.");
@@ -377,7 +379,8 @@ A custom description
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var fileOperations = Substitute.For<IFileOperations>();
+        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, fileOperations, stackConfig);
 
         var remoteUri = Some.HttpsUri().ToString();
         outputProvider
@@ -407,15 +410,15 @@ A custom description
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
         inputProvider.Confirm(Questions.ConfirmStartCreatePullRequests(1)).Returns(true);
         inputProvider.Confirm(Questions.ConfirmCreatePullRequests).Returns(true);
-        inputProvider.Text(Questions.PullRequestTitle("branch-5", "branch-1")).Returns("PR Title for branch-5");
+        inputProvider.Text(Questions.PullRequestTitle).Returns("PR Title");
         inputProvider.Text(Questions.PullRequestStackDescription, Arg.Any<string>()).Returns("A custom description");
 
-        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", string.Empty, GitHubPullRequestStates.Merged, Some.HttpsUri(), false);
+        var prForBranch3 = new GitHubPullRequest(1, "PR Title", string.Empty, GitHubPullRequestStates.Merged, Some.HttpsUri(), false);
         gitHubOperations.GetPullRequest("branch-3").Returns(prForBranch3);
 
-        var prForBranch5 = new GitHubPullRequest(2, "PR Title for branch-5", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
+        var prForBranch5 = new GitHubPullRequest(2, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubOperations
-            .CreatePullRequest("branch-5", "branch-1", "PR Title for branch-5", string.Empty, false)
+            .CreatePullRequest("branch-5", "branch-1", "PR Title", Arg.Any<string>(), false)
             .Returns(prForBranch5);
 
         gitHubOperations
@@ -430,8 +433,8 @@ A custom description
         await handler.Handle(CreatePullRequestsCommandInputs.Empty);
 
         // Assert        
-        gitHubOperations.DidNotReceive().CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty, false);
-        gitHubOperations.Received().CreatePullRequest("branch-5", "branch-1", "PR Title for branch-5", string.Empty, false);
+        gitHubOperations.DidNotReceive().CreatePullRequest("branch-3", "branch-1", "PR Title", Arg.Any<string>(), false);
+        gitHubOperations.Received().CreatePullRequest("branch-5", "branch-1", "PR Title", Arg.Any<string>(), false);
         var expectedStackDescription = $@"<!-- stack-pr-list -->
 A custom description
 
@@ -452,7 +455,8 @@ A custom description
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var fileOperations = Substitute.For<IFileOperations>();
+        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, fileOperations, stackConfig);
 
         var remoteUri = Some.HttpsUri().ToString();
         outputProvider
@@ -470,7 +474,7 @@ A custom description
             .Returns(["branch-1", "branch-3"]);
 
         gitOperations.GetRootOfRepository().Returns("repo");
-        gitOperations.GetFileContents(Path.Join("repo", ".github", "pull_request_template.md")).Returns("PR Template");
+        fileOperations.Exists(Path.Join("repo", ".github", "pull_request_template.md")).Returns(true);
 
         var stacks = new List<Config.Stack>(
         [
@@ -485,18 +489,19 @@ A custom description
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
         inputProvider.Confirm(Questions.ConfirmStartCreatePullRequests(1)).Returns(true);
         inputProvider.Confirm(Questions.ConfirmCreatePullRequests).Returns(true);
-        inputProvider.Text(Questions.PullRequestTitle("branch-3", "branch-1")).Returns("PR Title for branch-3");
+        inputProvider.Text(Questions.PullRequestTitle).Returns("PR Title");
 
-        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", "PR Template", GitHubPullRequestStates.Open, Some.HttpsUri(), false);
+        var prForBranch3 = new GitHubPullRequest(1, "PR Title", "PR Template", GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubOperations
-            .CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", "PR Template", false)
+            .CreatePullRequest("branch-3", "branch-1", "PR Title", Arg.Any<string>(), false)
             .Returns(prForBranch3);
 
         // Act
         await handler.Handle(CreatePullRequestsCommandInputs.Empty);
 
         // Assert        
-        gitHubOperations.Received().CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", "PR Template", false);
+        gitHubOperations.Received().CreatePullRequest("branch-3", "branch-1", "PR Title", Arg.Any<string>(), false);
+        fileOperations.Received().Copy(Path.Join("repo", ".github", "pull_request_template.md"), Arg.Any<string>(), true);
     }
 
     [Fact]
@@ -508,7 +513,8 @@ A custom description
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var fileOperations = Substitute.For<IFileOperations>();
+        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, fileOperations, stackConfig);
 
         var remoteUri = Some.HttpsUri().ToString();
         outputProvider
@@ -538,86 +544,24 @@ A custom description
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
         inputProvider.Confirm(Questions.ConfirmStartCreatePullRequests(2)).Returns(true);
         inputProvider.Confirm(Questions.ConfirmCreatePullRequests).Returns(true);
-        inputProvider.Confirm(Questions.CreatePullRequestsAsDrafts, false).Returns(true);
-        inputProvider.Text(Questions.PullRequestTitle("branch-3", "branch-1")).Returns("PR Title for branch-3");
-        inputProvider.Text(Questions.PullRequestTitle("branch-5", "branch-3")).Returns("PR Title for branch-5");
+        inputProvider.Confirm(Questions.CreatePullRequestAsDraft, false).Returns(true);
+        inputProvider.Text(Questions.PullRequestTitle).Returns("PR Title");
 
-        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), true);
+        var prForBranch3 = new GitHubPullRequest(1, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), true);
         gitHubOperations
-            .CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty, true)
+            .CreatePullRequest("branch-3", "branch-1", "PR Title", Arg.Any<string>(), true)
             .Returns(prForBranch3);
 
-        var prForBranch5 = new GitHubPullRequest(2, "PR Title for branch-5", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), true);
+        var prForBranch5 = new GitHubPullRequest(2, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), true);
         gitHubOperations
-            .CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty, true)
+            .CreatePullRequest("branch-5", "branch-3", "PR Title", Arg.Any<string>(), true)
             .Returns(prForBranch5);
 
         // Act
         await handler.Handle(CreatePullRequestsCommandInputs.Empty);
 
         // Assert        
-        gitHubOperations.Received().CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty, true);
-        gitHubOperations.Received().CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty, true);
-    }
-
-    [Fact]
-    public async Task WhenDraftIsProvided_PullRequestsAreCreatedAsDrafts()
-    {
-        // Arrange
-        var gitOperations = Substitute.For<IGitOperations>();
-        var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<IInputProvider>();
-        var outputProvider = Substitute.For<IOutputProvider>();
-        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
-
-        var remoteUri = Some.HttpsUri().ToString();
-        outputProvider
-            .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
-            .Do(ci => ci.ArgAt<Action>(1)());
-
-        gitOperations.GetRemoteUri().Returns(remoteUri);
-        gitOperations.GetCurrentBranch().Returns("branch-1");
-        gitOperations
-            .GetBranchesThatExistInRemote(Arg.Any<string[]>())
-            .Returns(["branch-1", "branch-3", "branch-5"]);
-
-        gitOperations
-            .GetBranchesThatExistLocally(Arg.Any<string[]>())
-            .Returns(["branch-1", "branch-3", "branch-5"]);
-
-        var stacks = new List<Config.Stack>(
-        [
-            new("Stack1", remoteUri, "branch-1", ["branch-3", "branch-5"]),
-            new("Stack2", remoteUri, "branch-2", ["branch-4"])
-        ]);
-        stackConfig.Load().Returns(stacks);
-        stackConfig
-            .WhenForAnyArgs(s => s.Save(Arg.Any<List<Config.Stack>>()))
-            .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
-
-        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
-        inputProvider.Confirm(Questions.ConfirmStartCreatePullRequests(2)).Returns(true);
-        inputProvider.Confirm(Questions.ConfirmCreatePullRequests).Returns(true);
-        inputProvider.Text(Questions.PullRequestTitle("branch-3", "branch-1")).Returns("PR Title for branch-3");
-        inputProvider.Text(Questions.PullRequestTitle("branch-5", "branch-3")).Returns("PR Title for branch-5");
-
-        var prForBranch3 = new GitHubPullRequest(1, "PR Title for branch-3", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), true);
-        gitHubOperations
-            .CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty, true)
-            .Returns(prForBranch3);
-
-        var prForBranch5 = new GitHubPullRequest(2, "PR Title for branch-5", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), true);
-        gitHubOperations
-            .CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty, true)
-            .Returns(prForBranch5);
-
-        // Act
-        await handler.Handle(new CreatePullRequestsCommandInputs(null, true));
-
-        // Assert        
-        gitHubOperations.Received().CreatePullRequest("branch-3", "branch-1", "PR Title for branch-3", string.Empty, true);
-        gitHubOperations.Received().CreatePullRequest("branch-5", "branch-3", "PR Title for branch-5", string.Empty, true);
-        inputProvider.DidNotReceive().Confirm(Questions.CreatePullRequestsAsDrafts, false);
+        gitHubOperations.Received().CreatePullRequest("branch-3", "branch-1", "PR Title", Arg.Any<string>(), true);
+        gitHubOperations.Received().CreatePullRequest("branch-5", "branch-3", "PR Title", Arg.Any<string>(), true);
     }
 }

--- a/src/Stack/Commands/Helpers/Questions.cs
+++ b/src/Stack/Commands/Helpers/Questions.cs
@@ -21,6 +21,6 @@ public static class Questions
     public const string ConfirmCreatePullRequests = "Are you sure you want to create pull requests for branches in this stack?";
     public const string PullRequestTitle = "Title:";
     public const string PullRequestStackDescription = "Stack description for pull request:";
-    public const string OpenPullRequests = "Open the new pull requests in a browser?";
+    public const string OpenPullRequests = "Open new pull requests in a browser?";
     public const string CreatePullRequestAsDraft = "Create pull request as draft?";
 }

--- a/src/Stack/Commands/Helpers/Questions.cs
+++ b/src/Stack/Commands/Helpers/Questions.cs
@@ -19,8 +19,8 @@ public static class Questions
     public const string ConfirmSwitchToBranch = "Do you want to switch to the new branch?";
     public static string ConfirmStartCreatePullRequests(int numberOfBranchesWithoutPullRequests) => $"There {"are".ToQuantity(numberOfBranchesWithoutPullRequests, ShowQuantityAs.None)} {"branch".ToQuantity(numberOfBranchesWithoutPullRequests)} to create pull requests for. Do you want to continue?";
     public const string ConfirmCreatePullRequests = "Are you sure you want to create pull requests for branches in this stack?";
-    public static string PullRequestTitle(string sourceBranch, string targetBranch) => $"Title for pull request from {sourceBranch.Branch()} -> {targetBranch.Branch()}:";
+    public const string PullRequestTitle = "Title:";
     public const string PullRequestStackDescription = "Stack description for pull request:";
-    public const string OpenPullRequests = "Open the pull requests in the browser?";
-    public const string CreatePullRequestsAsDrafts = "Create pull requests as drafts?";
+    public const string OpenPullRequests = "Open the new pull requests in a browser?";
+    public const string CreatePullRequestAsDraft = "Create pull request as draft?";
 }

--- a/src/Stack/Git/GitHubOperations.cs
+++ b/src/Stack/Git/GitHubOperations.cs
@@ -43,7 +43,7 @@ public static class GitHubPullRequestExtensionMethods
 public interface IGitHubOperations
 {
     GitHubPullRequest? GetPullRequest(string branch);
-    GitHubPullRequest? CreatePullRequest(string headBranch, string baseBranch, string title, string body, bool draft);
+    GitHubPullRequest? CreatePullRequest(string headBranch, string baseBranch, string title, string bodyFilePath, bool draft);
     void EditPullRequest(int number, string body);
     void OpenPullRequest(GitHubPullRequest pullRequest);
 }
@@ -59,9 +59,9 @@ public class GitHubOperations(IAnsiConsole console, GitHubOperationSettings sett
         return pullRequests.FirstOrDefault();
     }
 
-    public GitHubPullRequest? CreatePullRequest(string headBranch, string baseBranch, string title, string body, bool draft)
+    public GitHubPullRequest? CreatePullRequest(string headBranch, string baseBranch, string title, string bodyFilePath, bool draft)
     {
-        var command = $"pr create --title \"{title}\" --body \"{body}\" --base {baseBranch} --head {headBranch}";
+        var command = $"pr create --title \"{title}\" --body-file \"{bodyFilePath}\" --base {baseBranch} --head {headBranch}";
 
         if (draft)
         {

--- a/src/Stack/Infrastructure/ConsoleOutputProvider.cs
+++ b/src/Stack/Infrastructure/ConsoleOutputProvider.cs
@@ -10,6 +10,7 @@ public interface IOutputProvider
     void Warning(string message);
     void Error(string message);
     void Debug(string message);
+    void Rule(string message);
 }
 
 public static class OutputProviderExtensionMethods
@@ -37,6 +38,14 @@ public class ConsoleOutputProvider(IAnsiConsole console) : IOutputProvider
             tree.AddNode(item);
 
         console.Write(tree);
+    }
+
+    public void Rule(string message)
+    {
+        var rule = new Rule(message);
+        rule.LeftJustified();
+        rule.DoubleBorder();
+        console.Write(rule);
     }
 }
 

--- a/src/Stack/Infrastructure/FileOperations.cs
+++ b/src/Stack/Infrastructure/FileOperations.cs
@@ -1,0 +1,26 @@
+namespace Stack.Infrastructure;
+
+public interface IFileOperations
+{
+    void Copy(string sourceFileName, string destFileName, bool overwrite);
+    bool Exists(string path);
+    string GetTempPath();
+}
+
+public class FileOperations : IFileOperations
+{
+    public void Copy(string sourceFileName, string destFileName, bool overwrite)
+    {
+        File.Copy(sourceFileName, destFileName, overwrite);
+    }
+
+    public bool Exists(string path)
+    {
+        return File.Exists(path);
+    }
+
+    public string GetTempPath()
+    {
+        return Path.GetTempPath();
+    }
+}


### PR DESCRIPTION
This PR makes more improvements to the `pr create` command:

- Support editing the body of the PR in an editor, including proper template support
- Improves asking questions for each PR being created
- Show new PR properly when previous PR for a branch was closed
- Support asking for draft for each PR being created
- Only open new pull request created in stack, not all
