### PR TITLE
Rename `IGitOperations` to `IGitClient`

### DIFF
--- a/src/Stack.Tests/Commands/Branch/AddBranchCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Branch/AddBranchCommandHandlerTests.cs
@@ -27,8 +27,8 @@ public class AddBranchCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new AddBranchCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new AddBranchCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -70,8 +70,8 @@ public class AddBranchCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new AddBranchCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new AddBranchCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -113,8 +113,8 @@ public class AddBranchCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new AddBranchCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new AddBranchCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -153,8 +153,8 @@ public class AddBranchCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new AddBranchCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new AddBranchCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -187,8 +187,8 @@ public class AddBranchCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new AddBranchCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new AddBranchCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -230,8 +230,8 @@ public class AddBranchCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new AddBranchCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new AddBranchCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -266,8 +266,8 @@ public class AddBranchCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new AddBranchCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new AddBranchCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -301,8 +301,8 @@ public class AddBranchCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new AddBranchCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new AddBranchCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [

--- a/src/Stack.Tests/Commands/Branch/NewBranchCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Branch/NewBranchCommandHandlerTests.cs
@@ -26,8 +26,8 @@ public class NewBranchCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new NewBranchCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new NewBranchCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -52,7 +52,7 @@ public class NewBranchCommandHandlerTests
             new("Stack1", repo.RemoteUri, sourceBranch, [anotherBranch, newBranch]),
             new("Stack2", repo.RemoteUri, sourceBranch, [])
         });
-        gitOperations.GetCurrentBranch().Should().Be(newBranch);
+        gitClient.GetCurrentBranch().Should().Be(newBranch);
         repo.GetBranches().Should().Contain(b => b.FriendlyName == newBranch && !b.IsTracking);
     }
 
@@ -71,8 +71,8 @@ public class NewBranchCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new NewBranchCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new NewBranchCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -97,7 +97,7 @@ public class NewBranchCommandHandlerTests
             new("Stack1", repo.RemoteUri, sourceBranch, [anotherBranch, newBranch]),
             new("Stack2", repo.RemoteUri, sourceBranch, [])
         });
-        gitOperations.GetCurrentBranch().Should().NotBe(newBranch);
+        gitClient.GetCurrentBranch().Should().NotBe(newBranch);
     }
 
     [Fact]
@@ -115,8 +115,8 @@ public class NewBranchCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new NewBranchCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new NewBranchCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -157,8 +157,8 @@ public class NewBranchCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new NewBranchCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new NewBranchCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -197,8 +197,8 @@ public class NewBranchCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new NewBranchCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new NewBranchCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -230,8 +230,8 @@ public class NewBranchCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new NewBranchCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new NewBranchCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -271,8 +271,8 @@ public class NewBranchCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new NewBranchCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new NewBranchCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -306,8 +306,8 @@ public class NewBranchCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new NewBranchCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new NewBranchCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -340,8 +340,8 @@ public class NewBranchCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new NewBranchCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new NewBranchCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -380,8 +380,8 @@ public class NewBranchCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new NewBranchCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new NewBranchCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -406,7 +406,7 @@ public class NewBranchCommandHandlerTests
             new("A stack with multiple words", repo.RemoteUri, sourceBranch, [anotherBranch, newBranch]),
             new("Stack2", repo.RemoteUri, sourceBranch, [])
         });
-        gitOperations.GetCurrentBranch().Should().Be(newBranch);
+        gitClient.GetCurrentBranch().Should().Be(newBranch);
     }
 
     [Fact]
@@ -424,8 +424,8 @@ public class NewBranchCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new NewBranchCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new NewBranchCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -450,7 +450,7 @@ public class NewBranchCommandHandlerTests
             new("Stack1", repo.RemoteUri, sourceBranch, [anotherBranch, newBranch]),
             new("Stack2", repo.RemoteUri, sourceBranch, [])
         });
-        gitOperations.GetCurrentBranch().Should().NotBe(newBranch);
+        gitClient.GetCurrentBranch().Should().NotBe(newBranch);
         repo.GetBranches().Should().Contain(b => b.FriendlyName == newBranch && b.IsTracking);
     }
 }

--- a/src/Stack.Tests/Commands/Branch/RemoveBranchCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Branch/RemoveBranchCommandHandlerTests.cs
@@ -25,8 +25,8 @@ public class RemoveBranchCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new RemoveBranchCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new RemoveBranchCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -67,8 +67,8 @@ public class RemoveBranchCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new RemoveBranchCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new RemoveBranchCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -109,8 +109,8 @@ public class RemoveBranchCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new RemoveBranchCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new RemoveBranchCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -141,8 +141,8 @@ public class RemoveBranchCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new RemoveBranchCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new RemoveBranchCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -183,8 +183,8 @@ public class RemoveBranchCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new RemoveBranchCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new RemoveBranchCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -217,8 +217,8 @@ public class RemoveBranchCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new RemoveBranchCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new RemoveBranchCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -259,8 +259,8 @@ public class RemoveBranchCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new RemoveBranchCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new RemoveBranchCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -298,8 +298,8 @@ public class RemoveBranchCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new RemoveBranchCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new RemoveBranchCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [

--- a/src/Stack.Tests/Commands/PullRequests/CreatePullRequestsCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/PullRequests/CreatePullRequestsCommandHandlerTests.cs
@@ -29,8 +29,8 @@ public class CreatePullRequestsCommandHandlerTests
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
         var fileOperations = Substitute.For<IFileOperations>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, fileOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, fileOperations, stackConfig);
 
         outputProvider
             .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
