### PR TITLE
Show local status by default in `stack status` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ OPTIONS:
 
 ### `stack status`
 
-Shows the status of a stack, including commits compared to other branches and the status of any associated pull requests.
+Shows the status of a stack, including commits compared to other branches and optionally the status of any associated pull requests.
 
 ```shell
 USAGE:
@@ -154,6 +154,7 @@ OPTIONS:
         --working-dir    The path to the directory containing the git repository. Defaults to the current directory
     -n, --name           The name of the stack to show the status of
         --all            Show status of all stacks
+        --full           Show full status including pull requests
 ```
 
 ### `stack delete`

--- a/src/Stack.Tests/Commands/Stack/StackStatusCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/StackStatusCommandHandlerTests.cs
@@ -53,7 +53,7 @@ public class StackStatusCommandHandlerTests
             .Returns(pr);
 
         // Act
-        var response = await handler.Handle(new StackStatusCommandInputs(null, false, false, true));
+        var response = await handler.Handle(new StackStatusCommandInputs(null, false, true));
 
         // Assert
         var expectedBranchDetails = new Dictionary<string, BranchDetail>
@@ -113,7 +113,7 @@ public class StackStatusCommandHandlerTests
             .Returns(pr);
 
         // Act
-        var response = await handler.Handle(new StackStatusCommandInputs("Stack1", false, false, true));
+        var response = await handler.Handle(new StackStatusCommandInputs("Stack1", false, true));
 
         // Assert
         var expectedBranchDetails = new Dictionary<string, BranchDetail>
@@ -176,7 +176,7 @@ public class StackStatusCommandHandlerTests
             .Returns(pr);
 
         // Act
-        var response = await handler.Handle(new StackStatusCommandInputs(null, true, false, true));
+        var response = await handler.Handle(new StackStatusCommandInputs(null, true, true));
 
         // Assert
         var expectedBranchDetailsForStack1 = new Dictionary<string, BranchDetail>
@@ -246,7 +246,7 @@ public class StackStatusCommandHandlerTests
             .Returns(pr);
 
         // Act
-        var response = await handler.Handle(new StackStatusCommandInputs(null, true, false, true));
+        var response = await handler.Handle(new StackStatusCommandInputs(null, true, true));
 
         // Assert
         var expectedBranchDetailsForStack1 = new Dictionary<string, BranchDetail>
@@ -302,7 +302,7 @@ public class StackStatusCommandHandlerTests
         // Act and assert
         var incorrectStackName = Some.Name();
         await handler
-            .Invoking(async h => await h.Handle(new StackStatusCommandInputs(incorrectStackName, false, false, false)))
+            .Invoking(async h => await h.Handle(new StackStatusCommandInputs(incorrectStackName, false, false)))
             .Should().ThrowAsync<InvalidOperationException>()
             .WithMessage($"Stack '{incorrectStackName}' not found.");
     }
@@ -349,7 +349,7 @@ public class StackStatusCommandHandlerTests
             .Returns(pr);
 
         // Act
-        var response = await handler.Handle(new StackStatusCommandInputs(null, false, false, true));
+        var response = await handler.Handle(new StackStatusCommandInputs(null, false, true));
 
         // Assert
         var expectedBranchDetails = new Dictionary<string, BranchDetail>
@@ -406,7 +406,7 @@ public class StackStatusCommandHandlerTests
             .Returns(pr);
 
         // Act
-        var response = await handler.Handle(new StackStatusCommandInputs(null, false, false, true));
+        var response = await handler.Handle(new StackStatusCommandInputs(null, false, true));
 
         // Assert
         var expectedBranchDetails = new Dictionary<string, BranchDetail>
@@ -463,7 +463,7 @@ public class StackStatusCommandHandlerTests
             .Returns(pr);
 
         // Act
-        var response = await handler.Handle(new StackStatusCommandInputs(null, false, false, true));
+        var response = await handler.Handle(new StackStatusCommandInputs(null, false, true));
 
         // Assert
         var expectedBranchDetails = new Dictionary<string, BranchDetail>

