### PR TITLE
Use output provider for Git and GitHub operations

### DIFF
--- a/src/Stack/Commands/Branch/AddBranchCommand.cs
+++ b/src/Stack/Commands/Branch/AddBranchCommand.cs
@@ -26,11 +26,12 @@ public class AddBranchCommand : AsyncCommand<AddBranchCommandSettings>
         await Task.CompletedTask;
 
         var console = AnsiConsole.Console;
+        var outputProvider = new ConsoleOutputProvider(console);
 
         var handler = new AddBranchCommandHandler(
             new ConsoleInputProvider(console),
-            new ConsoleOutputProvider(console),
-            new GitOperations(console, settings.GetGitOperationSettings()),
+            outputProvider,
+            new GitOperations(outputProvider, settings.GetGitOperationSettings()),
             new StackConfig());
 
         await handler.Handle(new AddBranchCommandInputs(settings.Stack, settings.Name));

--- a/src/Stack/Commands/Branch/NewBranchCommand.cs
+++ b/src/Stack/Commands/Branch/NewBranchCommand.cs
@@ -30,11 +30,12 @@ public class NewBranchCommand : AsyncCommand<NewBranchCommandSettings>
         await Task.CompletedTask;
 
         var console = AnsiConsole.Console;
+        var outputProvider = new ConsoleOutputProvider(console);
 
         var handler = new NewBranchCommandHandler(
             new ConsoleInputProvider(console),
-            new ConsoleOutputProvider(console),
-            new GitOperations(console, settings.GetGitOperationSettings()),
+            outputProvider,
+            new GitOperations(outputProvider, settings.GetGitOperationSettings()),
             new StackConfig());
 
         await handler.Handle(new NewBranchCommandInputs(settings.Stack, settings.Name, settings.Force));

--- a/src/Stack/Commands/Branch/RemoveBranchCommand.cs
+++ b/src/Stack/Commands/Branch/RemoveBranchCommand.cs
@@ -30,11 +30,12 @@ public class RemoveBranchCommand : AsyncCommand<RemoveBranchCommandSettings>
         await Task.CompletedTask;
 
         var console = AnsiConsole.Console;
+        var outputProvider = new ConsoleOutputProvider(console);
 
         var handler = new RemoveBranchCommandHandler(
             new ConsoleInputProvider(console),
-            new ConsoleOutputProvider(console),
-            new GitOperations(console, settings.GetGitOperationSettings()),
+            outputProvider,
+            new GitOperations(outputProvider, settings.GetGitOperationSettings()),
             new StackConfig());
 
         await handler.Handle(new RemoveBranchCommandInputs(settings.Stack, settings.Name, settings.Force));

--- a/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
+++ b/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
@@ -26,7 +26,7 @@ public class CreatePullRequestsCommand : AsyncCommand<CreatePullRequestsCommandS
             new ConsoleInputProvider(console),
             outputProvider,
             new GitOperations(outputProvider, settings.GetGitOperationSettings()),
-            new GitHubOperations(console, settings.GetGitHubOperationSettings()),
+            new GitHubOperations(outputProvider, settings.GetGitHubOperationSettings()),
             new FileOperations(),
             new StackConfig());
 

--- a/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
+++ b/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
@@ -20,11 +20,12 @@ public class CreatePullRequestsCommand : AsyncCommand<CreatePullRequestsCommandS
     public override async Task<int> ExecuteAsync(CommandContext context, CreatePullRequestsCommandSettings settings)
     {
         var console = AnsiConsole.Console;
+        var outputProvider = new ConsoleOutputProvider(console);
 
         var handler = new CreatePullRequestsCommandHandler(
             new ConsoleInputProvider(console),
-            new ConsoleOutputProvider(console),
-            new GitOperations(console, settings.GetGitOperationSettings()),
+            outputProvider,
+            new GitOperations(outputProvider, settings.GetGitOperationSettings()),
             new GitHubOperations(console, settings.GetGitHubOperationSettings()),
             new FileOperations(),
             new StackConfig());

--- a/src/Stack/Commands/PullRequests/OpenPullRequestsCommand.cs
+++ b/src/Stack/Commands/PullRequests/OpenPullRequestsCommand.cs
@@ -26,7 +26,7 @@ public class OpenPullRequestsCommand : AsyncCommand<OpenPullRequestsCommandSetti
             new ConsoleInputProvider(console),
             outputProvider,
             new GitOperations(outputProvider, settings.GetGitOperationSettings()),
-            new GitHubOperations(console, settings.GetGitHubOperationSettings()),
+            new GitHubOperations(outputProvider, settings.GetGitHubOperationSettings()),
             new StackConfig());
 
         await handler.Handle(new OpenPullRequestsCommandInputs(settings.Name));