@@ -87,8 +87,8 @@ public class CreatePullRequestsCommandHandlerTests
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
         var fileOperations = Substitute.For<IFileOperations>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, fileOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, fileOperations, stackConfig);
 
         outputProvider
             .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
@@ -161,8 +161,8 @@ A custom description
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
         var fileOperations = Substitute.For<IFileOperations>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, fileOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, fileOperations, stackConfig);
 
         outputProvider
             .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
@@ -235,8 +235,8 @@ A custom description
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
         var fileOperations = Substitute.For<IFileOperations>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, fileOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, fileOperations, stackConfig);
 
         outputProvider
             .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
@@ -293,8 +293,8 @@ A custom description
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
         var fileOperations = Substitute.For<IFileOperations>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, fileOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, fileOperations, stackConfig);
 
         outputProvider
             .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
@@ -346,8 +346,8 @@ A custom description
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
         var fileOperations = Substitute.For<IFileOperations>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, fileOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, fileOperations, stackConfig);
 
         outputProvider
             .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
@@ -386,8 +386,8 @@ A custom description
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
         var fileOperations = Substitute.For<IFileOperations>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, fileOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, fileOperations, stackConfig);
 
         outputProvider
             .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
@@ -460,8 +460,8 @@ A custom description
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
         var fileOperations = Substitute.For<IFileOperations>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, fileOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, fileOperations, stackConfig);
 
         outputProvider
             .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
@@ -515,8 +515,8 @@ A custom description
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
         var fileOperations = Substitute.For<IFileOperations>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, fileOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, fileOperations, stackConfig);
 
         outputProvider
             .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))

--- a/src/Stack.Tests/Commands/PullRequests/OpenPullRequestsCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/PullRequests/OpenPullRequestsCommandHandlerTests.cs
@@ -29,8 +29,8 @@ public class OpenPullRequestsCommandHandlerTests
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
         var fileOperations = Substitute.For<IFileOperations>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new OpenPullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new OpenPullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -80,8 +80,8 @@ public class OpenPullRequestsCommandHandlerTests
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
         var fileOperations = Substitute.For<IFileOperations>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new OpenPullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new OpenPullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -128,8 +128,8 @@ public class OpenPullRequestsCommandHandlerTests
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
         var fileOperations = Substitute.For<IFileOperations>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new OpenPullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new OpenPullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -174,8 +174,8 @@ public class OpenPullRequestsCommandHandlerTests
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
         var fileOperations = Substitute.For<IFileOperations>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new OpenPullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new OpenPullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -219,8 +219,8 @@ public class OpenPullRequestsCommandHandlerTests
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
         var fileOperations = Substitute.For<IFileOperations>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new OpenPullRequestsCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new OpenPullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [

--- a/src/Stack.Tests/Commands/Remote/PullStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Remote/PullStackCommandHandlerTests.cs
@@ -36,10 +36,10 @@ public class PullStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = new TestOutputProvider(testOutputHelper);
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new PullStackCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new PullStackCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
-        gitOperations.ChangeBranch(branch1);
+        gitClient.ChangeBranch(branch1);
 
         var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
         var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, []);
@@ -80,10 +80,10 @@ public class PullStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = new TestOutputProvider(testOutputHelper);
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new PullStackCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new PullStackCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
-        gitOperations.ChangeBranch(branch1);
+        gitClient.ChangeBranch(branch1);
 
         var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
         var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, []);
@@ -123,10 +123,10 @@ public class PullStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = new TestOutputProvider(testOutputHelper);
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new PullStackCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new PullStackCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
-        gitOperations.ChangeBranch(branch1);
+        gitClient.ChangeBranch(branch1);
 
         var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
         var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, []);
@@ -163,10 +163,10 @@ public class PullStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = new TestOutputProvider(testOutputHelper);
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new PullStackCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new PullStackCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
-        gitOperations.ChangeBranch(branch1);
+        gitClient.ChangeBranch(branch1);
 
         var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1]);
         var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, [branch2]);

--- a/src/Stack.Tests/Commands/Remote/PushStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Remote/PushStackCommandHandlerTests.cs
@@ -36,10 +36,10 @@ public class PushStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = new TestOutputProvider(testOutputHelper);
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new PushStackCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new PushStackCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
-        gitOperations.ChangeBranch(branch1);
+        gitClient.ChangeBranch(branch1);
 
         var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
         var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, []);
@@ -80,10 +80,10 @@ public class PushStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = new TestOutputProvider(testOutputHelper);
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new PushStackCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new PushStackCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
-        gitOperations.ChangeBranch(branch1);
+        gitClient.ChangeBranch(branch1);
 
         var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
         var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, []);