--- a/src/Stack.Tests/Commands/Stack/StackStatusCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/StackStatusCommandHandlerTests.cs
@@ -54,8 +54,8 @@ public class StackStatusCommandHandlerTests
         // Assert
         var expectedBranchDetails = new Dictionary<string, BranchDetail>
         {
-            { aBranch, new BranchDetail { Status = new BranchStatus(true, true, 10, 5), PullRequest = pr } },
-            { aSecondBranch, new BranchDetail { Status = new BranchStatus(true, true, 1, 0) } }
+            { aBranch, new BranchDetail { Status = new BranchStatus(true, true, 10, 5, 0, 0), PullRequest = pr } },
+            { aSecondBranch, new BranchDetail { Status = new BranchStatus(true, true, 1, 0, 0, 0) } }
         };
         response.Statuses.Should().BeEquivalentTo(new Dictionary<Config.Stack, StackStatus>
         {
@@ -108,8 +108,8 @@ public class StackStatusCommandHandlerTests
         // Assert
         var expectedBranchDetails = new Dictionary<string, BranchDetail>
         {
-            { aBranch, new BranchDetail { Status = new BranchStatus(true, true, 10, 5), PullRequest = pr } },
-            { aSecondBranch, new BranchDetail { Status = new BranchStatus(true, true, 1, 0) } }
+            { aBranch, new BranchDetail { Status = new BranchStatus(true, true, 10, 5, 0, 0), PullRequest = pr } },
+            { aSecondBranch, new BranchDetail { Status = new BranchStatus(true, true, 1, 0, 0, 0) } }
         };
         response.Statuses.Should().BeEquivalentTo(new Dictionary<Config.Stack, StackStatus>
         {
@@ -165,12 +165,12 @@ public class StackStatusCommandHandlerTests
         // Assert
         var expectedBranchDetailsForStack1 = new Dictionary<string, BranchDetail>
         {
-            { aBranch, new BranchDetail { Status = new BranchStatus(true, true, 10, 5), PullRequest = pr } },
-            { aSecondBranch, new BranchDetail { Status = new BranchStatus(true, true, 1, 0) } }
+            { aBranch, new BranchDetail { Status = new BranchStatus(true, true, 10, 5, 0, 0), PullRequest = pr } },
+            { aSecondBranch, new BranchDetail { Status = new BranchStatus(true, true, 1, 0, 0, 0) } }
         };
         var expectedBranchDetailsForStack2 = new Dictionary<string, BranchDetail>
         {
-            { aThirdBranch, new BranchDetail { Status = new BranchStatus(true, true, 3, 5) } }
+            { aThirdBranch, new BranchDetail { Status = new BranchStatus(true, true, 3, 5, 0, 0) } }
         };
         response.Statuses.Should().BeEquivalentTo(new Dictionary<Config.Stack, StackStatus>
         {
@@ -228,12 +228,12 @@ public class StackStatusCommandHandlerTests
         // Assert
         var expectedBranchDetailsForStack1 = new Dictionary<string, BranchDetail>
         {
-            { aBranch, new BranchDetail { Status = new BranchStatus(true, true, 10, 5), PullRequest = pr } },
-            { aSecondBranch, new BranchDetail { Status = new BranchStatus(true, true, 1, 0) } }
+            { aBranch, new BranchDetail { Status = new BranchStatus(true, true, 10, 5, 0, 0), PullRequest = pr } },
+            { aSecondBranch, new BranchDetail { Status = new BranchStatus(true, true, 1, 0, 0, 0) } }
         };
         var expectedBranchDetailsForStack2 = new Dictionary<string, BranchDetail>
         {
-            { aThirdBranch, new BranchDetail { Status = new BranchStatus(true, true, 3, 5) } }
+            { aThirdBranch, new BranchDetail { Status = new BranchStatus(true, true, 3, 5, 0, 0) } }
         };
         response.Statuses.Should().BeEquivalentTo(new Dictionary<Config.Stack, StackStatus>
         {
@@ -325,8 +325,8 @@ public class StackStatusCommandHandlerTests
         // Assert
         var expectedBranchDetails = new Dictionary<string, BranchDetail>
         {
-            { aBranch, new BranchDetail { Status = new BranchStatus(true, false, 0, 0) } },
-            { aSecondBranch, new BranchDetail { Status = new BranchStatus(true, true, 11, 0), PullRequest = pr } } // The 11 commits are the 10 commits from the parent branch and one from this branch
+            { aBranch, new BranchDetail { Status = new BranchStatus(true, false, 0, 0, 0, 0) } },
+            { aSecondBranch, new BranchDetail { Status = new BranchStatus(true, true, 11, 0, 0, 0), PullRequest = pr } } // The 11 commits are the 10 commits from the parent branch and one from this branch
         };
         response.Statuses.Should().BeEquivalentTo(new Dictionary<Config.Stack, StackStatus>
         {
@@ -378,8 +378,8 @@ public class StackStatusCommandHandlerTests
         // Assert
         var expectedBranchDetails = new Dictionary<string, BranchDetail>
         {
-            { aBranch, new BranchDetail { Status = new BranchStatus(false, false, 0, 0) } },
-            { aSecondBranch, new BranchDetail { Status = new BranchStatus(true, true, 1, 0), PullRequest = pr } }
+            { aBranch, new BranchDetail { Status = new BranchStatus(false, false, 0, 0, 0, 0) } },
+            { aSecondBranch, new BranchDetail { Status = new BranchStatus(true, true, 1, 0, 0, 0), PullRequest = pr } }
         };
         response.Statuses.Should().BeEquivalentTo(new Dictionary<Config.Stack, StackStatus>
         {
@@ -430,8 +430,8 @@ public class StackStatusCommandHandlerTests
         // Assert
         var expectedBranchDetails = new Dictionary<string, BranchDetail>
         {
-            { aBranch, new BranchDetail { Status = new BranchStatus(true, true, 10, 5), PullRequest = pr } },
-            { aSecondBranch, new BranchDetail { Status = new BranchStatus(true, true, 1, 0) } }
+            { aBranch, new BranchDetail { Status = new BranchStatus(true, true, 10, 5, 0, 0), PullRequest = pr } },
+            { aSecondBranch, new BranchDetail { Status = new BranchStatus(true, true, 1, 0, 0, 0) } }
         };
         response.Statuses.Should().BeEquivalentTo(new Dictionary<Config.Stack, StackStatus>
         {

--- a/src/Stack.Tests/Git/GitBranchStatusParserTests.cs
+++ b/src/Stack.Tests/Git/GitBranchStatusParserTests.cs
@@ -1,0 +1,85 @@
+using FluentAssertions;
+using Stack.Git;
+
+namespace Stack.Tests.Git;
+
+public class GitBranchStatusParserTests
+{
+    [Fact]
+    public void WhenBranchIsCurrentBranch_ReturnsCorrectStatus()
+    {
+        // Arrange
+        var branchStatus = "* main 1234567 [origin/main] Some message";
+
+        // Act
+        var result = GitBranchStatusParser.Parse(branchStatus);
+
+        // Assert
+        result.Should().Be(new GitBranchStatus("main", "origin/main", true, true, 0, 0, new Commit("1234567", "Some message")));
+    }
+
+    [Fact]
+    public void WhenBranchIsAheadAndBehindItsRemoteTrackingBranch_ReturnsCorrectStatus()
+    {
+        // Arrange
+        var branchStatus = "  main 1234567 [origin/main: ahead 1, behind 2] Some message";
+
+        // Act
+        var result = GitBranchStatusParser.Parse(branchStatus);
+
+        // Assert
+        result.Should().Be(new GitBranchStatus("main", "origin/main", true, false, 1, 2, new Commit("1234567", "Some message")));
+    }
+
+    [Fact]
+    public void WhenBranchIsAheadOfItsRemoteTrackingBranch_ReturnsCorrectStatus()
+    {
+        // Arrange
+        var branchStatus = "  main 1234567 [origin/main: ahead 1] Some message";
+
+        // Act
+        var result = GitBranchStatusParser.Parse(branchStatus);
+
+        // Assert
+        result.Should().Be(new GitBranchStatus("main", "origin/main", true, false, 1, 0, new Commit("1234567", "Some message")));
+    }
+
+    [Fact]
+    public void WhenBranchIsBehindItsRemoteTrackingBranch_ReturnsCorrectStatus()
+    {
+        // Arrange
+        var branchStatus = "  main 1234567 [origin/main: behind 2] Some message";
+
+        // Act
+        var result = GitBranchStatusParser.Parse(branchStatus);
+
+        // Assert
+        result.Should().Be(new GitBranchStatus("main", "origin/main", true, false, 0, 2, new Commit("1234567", "Some message")));
+    }
+
+    [Fact]
+    public void WhenBranchIsNotTracked_ReturnsCorrectStatus()
+    {
+        // Arrange
+        var branchStatus = "  main 1234567 Some message";
+
+        // Act
+        var result = GitBranchStatusParser.Parse(branchStatus);
+
+        // Assert
+        result.Should().Be(new GitBranchStatus("main", null, false, false, 0, 0, new Commit("1234567", "Some message")));
+    }
+
+    [Fact]
+    public void WhenRemoteTrackingBranchIsGone_ReturnsCorrectStatus()
+    {
+        // Arrange
+        var branchStatus = "  main 1234567 [origin/main: gone] Some message";
+
+        // Act
+        var result = GitBranchStatusParser.Parse(branchStatus);
+
+        // Assert
+        result.Should().Be(new GitBranchStatus("main", "origin/main", false, false, 0, 0, new Commit("1234567", "Some message")));
+    }
+}

--- a/src/Stack.Tests/Helpers/TestGitRepositoryBuilder.cs
+++ b/src/Stack.Tests/Helpers/TestGitRepositoryBuilder.cs
@@ -56,7 +56,7 @@ public class BranchBuilder
         }
     }
 
-    private static Commit CreateEmptyCommit(Repository repository, Branch branch, string message)
+    private static LibGit2Sharp.Commit CreateEmptyCommit(Repository repository, Branch branch, string message)
     {
         repository.Refs.UpdateTarget("HEAD", branch.CanonicalName);
         var signature = new Signature(Some.Name(), Some.Name(), DateTimeOffset.Now);
@@ -238,7 +238,7 @@ public class TestGitRepositoryBuilder
         return new TestGitRepository(localDirectory, remoteDirectory, localRepo);
     }
 
-    private static Commit CreateInitialCommit(Repository repository)
+    private static LibGit2Sharp.Commit CreateInitialCommit(Repository repository)
     {
         var message = $"Initial commit";
         var signature = new Signature(Some.Name(), Some.Name(), DateTimeOffset.Now);
@@ -252,12 +252,12 @@ public class TestGitRepository(TemporaryDirectory LocalDirectory, TemporaryDirec
     public string RemoteUri => RemoteDirectory.DirectoryPath;
     public GitOperationSettings GitOperationSettings => new GitOperationSettings(false, false, LocalDirectory.DirectoryPath);
 
-    public Commit GetTipOfBranch(string branchName)
+    public LibGit2Sharp.Commit GetTipOfBranch(string branchName)
     {
         return LocalRepository.Branches[branchName].Tip;
     }
 
-    public List<Commit> GetCommitsReachableFromBranch(string branchName)
+    public List<LibGit2Sharp.Commit> GetCommitsReachableFromBranch(string branchName)
     {
         return [.. LocalRepository.Branches[branchName].Commits];
     }

--- a/src/Stack/Commands/Helpers/StackStatusHelpers.cs
+++ b/src/Stack/Commands/Helpers/StackStatusHelpers.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Microsoft.VisualBasic;
 using Spectre.Console;
 using Stack.Config;
 using Stack.Git;
@@ -8,14 +9,14 @@ namespace Stack.Commands.Helpers;
 
 public class BranchDetail
 {
-    public BranchStatus Status { get; set; } = new(false, false, 0, 0, 0, 0);
+    public BranchStatus Status { get; set; } = new(false, false, false, 0, 0, 0, 0, null);
     public GitHubPullRequest? PullRequest { get; set; }
 
     public bool IsActive => Status.ExistsLocally && Status.ExistsInRemote && (PullRequest is null || PullRequest.State != GitHubPullRequestStates.Merged);
     public bool CouldBeCleanedUp => Status.ExistsLocally && (!Status.ExistsInRemote || PullRequest is not null && PullRequest.State == GitHubPullRequestStates.Merged);
     public bool HasPullRequest => PullRequest is not null && PullRequest.State != GitHubPullRequestStates.Closed;
 }
-public record BranchStatus(bool ExistsLocally, bool ExistsInRemote, int AheadOfParent, int BehindParent, int AheadOfRemote, int BehindRemote);
+public record BranchStatus(bool ExistsLocally, bool ExistsInRemote, bool IsCurrentBranch, int AheadOfParent, int BehindParent, int AheadOfRemote, int BehindRemote, Commit? Tip);
 public record StackStatus(Dictionary<string, BranchDetail> Branches)
 {
     public string[] GetActiveBranches() => Branches.Where(b => b.Value.IsActive).Select(b => b.Key).ToArray();
@@ -29,6 +30,7 @@ public static class StackStatusHelpers
         IOutputProvider outputProvider,
         IGitOperations gitOperations,
         IGitHubOperations gitHubOperations,
+        bool includeParentBranchStatus = true,
         bool includePullRequestStatus = true)
     {
         var stacksToCheckStatusFor = new Dictionary<Config.Stack, StackStatus>();
@@ -40,44 +42,37 @@ public static class StackStatusHelpers
 
         var allBranchesInStacks = stacks.SelectMany(s => new List<string>([s.SourceBranch]).Concat(s.Branches)).Distinct().ToArray();
 
-        outputProvider.Status("Checking status of branches...", () =>
+        var branchStatuses = gitOperations.GetBranchStatuses(allBranchesInStacks);
+
+        foreach (var (stack, status) in stacksToCheckStatusFor)
         {
-            var branchesThatExistInRemote = gitOperations.GetBranchesThatExistInRemote(allBranchesInStacks);
-            var branchesThatExistLocally = gitOperations.GetBranchesThatExistLocally(allBranchesInStacks);
+            var parentBranch = stack.SourceBranch;
 
-            foreach (var (stack, status) in stacksToCheckStatusFor)
+            status.Branches.Add(stack.SourceBranch, new BranchDetail());
+            branchStatuses.TryGetValue(stack.SourceBranch, out var sourceBranchStatus);
+            if (sourceBranchStatus is not null)
             {
-                void CheckBranchStatus(string branch, string sourceBranch)
+                status.Branches[stack.SourceBranch].Status = new BranchStatus(true, sourceBranchStatus.RemoteBranchExists, sourceBranchStatus.IsCurrentBranch, 0, 0, sourceBranchStatus.Ahead, sourceBranchStatus.Behind, sourceBranchStatus.Tip);
+            }
+
+            foreach (var branch in stack.Branches)
+            {
+                status.Branches.Add(branch, new BranchDetail());
+                branchStatuses.TryGetValue(branch, out var branchStatus);
+
+                if (branchStatus is not null)
                 {
-                    var branchExistsLocally = branchesThatExistLocally.Contains(branch);
-                    var (ahead, behind) = gitOperations.CompareBranches(branch, sourceBranch);
-                    var (aheadRemote, behindRemote) = gitOperations.GetComparisonToRemoteTrackingBranch(branch);
-                    var branchStatus = new BranchStatus(branchExistsLocally, true, ahead, behind, aheadRemote, behindRemote);
-                    status.Branches[branch].Status = branchStatus;
-                }
+                    var (aheadOfParent, behindParent) = includeParentBranchStatus && branchStatus.RemoteBranchExists ? gitOperations.CompareBranches(branch, parentBranch) : (0, 0);
 
-                var parentBranch = stack.SourceBranch;
+                    status.Branches[branch].Status = new BranchStatus(true, branchStatus.RemoteBranchExists, branchStatus.IsCurrentBranch, aheadOfParent, behindParent, branchStatus.Ahead, branchStatus.Behind, branchStatus.Tip);
 
-                status.Branches.Add(stack.SourceBranch, new BranchDetail());
-                var sourceBranchRemoteStatus = gitOperations.GetComparisonToRemoteTrackingBranch(stack.SourceBranch);
-                status.Branches[stack.SourceBranch].Status = new BranchStatus(branchesThatExistLocally.Contains(stack.SourceBranch), true, 0, 0, sourceBranchRemoteStatus.Ahead, sourceBranchRemoteStatus.Behind);
-
-                foreach (var branch in stack.Branches)
-                {
-                    status.Branches.Add(branch, new BranchDetail());
-
-                    if (branchesThatExistInRemote.Contains(branch))
+                    if (branchStatus.RemoteBranchExists)
                     {
-                        CheckBranchStatus(branch, parentBranch);
                         parentBranch = branch;
-                    }
-                    else
-                    {
-                        status.Branches[branch].Status = new BranchStatus(branchesThatExistLocally.Contains(branch), false, 0, 0, 0, 0);
                     }
                 }
             }
-        });
+        }
 
         if (includePullRequestStatus)
         {
@@ -122,22 +117,25 @@ public static class StackStatusHelpers
 
     public static void OutputStackStatus(
         Dictionary<Config.Stack, StackStatus> stackStatuses,
-        IGitOperations gitOperations,
         IOutputProvider outputProvider)
     {
         foreach (var (stack, status) in stackStatuses)
         {
-            OutputStackStatus(stack, status, gitOperations, outputProvider);
+            OutputStackStatus(stack, status, outputProvider);
+            outputProvider.NewLine();
         }
     }
 
     public static void OutputStackStatus(
         Config.Stack stack,
         StackStatus status,
-        IGitOperations gitOperations,
         IOutputProvider outputProvider)
     {
-        var header = $"{stack.Name.Stack()}: {stack.SourceBranch.Muted()}";
+        var header = stack.SourceBranch.Branch();
+        if (status.Branches.TryGetValue(stack.SourceBranch, out var sourceBranchStatus))
+        {
+            header = GetBranchStatusOutput(stack.SourceBranch, null, sourceBranchStatus);
+        }
         var items = new List<string>();
 
         string parentBranch = stack.SourceBranch;
@@ -146,7 +144,7 @@ public static class StackStatusHelpers
         {
             if (status.Branches.TryGetValue(branch, out var branchDetail))
             {
-                items.Add(GetBranchAndPullRequestStatusOutput(branch, parentBranch, branchDetail, gitOperations));
+                items.Add(GetBranchAndPullRequestStatusOutput(branch, parentBranch, branchDetail));
 
                 if (branchDetail.IsActive)
                 {
@@ -154,17 +152,17 @@ public static class StackStatusHelpers
                 }
             }
         }
+        outputProvider.Information(stack.Name.Stack());
         outputProvider.Tree(header, [.. items]);
     }
 
     public static string GetBranchAndPullRequestStatusOutput(
         string branch,
-        string parentBranch,
-        BranchDetail branchDetail,
-        IGitOperations gitOperations)
+        string? parentBranch,
+        BranchDetail branchDetail)
     {
         var branchNameBuilder = new StringBuilder();
-        branchNameBuilder.Append(GetBranchStatusOutput(branch, parentBranch, branchDetail, gitOperations));
+        branchNameBuilder.Append(GetBranchStatusOutput(branch, parentBranch, branchDetail));
 
         if (branchDetail.PullRequest is not null)
         {
@@ -176,52 +174,64 @@ public static class StackStatusHelpers
 
     public static string GetBranchStatusOutput(
         string branch,
-        string parentBranch,
-        BranchDetail branchDetail,
-        IGitOperations gitOperations)
+        string? parentBranch,
+        BranchDetail branchDetail)
     {
         var branchNameBuilder = new StringBuilder();
-        var currentBranch = gitOperations.GetCurrentBranch();
 
-        var color = !branchDetail.IsActive ? "grey" : branch.Equals(currentBranch, StringComparison.OrdinalIgnoreCase) ? "blue" : null;
-        Decoration? decoration = !branchDetail.IsActive ? Decoration.Strikethrough : null;
+        var branchName = branchDetail.Status.IsCurrentBranch ? $"* [{Color.Green}]{branch}[/]" : branch;
+        Color? color = branchDetail.Status.ExistsLocally ? null : Color.Grey;
+        Decoration? decoration = branchDetail.Status.ExistsLocally ? null : Decoration.Strikethrough;
 
         if (color is not null && decoration is not null)
         {
-            branchNameBuilder.Append($"[{decoration} {color}]{branch}[/]");
+            branchNameBuilder.Append($"[{decoration} {color}]{branchName}[/]");
         }
         else if (color is not null)
         {
-            branchNameBuilder.Append($"[{color}]{branch}[/]");
+            branchNameBuilder.Append($"[{color}]{branchName}[/]");
         }
         else if (decoration is not null)
         {
-            branchNameBuilder.Append($"[{decoration}]{branch}[/]");
+            branchNameBuilder.Append($"[{decoration}]{branchName}[/]");
         }
         else
         {
-            branchNameBuilder.Append(branch);
+            branchNameBuilder.Append(branchName);
         }
 
         if (branchDetail.IsActive)
         {
             if (branchDetail.Status.AheadOfRemote > 0 || branchDetail.Status.BehindRemote > 0)
             {
-                branchNameBuilder.Append($" {branchDetail.Status.BehindRemote}{Emoji.Known.DownArrow}{branchDetail.Status.AheadOfRemote}{Emoji.Known.UpArrow}".Muted());
+                branchNameBuilder.Append($" {branchDetail.Status.BehindRemote}{Emoji.Known.DownArrow}{branchDetail.Status.AheadOfRemote}{Emoji.Known.UpArrow}");
             }
 
             if (branchDetail.Status.AheadOfParent > 0 && branchDetail.Status.BehindParent > 0)
             {
-                branchNameBuilder.Append($" [grey]({branchDetail.Status.AheadOfParent} ahead, {branchDetail.Status.BehindParent} behind {parentBranch})[/]");
+                branchNameBuilder.Append($" ({branchDetail.Status.AheadOfParent} ahead, {branchDetail.Status.BehindParent} behind {parentBranch})".Muted());
             }
             else if (branchDetail.Status.AheadOfParent > 0)
             {
-                branchNameBuilder.Append($" [grey]({branchDetail.Status.AheadOfParent} ahead of {parentBranch})[/]");
+                branchNameBuilder.Append($" ({branchDetail.Status.AheadOfParent} ahead of {parentBranch})".Muted());
             }
             else if (branchDetail.Status.BehindParent > 0)
             {
-                branchNameBuilder.Append($" [grey]({branchDetail.Status.BehindParent} behind {parentBranch})[/]");
+                branchNameBuilder.Append($" ({branchDetail.Status.BehindParent} behind {parentBranch})".Muted());
             }
+        }
+        else if (branchDetail.Status.ExistsLocally && !branchDetail.Status.ExistsInRemote)
+        {
+            branchNameBuilder.Append(" (remote branch deleted)".Muted());
+        }
+        else if (branchDetail.PullRequest is not null && branchDetail.PullRequest.State == GitHubPullRequestStates.Merged)
+        {
+            branchNameBuilder.Append(" (pull request merged)".Muted());
+        }
+
+        if (branchDetail.Status.Tip is not null)
+        {
+            branchNameBuilder.Append($" {branchDetail.Status.Tip.Sha[..7].Commit()} {branchDetail.Status.Tip.Message}");
         }
 
         return branchNameBuilder.ToString();

--- a/src/Stack/Commands/Helpers/StackStatusHelpers.cs
+++ b/src/Stack/Commands/Helpers/StackStatusHelpers.cs
@@ -165,7 +165,7 @@ public static class StackStatusHelpers
 
         if (branchDetail.PullRequest is not null)
         {
-            branchNameBuilder.Append($" {branchDetail.PullRequest.GetPullRequestDisplay()}");
+            branchNameBuilder.Append($"   {branchDetail.PullRequest.GetPullRequestDisplay()}");
         }
 
         return branchNameBuilder.ToString();
@@ -178,7 +178,7 @@ public static class StackStatusHelpers
     {
         var branchNameBuilder = new StringBuilder();
 
-        var branchName = branchDetail.Status.IsCurrentBranch ? $"* [{Color.Green}]{branch}[/]" : branch;
+        var branchName = branchDetail.Status.IsCurrentBranch ? $"* {branch.Branch()}" : branch;
         Color? color = branchDetail.Status.ExistsLocally ? null : Color.Grey;
         Decoration? decoration = branchDetail.Status.ExistsLocally ? null : Decoration.Strikethrough;
 
@@ -230,7 +230,7 @@ public static class StackStatusHelpers
 
         if (branchDetail.Status.Tip is not null)
         {
-            branchNameBuilder.Append($" {branchDetail.Status.Tip.Sha[..7].Commit()} {branchDetail.Status.Tip.Message}");
+            branchNameBuilder.Append($"   {branchDetail.Status.Tip.Sha[..7]} {branchDetail.Status.Tip.Message}");
         }
 
         return branchNameBuilder.ToString();

--- a/src/Stack/Commands/Helpers/StackStatusHelpers.cs
+++ b/src/Stack/Commands/Helpers/StackStatusHelpers.cs
@@ -30,7 +30,6 @@ public static class StackStatusHelpers
         IOutputProvider outputProvider,
         IGitOperations gitOperations,
         IGitHubOperations gitHubOperations,
-        bool includeParentBranchStatus = true,
         bool includePullRequestStatus = true)
     {
         var stacksToCheckStatusFor = new Dictionary<Config.Stack, StackStatus>();
@@ -62,7 +61,7 @@ public static class StackStatusHelpers
 
                 if (branchStatus is not null)
                 {
-                    var (aheadOfParent, behindParent) = includeParentBranchStatus && branchStatus.RemoteBranchExists ? gitOperations.CompareBranches(branch, parentBranch) : (0, 0);
+                    var (aheadOfParent, behindParent) = branchStatus.RemoteBranchExists ? gitOperations.CompareBranches(branch, parentBranch) : (0, 0);
 
                     status.Branches[branch].Status = new BranchStatus(true, branchStatus.RemoteBranchExists, branchStatus.IsCurrentBranch, aheadOfParent, behindParent, branchStatus.Ahead, branchStatus.Behind, branchStatus.Tip);
 

--- a/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
+++ b/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
@@ -100,7 +100,7 @@ public class CreatePullRequestsCommandHandler(
             }
         }
 
-        StackStatusHelpers.OutputStackStatus(stack, status, gitOperations, outputProvider);
+        StackStatusHelpers.OutputStackStatus(stack, status, outputProvider);
 
         outputProvider.NewLine();
 
@@ -112,7 +112,7 @@ public class CreatePullRequestsCommandHandler(
 
                 outputProvider.NewLine();
 
-                OutputUpdatedStackStatus(outputProvider, gitOperations, stack, status, pullRequestCreateActions);
+                OutputUpdatedStackStatus(outputProvider, stack, status, pullRequestCreateActions);
 
                 outputProvider.NewLine();
 
@@ -229,7 +229,7 @@ public class CreatePullRequestsCommandHandler(
         return pullRequests;
     }
 
-    private static void OutputUpdatedStackStatus(IOutputProvider outputProvider, IGitOperations gitOperations, Config.Stack stack, StackStatus status, List<GitHubPullRequestCreateAction> pullRequestCreateActions)
+    private static void OutputUpdatedStackStatus(IOutputProvider outputProvider, Config.Stack stack, StackStatus status, List<GitHubPullRequestCreateAction> pullRequestCreateActions)
     {
         var branchDisplayItems = new List<string>();
         var parentBranch = stack.SourceBranch;
@@ -239,12 +239,12 @@ public class CreatePullRequestsCommandHandler(
             var branchDetail = status.Branches[branch];
             if (branchDetail.PullRequest is not null && branchDetail.PullRequest.State != GitHubPullRequestStates.Closed)
             {
-                branchDisplayItems.Add(StackStatusHelpers.GetBranchAndPullRequestStatusOutput(branch, parentBranch, branchDetail, gitOperations));
+                branchDisplayItems.Add(StackStatusHelpers.GetBranchAndPullRequestStatusOutput(branch, parentBranch, branchDetail));
             }
             else
             {
                 var action = pullRequestCreateActions.FirstOrDefault(a => a.HeadBranch == branch);
-                branchDisplayItems.Add($"{StackStatusHelpers.GetBranchStatusOutput(branch, parentBranch, branchDetail, gitOperations)} *NEW* {action?.Title}{(action?.Draft == true ? " (draft)".Muted() : string.Empty)}");
+                branchDisplayItems.Add($"{StackStatusHelpers.GetBranchStatusOutput(branch, parentBranch, branchDetail)} *NEW* {action?.Title}{(action?.Draft == true ? " (draft)".Muted() : string.Empty)}");
             }
             parentBranch = branch;
         }

--- a/src/Stack/Commands/Stack/StackStatusCommand.cs
+++ b/src/Stack/Commands/Stack/StackStatusCommand.cs
@@ -17,6 +17,10 @@ public class StackStatusCommandSettings : CommandSettingsBase
     [Description("Show status of all stacks.")]
     [CommandOption("--all")]
     public bool All { get; init; }
+
+    [Description("Show full status including pull requests.")]
+    [CommandOption("--full")]
+    public bool Full { get; init; }
 }
 
 public class StackStatusCommand : AsyncCommand<StackStatusCommandSettings>
@@ -33,13 +37,13 @@ public class StackStatusCommand : AsyncCommand<StackStatusCommandSettings>
             new GitHubOperations(outputProvider, settings.GetGitHubOperationSettings()),
             new StackConfig());
 
-        await handler.Handle(new StackStatusCommandInputs(settings.Name, settings.All));
+        await handler.Handle(new StackStatusCommandInputs(settings.Name, settings.All, settings.Full));
 
         return 0;
     }
 }
 
-public record StackStatusCommandInputs(string? Name, bool All);
+public record StackStatusCommandInputs(string? Name, bool All, bool Full);
 public record StackStatusCommandResponse(Dictionary<Config.Stack, StackStatus> Statuses);
 
 public class StackStatusCommandHandler(
@@ -81,7 +85,8 @@ public class StackStatusCommandHandler(
             currentBranch,
             outputProvider,
             gitOperations,
-            gitHubOperations);
+            gitHubOperations,
+            inputs.Full);
 
         StackStatusHelpers.OutputStackStatus(stackStatusResults, gitOperations, outputProvider);
 

--- a/src/Stack/Commands/Stack/StackStatusCommand.cs
+++ b/src/Stack/Commands/Stack/StackStatusCommand.cs
@@ -18,6 +18,10 @@ public class StackStatusCommandSettings : CommandSettingsBase
     [CommandOption("--all")]
     public bool All { get; init; }
 
+    [Description("Show minimal status.")]
+    [CommandOption("--minimal")]
+    public bool Minimal { get; init; }
+
     [Description("Show full status including pull requests.")]
     [CommandOption("--full")]
     public bool Full { get; init; }
@@ -37,13 +41,13 @@ public class StackStatusCommand : AsyncCommand<StackStatusCommandSettings>
             new GitHubOperations(outputProvider, settings.GetGitHubOperationSettings()),
             new StackConfig());
 
-        await handler.Handle(new StackStatusCommandInputs(settings.Name, settings.All, settings.Full));
+        await handler.Handle(new StackStatusCommandInputs(settings.Name, settings.All, settings.Minimal, settings.Full));
 
         return 0;
     }
 }
 
-public record StackStatusCommandInputs(string? Name, bool All, bool Full);
+public record StackStatusCommandInputs(string? Name, bool All, bool Minimal, bool Full);
 public record StackStatusCommandResponse(Dictionary<Config.Stack, StackStatus> Statuses);
 
 public class StackStatusCommandHandler(
@@ -86,9 +90,10 @@ public class StackStatusCommandHandler(
             outputProvider,
             gitOperations,
             gitHubOperations,
+            !inputs.Minimal,
             inputs.Full);
 
-        StackStatusHelpers.OutputStackStatus(stackStatusResults, gitOperations, outputProvider);
+        StackStatusHelpers.OutputStackStatus(stackStatusResults, outputProvider);
 
         if (stacksToCheckStatusFor.Count == 1)
         {

--- a/src/Stack/Commands/Stack/StackStatusCommand.cs
+++ b/src/Stack/Commands/Stack/StackStatusCommand.cs
@@ -18,10 +18,6 @@ public class StackStatusCommandSettings : CommandSettingsBase
     [CommandOption("--all")]
     public bool All { get; init; }
 
-    [Description("Show minimal status.")]
-    [CommandOption("--minimal")]
-    public bool Minimal { get; init; }
-
     [Description("Show full status including pull requests.")]
     [CommandOption("--full")]
     public bool Full { get; init; }
@@ -41,13 +37,13 @@ public class StackStatusCommand : AsyncCommand<StackStatusCommandSettings>
             new GitHubOperations(outputProvider, settings.GetGitHubOperationSettings()),
             new StackConfig());
 
-        await handler.Handle(new StackStatusCommandInputs(settings.Name, settings.All, settings.Minimal, settings.Full));
+        await handler.Handle(new StackStatusCommandInputs(settings.Name, settings.All, settings.Full));
 
         return 0;
     }
 }
 
-public record StackStatusCommandInputs(string? Name, bool All, bool Minimal, bool Full);
+public record StackStatusCommandInputs(string? Name, bool All, bool Full);
 public record StackStatusCommandResponse(Dictionary<Config.Stack, StackStatus> Statuses);
 
 public class StackStatusCommandHandler(
@@ -90,7 +86,6 @@ public class StackStatusCommandHandler(
             outputProvider,
             gitOperations,
             gitHubOperations,
-            !inputs.Minimal,
             inputs.Full);
 
         StackStatusHelpers.OutputStackStatus(stackStatusResults, outputProvider);

--- a/src/Stack/Commands/Stack/StackStatusCommand.cs
+++ b/src/Stack/Commands/Stack/StackStatusCommand.cs
@@ -88,6 +88,11 @@ public class StackStatusCommandHandler(
             gitHubOperations,
             inputs.Full);
 
+        if (stackStatusResults.Count == 1)
+        {
+            outputProvider.NewLine();
+        }
+
         StackStatusHelpers.OutputStackStatus(stackStatusResults, outputProvider);
 
         if (stacksToCheckStatusFor.Count == 1)

--- a/src/Stack/Git/GitBranchStatusParser.cs
+++ b/src/Stack/Git/GitBranchStatusParser.cs
@@ -1,0 +1,31 @@
+using System.Text.RegularExpressions;
+
+namespace Stack.Git;
+
+public static class GitBranchStatusParser
+{
+    static Regex regex = new(
+        @"^(?<isCurrentBranch>\*)?\s*(?<branchName>\S+)\s+(?<sha>\S+)\s*(\[(?<remoteTrackingBranchName>[^:]+)?(?::\s*(?<status>(ahead\s+(?<ahead>\d+),\s*behind\s+(?<behind>\d+))|(ahead\s+(?<aheadOnly>\d+))|(behind\s+(?<behindOnly>\d+))|(gone)))?\])?\s+(?<message>.+)$",
+        RegexOptions.Compiled);
+
+    public static GitBranchStatus? Parse(string branchStatus)
+    {
+        var match = regex.Match(branchStatus);
+
+        if (match.Success)
+        {
+            var branchName = match.Groups["branchName"].Value;
+            var isCurrentBranch = match.Groups["isCurrentBranch"].Success;
+            var remoteTrackingBranchName = string.IsNullOrEmpty(match.Groups["remoteTrackingBranchName"].Value) ? null : match.Groups["remoteTrackingBranchName"].Value;
+            var ahead = match.Groups["ahead"].Success ? int.Parse(match.Groups["ahead"].Value) : (match.Groups["aheadOnly"].Success ? int.Parse(match.Groups["aheadOnly"].Value) : 0);
+            var behind = match.Groups["behind"].Success ? int.Parse(match.Groups["behind"].Value) : (match.Groups["behindOnly"].Success ? int.Parse(match.Groups["behindOnly"].Value) : 0);
+            var remoteBranchExists = remoteTrackingBranchName is not null && !match.Groups["status"].Value.Contains("gone");
+            var sha = match.Groups["sha"].Value;
+            var message = match.Groups["message"].Value;
+
+            return new GitBranchStatus(branchName, remoteTrackingBranchName, remoteBranchExists, isCurrentBranch, ahead, behind, new Commit(sha, message));
+        }
+
+        return null;
+    }
+}

--- a/src/Stack/Git/GitOperations.cs
+++ b/src/Stack/Git/GitOperations.cs
@@ -35,8 +35,6 @@ public interface IGitOperations
     string[] GetBranchesThatHaveBeenMerged(string[] branches, string sourceBranchName);
     (int Ahead, int Behind) GetStatusOfRemoteBranch(string branchName, string sourceBranchName);
     (int Ahead, int Behind) CompareBranches(string branchName, string sourceBranchName);
-    (int Ahead, int Behind) GetComparisonToRemoteTrackingBranch(string branchName);
-    Commit GetTipOfBranch(string branchName);
     Dictionary<string, GitBranchStatus> GetBranchStatuses(string[] branches);
     string GetRemoteUri();
     string[] GetLocalBranchesOrderedByMostRecentCommitterDate();
@@ -151,20 +149,6 @@ public class GitOperations(IOutputProvider outputProvider, GitOperationSettings 
         var status = ExecuteGitCommandAndReturnOutput($"rev-list --left-right --count {branchName}...{sourceBranchName}").Trim();
         var parts = status.Split('\t');
         return (int.Parse(parts[0]), int.Parse(parts[1]));
-    }
-
-    public (int Ahead, int Behind) GetComparisonToRemoteTrackingBranch(string branchName)
-    {
-        var status = ExecuteGitCommandAndReturnOutput($"rev-list --left-right --count {branchName}...origin/{branchName}").Trim();
-        var parts = status.Split('\t');
-        return (int.Parse(parts[0]), int.Parse(parts[1]));
-    }
-
-    public Commit GetTipOfBranch(string branchName)
-    {
-        var commit = ExecuteGitCommandAndReturnOutput($"rev-list -n 1 {branchName}").Trim();
-        var message = ExecuteGitCommandAndReturnOutput($"log -1 --pretty=%B {commit}").Trim();
-        return new Commit(commit, message);
     }
 
     public Dictionary<string, GitBranchStatus> GetBranchStatuses(string[] branches)

--- a/src/Stack/Git/GitOperations.cs
+++ b/src/Stack/Git/GitOperations.cs
@@ -31,6 +31,8 @@ public interface IGitOperations
     bool IsRemoteBranchFullyMerged(string branchName, string sourceBranchName);
     string[] GetBranchesThatHaveBeenMerged(string[] branches, string sourceBranchName);
     (int Ahead, int Behind) GetStatusOfRemoteBranch(string branchName, string sourceBranchName);
+    (int Ahead, int Behind) CompareBranches(string branchName, string sourceBranchName);
+    (int Ahead, int Behind) GetComparisonToRemoteTrackingBranch(string branchName);
     string GetRemoteUri();
     string[] GetLocalBranchesOrderedByMostRecentCommitterDate();
     string GetRootOfRepository();
@@ -135,6 +137,20 @@ public class GitOperations(IOutputProvider outputProvider, GitOperationSettings 
     public (int Ahead, int Behind) GetStatusOfRemoteBranch(string branchName, string sourceBranchName)
     {
         var status = ExecuteGitCommandAndReturnOutput($"rev-list --left-right --count origin/{branchName}...origin/{sourceBranchName}").Trim();
+        var parts = status.Split('\t');
+        return (int.Parse(parts[0]), int.Parse(parts[1]));
+    }
+
+    public (int Ahead, int Behind) CompareBranches(string branchName, string sourceBranchName)
+    {
+        var status = ExecuteGitCommandAndReturnOutput($"rev-list --left-right --count {branchName}...{sourceBranchName}").Trim();
+        var parts = status.Split('\t');
+        return (int.Parse(parts[0]), int.Parse(parts[1]));
+    }
+
+    public (int Ahead, int Behind) GetComparisonToRemoteTrackingBranch(string branchName)
+    {
+        var status = ExecuteGitCommandAndReturnOutput($"rev-list --left-right --count {branchName}...origin/{branchName}").Trim();
         var parts = status.Split('\t');
         return (int.Parse(parts[0]), int.Parse(parts[1]));
     }

--- a/src/Stack/Git/GitOperations.cs
+++ b/src/Stack/Git/GitOperations.cs
@@ -122,9 +122,9 @@ public class GitOperations(IOutputProvider outputProvider, GitOperationSettings 
 
     public string[] GetBranchesThatExistInRemote(string[] branches)
     {
-        var remoteBranches = ExecuteGitCommandAndReturnOutput("branch --remote --format=%(refname:short)").Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        var remoteBranches = ExecuteGitCommandAndReturnOutput($"ls-remote --heads origin {string.Join(" ", branches)}").Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
 
-        return branches.Where(b => remoteBranches.Any(lb => lb.Equals($"origin/{b}", StringComparison.OrdinalIgnoreCase))).ToArray();
+        return branches.Where(b => remoteBranches.Any(rb => rb.EndsWith(b))).ToArray();
     }
 
     public bool IsRemoteBranchFullyMerged(string branchName, string sourceBranchName)

--- a/src/Stack/Git/GitOperations.cs
+++ b/src/Stack/Git/GitOperations.cs
@@ -156,7 +156,6 @@ public class GitOperations(IOutputProvider outputProvider, GitOperationSettings 
         var statuses = new Dictionary<string, GitBranchStatus>();
 
         var gitBranchVerbose = ExecuteGitCommandAndReturnOutput("branch -vv").Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
-        var regex = new Regex(@"^(?<isCurrentBranch>\*)?\s*(?<branchName>\S+)\s+(?<sha>\S+)\s*(\[(?<remoteTrackingBranchName>[^:]+)?(?::\s*(?<status>(ahead\s+(?<ahead>\d+),\s*behind\s+(?<behind>\d+))|(ahead\s+(?<aheadOnly>\d+))|(behind\s+(?<behindOnly>\d+))|(gone)))?\])?\s+(?<message>.+)$");
 
         foreach (var branchStatus in gitBranchVerbose)
         {

--- a/src/Stack/Infrastructure/ConsoleOutputProvider.cs
+++ b/src/Stack/Infrastructure/ConsoleOutputProvider.cs
@@ -55,5 +55,4 @@ public static class OutputStyleExtensionMethods
     public static string Branch(this string name) => $"[{Color.Blue}]{name}[/]";
     public static string Muted(this string name) => $"[{Color.Grey}]{name}[/]";
     public static string Example(this string name) => $"[{Color.Aqua}]{name}[/]";
-    public static string Commit(this string name) => $"[{Color.Orange1}]{name}[/]";
 }

--- a/src/Stack/Infrastructure/ConsoleOutputProvider.cs
+++ b/src/Stack/Infrastructure/ConsoleOutputProvider.cs
@@ -51,8 +51,9 @@ public class ConsoleOutputProvider(IAnsiConsole console) : IOutputProvider
 
 public static class OutputStyleExtensionMethods
 {
-    public static string Stack(this string name) => $"[yellow]{name}[/]";
-    public static string Branch(this string name) => $"[blue]{name}[/]";
-    public static string Muted(this string name) => $"[grey]{name}[/]";
-    public static string Example(this string name) => $"[aqua]{name}[/]";
+    public static string Stack(this string name) => $"[{Color.Yellow}]{name}[/]";
+    public static string Branch(this string name) => $"[{Color.Blue}]{name}[/]";
+    public static string Muted(this string name) => $"[{Color.Grey}]{name}[/]";
+    public static string Example(this string name) => $"[{Color.Aqua}]{name}[/]";
+    public static string Commit(this string name) => $"[{Color.Orange1}]{name}[/]";
 }


### PR DESCRIPTION
# Background

<!-- stack-pr-list -->
This PR is part of a series that separates commands that operate on the local Git repository from those that operate against the remote. This is to help align the tool to the way that Git itself operates.

- https://github.com/geofflamrock/stack/pull/159
- https://github.com/geofflamrock/stack/pull/160
- https://github.com/geofflamrock/stack/pull/164
- https://github.com/geofflamrock/stack/pull/165
- https://github.com/geofflamrock/stack/pull/166
- https://github.com/geofflamrock/stack/pull/167
<!-- /stack-pr-list -->

# Changes

This PR changes the way that the `status` command works so that it:
- Reads the status of branches in one go straight from the local repo using `git branch -vv` rather than lots of calls: This is now so much quicker to the point where can also ditch the Checking status of branches... bit.
- By default doesn't show the status of pull requests, this can now be done with a new option `--full`.
- Better shows the difference between the remote branch being gone, pr being merged and local branch being gone
- Shows the latest commit sha and message