--- a/src/Stack/Commands/PullRequests/OpenPullRequestsCommand.cs
+++ b/src/Stack/Commands/PullRequests/OpenPullRequestsCommand.cs
@@ -20,11 +20,12 @@ public class OpenPullRequestsCommand : AsyncCommand<OpenPullRequestsCommandSetti
     public override async Task<int> ExecuteAsync(CommandContext context, OpenPullRequestsCommandSettings settings)
     {
         var console = AnsiConsole.Console;
+        var outputProvider = new ConsoleOutputProvider(console);
 
         var handler = new OpenPullRequestsCommandHandler(
             new ConsoleInputProvider(console),
-            new ConsoleOutputProvider(console),
-            new GitOperations(console, settings.GetGitOperationSettings()),
+            outputProvider,
+            new GitOperations(outputProvider, settings.GetGitOperationSettings()),
             new GitHubOperations(console, settings.GetGitHubOperationSettings()),
             new StackConfig());
 

--- a/src/Stack/Commands/Stack/CleanupStackCommand.cs
+++ b/src/Stack/Commands/Stack/CleanupStackCommand.cs
@@ -27,10 +27,12 @@ public class CleanupStackCommand : AsyncCommand<CleanupStackCommandSettings>
         await Task.CompletedTask;
 
         var console = AnsiConsole.Console;
+        var outputProvider = new ConsoleOutputProvider(console);
+
         var handler = new CleanupStackCommandHandler(
             new ConsoleInputProvider(console),
-            new ConsoleOutputProvider(console),
-            new GitOperations(console, settings.GetGitOperationSettings()),
+            outputProvider,
+            new GitOperations(outputProvider, settings.GetGitOperationSettings()),
             new GitHubOperations(console, settings.GetGitHubOperationSettings()),
             new StackConfig());
 

--- a/src/Stack/Commands/Stack/CleanupStackCommand.cs
+++ b/src/Stack/Commands/Stack/CleanupStackCommand.cs
@@ -33,7 +33,7 @@ public class CleanupStackCommand : AsyncCommand<CleanupStackCommandSettings>
             new ConsoleInputProvider(console),
             outputProvider,
             new GitOperations(outputProvider, settings.GetGitOperationSettings()),
-            new GitHubOperations(console, settings.GetGitHubOperationSettings()),
+            new GitHubOperations(outputProvider, settings.GetGitHubOperationSettings()),
             new StackConfig());
 
         await handler.Handle(new CleanupStackCommandInputs(settings.Name, settings.Force));

--- a/src/Stack/Commands/Stack/DeleteStackCommand.cs
+++ b/src/Stack/Commands/Stack/DeleteStackCommand.cs
@@ -27,10 +27,12 @@ public class DeleteStackCommand : AsyncCommand<DeleteStackCommandSettings>
         await Task.CompletedTask;
 
         var console = AnsiConsole.Console;
+        var outputProvider = new ConsoleOutputProvider(console);
+
         var handler = new DeleteStackCommandHandler(
             new ConsoleInputProvider(console),
-            new ConsoleOutputProvider(console),
-            new GitOperations(console, settings.GetGitOperationSettings()),
+            outputProvider,
+            new GitOperations(outputProvider, settings.GetGitOperationSettings()),
             new GitHubOperations(console, settings.GetGitHubOperationSettings()),
             new StackConfig());
 

--- a/src/Stack/Commands/Stack/DeleteStackCommand.cs
+++ b/src/Stack/Commands/Stack/DeleteStackCommand.cs
@@ -33,7 +33,7 @@ public class DeleteStackCommand : AsyncCommand<DeleteStackCommandSettings>
             new ConsoleInputProvider(console),
             outputProvider,
             new GitOperations(outputProvider, settings.GetGitOperationSettings()),
-            new GitHubOperations(console, settings.GetGitHubOperationSettings()),
+            new GitHubOperations(outputProvider, settings.GetGitHubOperationSettings()),
             new StackConfig());
 
         var response = await handler.Handle(new DeleteStackCommandInputs(settings.Name, settings.Force));