@@ -125,10 +125,10 @@ public class PushStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = new TestOutputProvider(testOutputHelper);
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new PushStackCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new PushStackCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
-        gitOperations.ChangeBranch(branch1);
+        gitClient.ChangeBranch(branch1);
 
         var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
         var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, []);
@@ -168,10 +168,10 @@ public class PushStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = new TestOutputProvider(testOutputHelper);
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new PushStackCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new PushStackCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
-        gitOperations.ChangeBranch(branch1);
+        gitClient.ChangeBranch(branch1);
 
         var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1]);
         var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, [branch2]);
@@ -211,10 +211,10 @@ public class PushStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = new TestOutputProvider(testOutputHelper);
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new PushStackCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new PushStackCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
-        gitOperations.ChangeBranch(branch1);
+        gitClient.ChangeBranch(branch1);
 
         var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
         var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, []);
@@ -254,10 +254,10 @@ public class PushStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = new TestOutputProvider(testOutputHelper);
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new PushStackCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new PushStackCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
-        gitOperations.ChangeBranch(branch1);
+        gitClient.ChangeBranch(branch1);
 
         var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
         var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, []);

--- a/src/Stack.Tests/Commands/Remote/SyncStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Remote/SyncStackCommandHandlerTests.cs
@@ -32,11 +32,11 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = new TestOutputProvider(testOutputHelper);
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new SyncStackCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new SyncStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
-        gitOperations.ChangeBranch(branch1);
+        gitClient.ChangeBranch(branch1);
 
         var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
         var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, []);
@@ -74,11 +74,11 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = new TestOutputProvider(testOutputHelper);
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new SyncStackCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new SyncStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
-        gitOperations.ChangeBranch(branch1);
+        gitClient.ChangeBranch(branch1);
 
         var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
         var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, []);
@@ -116,11 +116,11 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = new TestOutputProvider(testOutputHelper);
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new SyncStackCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new SyncStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
-        gitOperations.ChangeBranch(branch1);
+        gitClient.ChangeBranch(branch1);
 
         var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
         var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, []);
@@ -158,11 +158,11 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = new TestOutputProvider(testOutputHelper);
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new SyncStackCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new SyncStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
-        gitOperations.ChangeBranch(branch1);
+        gitClient.ChangeBranch(branch1);
 
         var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
         var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, []);
@@ -196,12 +196,12 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = new TestOutputProvider(testOutputHelper);
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new SyncStackCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new SyncStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         // We are on a specific branch in the stack
-        gitOperations.ChangeBranch(branch1);
+        gitClient.ChangeBranch(branch1);
 
         var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
         var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, []);
@@ -217,7 +217,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         // Assert
         repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfRemoteSourceBranch);
         repo.GetCommitsReachableFromRemoteBranch(branch2).Should().Contain(tipOfRemoteSourceBranch);
-        gitOperations.GetCurrentBranch().Should().Be(branch1);
+        gitClient.GetCurrentBranch().Should().Be(branch1);
     }
 
     [Fact]
@@ -240,11 +240,11 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = new TestOutputProvider(testOutputHelper);
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new SyncStackCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new SyncStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
-        gitOperations.ChangeBranch(branch1);
+        gitClient.ChangeBranch(branch1);
 
         var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
         var stacks = new List<Config.Stack>([stack1]);
@@ -258,7 +258,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         // Assert
         repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfRemoteSourceBranch);
         repo.GetCommitsReachableFromRemoteBranch(branch2).Should().Contain(tipOfRemoteSourceBranch);
-        gitOperations.GetCurrentBranch().Should().Be(branch1);
+        gitClient.GetCurrentBranch().Should().Be(branch1);
 
         inputProvider.DidNotReceive().Select(Questions.SelectStack, Arg.Any<string[]>());
     }

--- a/src/Stack.Tests/Commands/Stack/CleanupStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/CleanupStackCommandHandlerTests.cs
@@ -27,9 +27,9 @@ public class CleanupStackCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new CleanupStackCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new CleanupStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -47,7 +47,7 @@ public class CleanupStackCommandHandlerTests
         await handler.Handle(CleanupStackCommandInputs.Empty);
 
         // Assert
-        gitOperations.GetBranchesThatExistLocally([branchToCleanup, branchToKeep]).Should().BeEquivalentTo([branchToKeep]);
+        gitClient.GetBranchesThatExistLocally([branchToCleanup, branchToKeep]).Should().BeEquivalentTo([branchToKeep]);
     }
 
     [Fact]
@@ -66,9 +66,9 @@ public class CleanupStackCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new CleanupStackCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new CleanupStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -84,7 +84,7 @@ public class CleanupStackCommandHandlerTests
         await handler.Handle(CleanupStackCommandInputs.Empty);
 
         // Assert
-        gitOperations.GetBranchesThatExistLocally([branchToKeep, anotherBranchToKeep]).Should().BeEquivalentTo([branchToKeep, anotherBranchToKeep]);
+        gitClient.GetBranchesThatExistLocally([branchToKeep, anotherBranchToKeep]).Should().BeEquivalentTo([branchToKeep, anotherBranchToKeep]);
     }
 
     [Fact]
@@ -103,9 +103,9 @@ public class CleanupStackCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new CleanupStackCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new CleanupStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -121,7 +121,7 @@ public class CleanupStackCommandHandlerTests
         await handler.Handle(CleanupStackCommandInputs.Empty);
 
         // Assert
-        gitOperations.GetBranchesThatExistLocally([branchToKeep, branchToCleanup]).Should().BeEquivalentTo([branchToKeep, branchToCleanup]);
+        gitClient.GetBranchesThatExistLocally([branchToKeep, branchToCleanup]).Should().BeEquivalentTo([branchToKeep, branchToCleanup]);
     }
 
     [Fact]
@@ -140,9 +140,9 @@ public class CleanupStackCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new CleanupStackCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new CleanupStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -176,9 +176,9 @@ public class CleanupStackCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new CleanupStackCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new CleanupStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -212,9 +212,9 @@ public class CleanupStackCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new CleanupStackCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new CleanupStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -249,9 +249,9 @@ public class CleanupStackCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new CleanupStackCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new CleanupStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [

--- a/src/Stack.Tests/Commands/Stack/DeleteStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/DeleteStackCommandHandlerTests.cs
@@ -21,9 +21,9 @@ public class DeleteStackCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new DeleteStackCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new DeleteStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -59,9 +59,9 @@ public class DeleteStackCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new DeleteStackCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new DeleteStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -98,9 +98,9 @@ public class DeleteStackCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new DeleteStackCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new DeleteStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -137,9 +137,9 @@ public class DeleteStackCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new DeleteStackCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new DeleteStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -176,9 +176,9 @@ public class DeleteStackCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new DeleteStackCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new DeleteStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -213,9 +213,9 @@ public class DeleteStackCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new DeleteStackCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new DeleteStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -252,9 +252,9 @@ public class DeleteStackCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new DeleteStackCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new DeleteStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [
@@ -280,7 +280,7 @@ public class DeleteStackCommandHandlerTests
         {
             new("Stack2", repo.RemoteUri, sourceBranch, [])
         });
-        gitOperations.GetBranchesThatExistLocally([branchToCleanup, branchToKeep]).Should().BeEquivalentTo([branchToKeep]);
+        gitClient.GetBranchesThatExistLocally([branchToCleanup, branchToKeep]).Should().BeEquivalentTo([branchToKeep]);
     }
 
     [Fact]
@@ -293,9 +293,9 @@ public class DeleteStackCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new DeleteStackCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new DeleteStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stacks = new List<Config.Stack>(
         [

--- a/src/Stack.Tests/Commands/Stack/NewStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/NewStackCommandHandlerTests.cs
@@ -24,9 +24,9 @@ public class NewStackCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new NewStackCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var handler = new NewStackCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>();
         stackConfig.Load().Returns(stacks);
@@ -51,7 +51,7 @@ public class NewStackCommandHandlerTests
             new("Stack1", repo.RemoteUri, sourceBranch, [newBranch])
         });
 
-        gitOperations.GetCurrentBranch().Should().Be(newBranch);
+        gitClient.GetCurrentBranch().Should().Be(newBranch);
         repo.GetBranches().Should().Contain(b => b.FriendlyName == newBranch && !b.IsTracking);
     }
 
@@ -69,9 +69,9 @@ public class NewStackCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new NewStackCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var handler = new NewStackCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>();
         stackConfig.Load().Returns(stacks);
@@ -96,7 +96,7 @@ public class NewStackCommandHandlerTests
             new("Stack1", repo.RemoteUri, sourceBranch, [existingBranch])
         });
 
-        gitOperations.GetCurrentBranch().Should().Be(existingBranch);
+        gitClient.GetCurrentBranch().Should().Be(existingBranch);
     }
 
     [Fact]
@@ -113,11 +113,11 @@ public class NewStackCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new NewStackCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var handler = new NewStackCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
-        gitOperations.ChangeBranch(existingBranch);
+        gitClient.ChangeBranch(existingBranch);
 
         var stacks = new List<Config.Stack>();
         stackConfig.Load().Returns(stacks);
@@ -140,7 +140,7 @@ public class NewStackCommandHandlerTests
             new("Stack1", repo.RemoteUri, sourceBranch, [])
         });
 
-        gitOperations.GetCurrentBranch().Should().Be(existingBranch);
+        gitClient.GetCurrentBranch().Should().Be(existingBranch);
     }
 
     [Fact]
@@ -156,11 +156,11 @@ public class NewStackCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new NewStackCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var handler = new NewStackCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
-        gitOperations.ChangeBranch(sourceBranch);
+        gitClient.ChangeBranch(sourceBranch);
 
         var stacks = new List<Config.Stack>();
         stackConfig.Load().Returns(stacks);
@@ -186,7 +186,7 @@ public class NewStackCommandHandlerTests
             new("Stack1", repo.RemoteUri, sourceBranch, [newBranch])
         });
 
-        gitOperations.GetCurrentBranch().Should().Be(sourceBranch);
+        gitClient.GetCurrentBranch().Should().Be(sourceBranch);
     }
 
     [Fact]