--- a/src/Stack/Commands/Stack/ListStacksCommand.cs
+++ b/src/Stack/Commands/Stack/ListStacksCommand.cs
@@ -3,6 +3,7 @@ using Spectre.Console;
 using Spectre.Console.Cli;
 using Stack.Config;
 using Stack.Git;
+using Stack.Infrastructure;
 
 namespace Stack.Commands;
 
@@ -14,7 +15,8 @@ public class ListStacksCommand : AsyncCommand<ListStacksCommandSettings>
     {
         await Task.CompletedTask;
         var console = AnsiConsole.Console;
-        var gitOperations = new GitOperations(console, settings.GetGitOperationSettings());
+        var outputProvider = new ConsoleOutputProvider(console);
+        var gitOperations = new GitOperations(outputProvider, settings.GetGitOperationSettings());
         var stackConfig = new StackConfig();
 
         var stacks = stackConfig.Load();

--- a/src/Stack/Commands/Stack/NewStackCommand.cs
+++ b/src/Stack/Commands/Stack/NewStackCommand.cs
@@ -40,10 +40,12 @@ public class NewStackCommand : AsyncCommand<NewStackCommandSettings>
     public override async Task<int> ExecuteAsync(CommandContext context, NewStackCommandSettings settings)
     {
         var console = AnsiConsole.Console;
+        var outputProvider = new ConsoleOutputProvider(console);
+
         var handler = new NewStackCommandHandler(
             new ConsoleInputProvider(console),
-            new ConsoleOutputProvider(console),
-            new GitOperations(console, settings.GetGitOperationSettings()),
+            outputProvider,
+            new GitOperations(outputProvider, settings.GetGitOperationSettings()),
             new StackConfig());
 
         var response = await handler.Handle(

--- a/src/Stack/Commands/Stack/StackStatusCommand.cs
+++ b/src/Stack/Commands/Stack/StackStatusCommand.cs
@@ -30,7 +30,7 @@ public class StackStatusCommand : AsyncCommand<StackStatusCommandSettings>
             new ConsoleInputProvider(console),
             outputProvider,
             new GitOperations(outputProvider, settings.GetGitOperationSettings()),
-            new GitHubOperations(console, settings.GetGitHubOperationSettings()),
+            new GitHubOperations(outputProvider, settings.GetGitHubOperationSettings()),
             new StackConfig());
 
         await handler.Handle(new StackStatusCommandInputs(settings.Name, settings.All));

--- a/src/Stack/Commands/Stack/StackStatusCommand.cs
+++ b/src/Stack/Commands/Stack/StackStatusCommand.cs
@@ -24,11 +24,12 @@ public class StackStatusCommand : AsyncCommand<StackStatusCommandSettings>
     public override async Task<int> ExecuteAsync(CommandContext context, StackStatusCommandSettings settings)
     {
         var console = AnsiConsole.Console;
+        var outputProvider = new ConsoleOutputProvider(console);
 
         var handler = new StackStatusCommandHandler(
             new ConsoleInputProvider(console),
-            new ConsoleOutputProvider(console),
-            new GitOperations(console, settings.GetGitOperationSettings()),
+            outputProvider,
+            new GitOperations(outputProvider, settings.GetGitOperationSettings()),
             new GitHubOperations(console, settings.GetGitHubOperationSettings()),
             new StackConfig());
 

--- a/src/Stack/Commands/Stack/StackSwitchCommand.cs
+++ b/src/Stack/Commands/Stack/StackSwitchCommand.cs
@@ -20,10 +20,11 @@ public class StackSwitchCommand : AsyncCommand<StackSwitchCommandSettings>
     public override async Task<int> ExecuteAsync(CommandContext context, StackSwitchCommandSettings settings)
     {
         var console = AnsiConsole.Console;
+        var outputProvider = new ConsoleOutputProvider(console);
 
         var handler = new StackSwitchCommandHandler(
             new ConsoleInputProvider(console),
-            new GitOperations(console, settings.GetGitOperationSettings()),
+            new GitOperations(outputProvider, settings.GetGitOperationSettings()),
             new StackConfig());
 
         await handler.Handle(new StackSwitchCommandInputs(settings.Branch));

--- a/src/Stack/Commands/Stack/UpdateStackCommand.cs
+++ b/src/Stack/Commands/Stack/UpdateStackCommand.cs
@@ -31,7 +31,7 @@ public class UpdateStackCommand : AsyncCommand<UpdateStackCommandSettings>
             new ConsoleInputProvider(console),
             outputProvider,
             new GitOperations(outputProvider, settings.GetGitOperationSettings()),
-            new GitHubOperations(console, settings.GetGitHubOperationSettings()),
+            new GitHubOperations(outputProvider, settings.GetGitHubOperationSettings()),
             new StackConfig());
 
         await handler.Handle(new UpdateStackCommandInputs(settings.Name, settings.Force));

--- a/src/Stack/Commands/Stack/UpdateStackCommand.cs
+++ b/src/Stack/Commands/Stack/UpdateStackCommand.cs
@@ -25,10 +25,12 @@ public class UpdateStackCommand : AsyncCommand<UpdateStackCommandSettings>
     public override async Task<int> ExecuteAsync(CommandContext context, UpdateStackCommandSettings settings)
     {
         var console = AnsiConsole.Console;
+        var outputProvider = new ConsoleOutputProvider(console);
+
         var handler = new UpdateStackCommandHandler(
             new ConsoleInputProvider(console),
-            new ConsoleOutputProvider(console),
-            new GitOperations(console, settings.GetGitOperationSettings()),
+            outputProvider,
+            new GitOperations(outputProvider, settings.GetGitOperationSettings()),
             new GitHubOperations(console, settings.GetGitHubOperationSettings()),
             new StackConfig());
 

--- a/src/Stack/Git/GitHubOperations.cs
+++ b/src/Stack/Git/GitHubOperations.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using Octopus.Shellfish;
 using Spectre.Console;
+using Stack.Infrastructure;
 
 namespace Stack.Git;
 
@@ -48,7 +49,7 @@ public interface IGitHubOperations
     void OpenPullRequest(GitHubPullRequest pullRequest);
 }
 
-public class GitHubOperations(IAnsiConsole console, GitHubOperationSettings settings) : IGitHubOperations
+public class GitHubOperations(IOutputProvider outputProvider, GitHubOperationSettings settings) : IGitHubOperations
 {
     public GitHubPullRequest? GetPullRequest(string branch)
     {
@@ -91,7 +92,7 @@ public class GitHubOperations(IAnsiConsole console, GitHubOperationSettings sett
     private string ExecuteGitHubCommandAndReturnOutput(string command)
     {
         if (settings.Verbose)
-            console.MarkupLine($"[grey]gh {command}[/]");
+            outputProvider.Debug($"gh {command}");
 
         var infoBuilder = new StringBuilder();
         var errorBuilder = new StringBuilder();
@@ -106,13 +107,13 @@ public class GitHubOperations(IAnsiConsole console, GitHubOperationSettings sett
 
         if (result != 0)
         {
-            console.MarkupLine($"[red]{errorBuilder}[/]");
+            outputProvider.Error($"{errorBuilder}");
             throw new Exception("Failed to execute gh command.");
         }
 
         if (settings.Verbose && infoBuilder.Length > 0)
         {
-            console.MarkupLine($"[grey]{infoBuilder}[/]");
+            outputProvider.Debug($"{infoBuilder}");
         }
 
         return infoBuilder.ToString();
@@ -121,7 +122,7 @@ public class GitHubOperations(IAnsiConsole console, GitHubOperationSettings sett
     private void ExecuteGitHubCommand(string command)
     {
         if (settings.Verbose)
-            console.MarkupLine($"[grey]gh {command}[/]");
+            outputProvider.Debug($"gh {command}");
 
         if (!settings.DryRun)
         {
@@ -144,14 +145,14 @@ public class GitHubOperations(IAnsiConsole console, GitHubOperationSettings sett
 
         if (result != 0)
         {
-            console.MarkupLine($"[red]{errorBuilder}[/]");
+            outputProvider.Error($"{errorBuilder}");
             throw new Exception("Failed to execute gh command.");
         }
         else
         {
             if (infoBuilder.Length > 0)
             {
-                console.MarkupLine($"[grey]{infoBuilder}[/]");
+                outputProvider.Debug($"{infoBuilder}");
             }
         }
     }


### PR DESCRIPTION
Currently `GitOperations` and `GitHubOperations` use `IAnsiConsole`, meaning they need to do markup and colours directly. This PR changes them to use `IOutputProvider`.