@@ -203,11 +203,11 @@ public class NewStackCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new NewStackCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var handler = new NewStackCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
-        gitOperations.ChangeBranch(sourceBranch);
+        gitClient.ChangeBranch(sourceBranch);
 
         var stacks = new List<Config.Stack>();
         stackConfig.Load().Returns(stacks);
@@ -232,7 +232,7 @@ public class NewStackCommandHandlerTests
             new("Stack1", repo.RemoteUri, sourceBranch, [existingBranch])
         });
 
-        gitOperations.GetCurrentBranch().Should().Be(sourceBranch);
+        gitClient.GetCurrentBranch().Should().Be(sourceBranch);
     }
 
     [Fact]
@@ -247,9 +247,9 @@ public class NewStackCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new NewStackCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var handler = new NewStackCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>();
         stackConfig.Load().Returns(stacks);
@@ -287,9 +287,9 @@ public class NewStackCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new NewStackCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var handler = new NewStackCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>();
         stackConfig.Load().Returns(stacks);
@@ -328,9 +328,9 @@ public class NewStackCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new NewStackCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var handler = new NewStackCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>();
         stackConfig.Load().Returns(stacks);
@@ -373,9 +373,9 @@ public class NewStackCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new NewStackCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var handler = new NewStackCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>();
         stackConfig.Load().Returns(stacks);
@@ -411,9 +411,9 @@ public class NewStackCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new NewStackCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var handler = new NewStackCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>();
         stackConfig.Load().Returns(stacks);
@@ -438,7 +438,7 @@ public class NewStackCommandHandlerTests
             new("A stack with multiple words", repo.RemoteUri, sourceBranch, [newBranch])
         });
 
-        gitOperations.GetCurrentBranch().Should().Be(newBranch);
+        gitClient.GetCurrentBranch().Should().Be(newBranch);
     }
 
     [Fact]
@@ -454,9 +454,9 @@ public class NewStackCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new NewStackCommandHandler(inputProvider, outputProvider, gitOperations, stackConfig);
+        var handler = new NewStackCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
 
         var stacks = new List<Config.Stack>();
         stackConfig.Load().Returns(stacks);

--- a/src/Stack.Tests/Commands/Stack/StackStatusCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/StackStatusCommandHandlerTests.cs
@@ -32,9 +32,9 @@ public class StackStatusCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new StackStatusCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new StackStatusCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
         var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, []);
@@ -92,9 +92,9 @@ public class StackStatusCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new StackStatusCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new StackStatusCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
         var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, []);
@@ -156,9 +156,9 @@ public class StackStatusCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new StackStatusCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new StackStatusCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
         var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, [branch3]);
@@ -225,9 +225,9 @@ public class StackStatusCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new StackStatusCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new StackStatusCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
         var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, [branch3]);
@@ -290,9 +290,9 @@ public class StackStatusCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new StackStatusCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new StackStatusCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [aBranch, aSecondBranch]);
         var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, [aThirdBranch]);
@@ -328,9 +328,9 @@ public class StackStatusCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new StackStatusCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new StackStatusCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
         var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, [branch3]);
@@ -385,9 +385,9 @@ public class StackStatusCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new StackStatusCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new StackStatusCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
         var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, [branch3]);
@@ -444,9 +444,9 @@ public class StackStatusCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new StackStatusCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new StackStatusCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
         var stacks = new List<Config.Stack>([stack1]);

--- a/src/Stack.Tests/Commands/Stack/StackSwitchCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/StackSwitchCommandHandlerTests.cs
@@ -26,10 +26,10 @@ public class StackSwitchCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new StackSwitchCommandHandler(inputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new StackSwitchCommandHandler(inputProvider, gitClient, stackConfig);
 
-        gitOperations.ChangeBranch(sourceBranch);
+        gitClient.ChangeBranch(sourceBranch);
 
         var stacks = new List<Config.Stack>(
         [
@@ -44,7 +44,7 @@ public class StackSwitchCommandHandlerTests
         await handler.Handle(new StackSwitchCommandInputs(null));
 
         // Assert
-        gitOperations.GetCurrentBranch().Should().Be(branchToSwitchTo);
+        gitClient.GetCurrentBranch().Should().Be(branchToSwitchTo);
     }
 
     [Fact]
@@ -62,10 +62,10 @@ public class StackSwitchCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new StackSwitchCommandHandler(inputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new StackSwitchCommandHandler(inputProvider, gitClient, stackConfig);
 
-        gitOperations.ChangeBranch(sourceBranch);
+        gitClient.ChangeBranch(sourceBranch);
 
         var stacks = new List<Config.Stack>(
         [
@@ -78,7 +78,7 @@ public class StackSwitchCommandHandlerTests
         await handler.Handle(new StackSwitchCommandInputs(branchToSwitchTo));
 
         // Assert
-        gitOperations.GetCurrentBranch().Should().Be(branchToSwitchTo);
+        gitClient.GetCurrentBranch().Should().Be(branchToSwitchTo);
         inputProvider.ReceivedCalls().Should().BeEmpty();
     }
 
@@ -97,10 +97,10 @@ public class StackSwitchCommandHandlerTests
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
-        var handler = new StackSwitchCommandHandler(inputProvider, gitOperations, stackConfig);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new StackSwitchCommandHandler(inputProvider, gitClient, stackConfig);
 
-        gitOperations.ChangeBranch(sourceBranch);
+        gitClient.ChangeBranch(sourceBranch);
 
         var stacks = new List<Config.Stack>(
         [

--- a/src/Stack.Tests/Commands/Stack/UpdateStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/UpdateStackCommandHandlerTests.cs
@@ -33,9 +33,9 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = new TestOutputProvider(testOutputHelper);
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new UpdateStackCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new UpdateStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
         var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, []);
@@ -72,9 +72,9 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = new TestOutputProvider(testOutputHelper);
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new UpdateStackCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new UpdateStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
         var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, []);
@@ -109,9 +109,9 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = new TestOutputProvider(testOutputHelper);
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new UpdateStackCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new UpdateStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
         var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, []);
@@ -150,9 +150,9 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = new TestOutputProvider(testOutputHelper);
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new UpdateStackCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new UpdateStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
         var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, []);
@@ -190,9 +190,9 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = new TestOutputProvider(testOutputHelper);
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new UpdateStackCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new UpdateStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
         var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, []);
@@ -227,12 +227,12 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = new TestOutputProvider(testOutputHelper);
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new UpdateStackCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new UpdateStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         // We are on a specific branch in the stack
-        gitOperations.ChangeBranch(branch1);
+        gitClient.ChangeBranch(branch1);
 
         var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
         var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, []);
@@ -248,7 +248,7 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         repo.GetCommitsReachableFromBranch(branch1).Should().Contain(tipOfSourceBranch);
         repo.GetCommitsReachableFromBranch(branch2).Should().Contain(tipOfSourceBranch);
         repo.GetCommitsReachableFromBranch(branch2).Should().Contain(tipOfBranch1);
-        gitOperations.GetCurrentBranch().Should().Be(branch1);
+        gitClient.GetCurrentBranch().Should().Be(branch1);
     }
 
     [Fact]
@@ -272,9 +272,9 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = new TestOutputProvider(testOutputHelper);
-        var gitOperations = new GitOperations(outputProvider, repo.GitOperationSettings);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var gitHubOperations = Substitute.For<IGitHubOperations>();
-        var handler = new UpdateStackCommandHandler(inputProvider, outputProvider, gitOperations, gitHubOperations, stackConfig);
+        var handler = new UpdateStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubOperations, stackConfig);
 
         var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
         var stacks = new List<Config.Stack>([stack1]);

--- a/src/Stack.Tests/Helpers/TestGitRepositoryBuilder.cs
+++ b/src/Stack.Tests/Helpers/TestGitRepositoryBuilder.cs
@@ -271,7 +271,7 @@ public class TestGitRepositoryBuilder
 public class TestGitRepository(TemporaryDirectory LocalDirectory, TemporaryDirectory RemoteDirectory, Repository LocalRepository) : IDisposable
 {
     public string RemoteUri => RemoteDirectory.DirectoryPath;
-    public GitOperationSettings GitOperationSettings => new GitOperationSettings(false, true, LocalDirectory.DirectoryPath);
+    public GitClientSettings GitClientSettings => new GitClientSettings(false, true, LocalDirectory.DirectoryPath);
 
     public LibGit2Sharp.Commit GetTipOfBranch(string branchName)
     {

--- a/src/Stack/Commands/Branch/AddBranchCommand.cs
+++ b/src/Stack/Commands/Branch/AddBranchCommand.cs
@@ -31,7 +31,7 @@ public class AddBranchCommand : AsyncCommand<AddBranchCommandSettings>
         var handler = new AddBranchCommandHandler(
             new ConsoleInputProvider(console),
             outputProvider,
-            new GitOperations(outputProvider, settings.GetGitOperationSettings()),
+            new GitClient(outputProvider, settings.GetGitClientSettings()),
             new StackConfig());
 
         await handler.Handle(new AddBranchCommandInputs(settings.Stack, settings.Name));
@@ -50,16 +50,16 @@ public record AddBranchCommandResponse();
 public class AddBranchCommandHandler(
     IInputProvider inputProvider,
     IOutputProvider outputProvider,
-    IGitOperations gitOperations,
+    IGitClient gitClient,
     IStackConfig stackConfig)
 {
     public async Task<AddBranchCommandResponse> Handle(AddBranchCommandInputs inputs)
     {
         await Task.CompletedTask;
 
-        var remoteUri = gitOperations.GetRemoteUri();
-        var currentBranch = gitOperations.GetCurrentBranch();
-        var branches = gitOperations.GetLocalBranchesOrderedByMostRecentCommitterDate();
+        var remoteUri = gitClient.GetRemoteUri();
+        var currentBranch = gitClient.GetCurrentBranch();
+        var branches = gitClient.GetLocalBranchesOrderedByMostRecentCommitterDate();
 
         var stacks = stackConfig.Load();
 
@@ -86,7 +86,7 @@ public class AddBranchCommandHandler(
             throw new InvalidOperationException($"Branch '{branchName}' already exists in stack '{stack.Name}'.");
         }
 
-        if (!gitOperations.DoesLocalBranchExist(branchName))
+        if (!gitClient.DoesLocalBranchExist(branchName))
         {
             throw new InvalidOperationException($"Branch '{branchName}' does not exist locally.");
         }

--- a/src/Stack/Commands/Branch/RemoveBranchCommand.cs
+++ b/src/Stack/Commands/Branch/RemoveBranchCommand.cs
@@ -35,7 +35,7 @@ public class RemoveBranchCommand : AsyncCommand<RemoveBranchCommandSettings>
         var handler = new RemoveBranchCommandHandler(
             new ConsoleInputProvider(console),
             outputProvider,
-            new GitOperations(outputProvider, settings.GetGitOperationSettings()),
+            new GitClient(outputProvider, settings.GetGitClientSettings()),
             new StackConfig());
 
         await handler.Handle(new RemoveBranchCommandInputs(settings.Stack, settings.Name, settings.Force));
@@ -54,7 +54,7 @@ public record RemoveBranchCommandResponse();
 public class RemoveBranchCommandHandler(
     IInputProvider inputProvider,
     IOutputProvider outputProvider,
-    IGitOperations gitOperations,
+    IGitClient gitClient,
     IStackConfig stackConfig)
 {
     public async Task<RemoveBranchCommandResponse> Handle(RemoveBranchCommandInputs inputs)
@@ -62,8 +62,8 @@ public class RemoveBranchCommandHandler(
         await Task.CompletedTask;
         var stacks = stackConfig.Load();
 
-        var remoteUri = gitOperations.GetRemoteUri();
-        var currentBranch = gitOperations.GetCurrentBranch();
+        var remoteUri = gitClient.GetRemoteUri();
+        var currentBranch = gitClient.GetCurrentBranch();
 
         var stacksForRemote = stacks.Where(s => s.RemoteUri.Equals(remoteUri, StringComparison.OrdinalIgnoreCase)).ToList();
         var stack = inputProvider.SelectStack(outputProvider, inputs.StackName, stacksForRemote, currentBranch);

--- a/src/Stack/Commands/Helpers/CommandSettingsBase.cs
+++ b/src/Stack/Commands/Helpers/CommandSettingsBase.cs
@@ -15,6 +15,6 @@ public class CommandSettingsBase : CommandSettings
     [CommandOption("--working-dir")]
     public string? WorkingDirectory { get; init; }
 
-    public virtual GitOperationSettings GetGitOperationSettings() => new(false, Verbose, WorkingDirectory);
+    public virtual GitClientSettings GetGitClientSettings() => new(false, Verbose, WorkingDirectory);
     public virtual GitHubOperationSettings GetGitHubOperationSettings() => new(false, Verbose, WorkingDirectory);
 }

--- a/src/Stack/Commands/Helpers/DryRunCommandSettingsBase.cs
+++ b/src/Stack/Commands/Helpers/DryRunCommandSettingsBase.cs
@@ -12,7 +12,7 @@ public class DryRunCommandSettingsBase : CommandSettingsBase
     [DefaultValue(false)]
     public bool DryRun { get; init; }
 
-    public override GitOperationSettings GetGitOperationSettings() => new(DryRun, Verbose, WorkingDirectory);
+    public override GitClientSettings GetGitClientSettings() => new(DryRun, Verbose, WorkingDirectory);
 
     public override GitHubOperationSettings GetGitHubOperationSettings() => new(DryRun, Verbose, WorkingDirectory);
 }

--- a/src/Stack/Commands/PullRequests/OpenPullRequestsCommand.cs
+++ b/src/Stack/Commands/PullRequests/OpenPullRequestsCommand.cs
@@ -25,7 +25,7 @@ public class OpenPullRequestsCommand : AsyncCommand<OpenPullRequestsCommandSetti
         var handler = new OpenPullRequestsCommandHandler(
             new ConsoleInputProvider(console),
             outputProvider,
-            new GitOperations(outputProvider, settings.GetGitOperationSettings()),
+            new GitClient(outputProvider, settings.GetGitClientSettings()),
             new GitHubOperations(outputProvider, settings.GetGitHubOperationSettings()),
             new StackConfig());
 
@@ -45,7 +45,7 @@ public record OpenPullRequestsCommandResponse();
 public class OpenPullRequestsCommandHandler(
     IInputProvider inputProvider,
     IOutputProvider outputProvider,
-    IGitOperations gitOperations,
+    IGitClient gitClient,
     IGitHubOperations gitHubOperations,
     IStackConfig stackConfig)
 {
@@ -54,7 +54,7 @@ public class OpenPullRequestsCommandHandler(
         await Task.CompletedTask;
         var stacks = stackConfig.Load();
 
-        var remoteUri = gitOperations.GetRemoteUri();
+        var remoteUri = gitClient.GetRemoteUri();
 
         var stacksForRemote = stacks.Where(s => s.RemoteUri.Equals(remoteUri, StringComparison.OrdinalIgnoreCase)).ToList();
 
@@ -64,7 +64,7 @@ public class OpenPullRequestsCommandHandler(
             return new OpenPullRequestsCommandResponse();
         }
 
-        var currentBranch = gitOperations.GetCurrentBranch();
+        var currentBranch = gitClient.GetCurrentBranch();
         var stack = inputProvider.SelectStack(outputProvider, inputs.StackName, stacksForRemote, currentBranch);
 
         if (stack is null)

--- a/src/Stack/Commands/Stack/ListStacksCommand.cs
+++ b/src/Stack/Commands/Stack/ListStacksCommand.cs
@@ -16,12 +16,12 @@ public class ListStacksCommand : AsyncCommand<ListStacksCommandSettings>
         await Task.CompletedTask;
         var console = AnsiConsole.Console;
         var outputProvider = new ConsoleOutputProvider(console);
-        var gitOperations = new GitOperations(outputProvider, settings.GetGitOperationSettings());
+        var gitClient = new GitClient(outputProvider, settings.GetGitClientSettings());
         var stackConfig = new StackConfig();
 
         var stacks = stackConfig.Load();
 
-        var remoteUri = gitOperations.GetRemoteUri();
+        var remoteUri = gitClient.GetRemoteUri();
 
         if (remoteUri is null)
         {

--- a/src/Stack/Commands/Stack/StackStatusCommand.cs
+++ b/src/Stack/Commands/Stack/StackStatusCommand.cs
@@ -33,7 +33,7 @@ public class StackStatusCommand : AsyncCommand<StackStatusCommandSettings>
         var handler = new StackStatusCommandHandler(
             new ConsoleInputProvider(console),
             outputProvider,
-            new GitOperations(outputProvider, settings.GetGitOperationSettings()),
+            new GitClient(outputProvider, settings.GetGitClientSettings()),
             new GitHubOperations(outputProvider, settings.GetGitHubOperationSettings()),
             new StackConfig());
 
@@ -49,7 +49,7 @@ public record StackStatusCommandResponse(Dictionary<Config.Stack, StackStatus> S
 public class StackStatusCommandHandler(
     IInputProvider inputProvider,
     IOutputProvider outputProvider,
-    IGitOperations gitOperations,
+    IGitClient gitClient,
     IGitHubOperations gitHubOperations,
     IStackConfig stackConfig)
 {
@@ -58,9 +58,9 @@ public class StackStatusCommandHandler(
         await Task.CompletedTask;
         var stacks = stackConfig.Load();
 
-        var remoteUri = gitOperations.GetRemoteUri();
+        var remoteUri = gitClient.GetRemoteUri();
         var stacksForRemote = stacks.Where(s => s.RemoteUri.Equals(remoteUri, StringComparison.OrdinalIgnoreCase)).ToList();
-        var currentBranch = gitOperations.GetCurrentBranch();
+        var currentBranch = gitClient.GetCurrentBranch();
 
         var stacksToCheckStatusFor = new List<Config.Stack>();
 
@@ -84,7 +84,7 @@ public class StackStatusCommandHandler(
             stacksToCheckStatusFor,
             currentBranch,
             outputProvider,
-            gitOperations,
+            gitClient,
             gitHubOperations,
             inputs.Full);
 

--- a/src/Stack/Git/GitClient.cs
+++ b/src/Stack/Git/GitClient.cs
@@ -1,21 +1,20 @@
 using System.Diagnostics;
 using System.Text;
-using System.Text.RegularExpressions;
 using Octopus.Shellfish;
 using Stack.Infrastructure;
 
 namespace Stack.Git;
 
-public record GitOperationSettings(bool DryRun, bool Verbose, string? WorkingDirectory)
+public record GitClientSettings(bool DryRun, bool Verbose, string? WorkingDirectory)
 {
-    public static GitOperationSettings Default => new(false, false, null);
+    public static GitClientSettings Default => new(false, false, null);
 }
 
 public record Commit(string Sha, string Message);
 
 public record GitBranchStatus(string BranchName, string? RemoteTrackingBranchName, bool RemoteBranchExists, bool IsCurrentBranch, int Ahead, int Behind, Commit Tip);
 
-public interface IGitOperations
+public interface IGitClient
 {
     void CreateNewBranch(string branchName, string sourceBranch);
     void PushNewBranch(string branchName);
@@ -44,7 +43,7 @@ public interface IGitOperations
     void OpenFileInEditorAndWaitForClose(string path);
 }
 
-public class GitOperations(IOutputProvider outputProvider, GitOperationSettings settings) : IGitOperations
+public class GitClient(IOutputProvider outputProvider, GitClientSettings settings) : IGitClient
 {
     public void CreateNewBranch(string branchName, string sourceBranch)
     {


### PR DESCRIPTION
<!-- stack-pr-list -->
This PR is part of a series doing some internal renaming and cleanup for clarity

- https://github.com/geofflamrock/stack/pull/171
- https://github.com/geofflamrock/stack/pull/172
<!-- /stack-pr-list -->

This PR renames `IGitOperations` to `IGitClient` to better reflect that we are operating on the Git client.
