### PR TITLE
Fixes issue with pulling branch that doesn't exist locally

### DIFF
--- a/src/Stack/Commands/Helpers/StackHelpers.cs
+++ b/src/Stack/Commands/Helpers/StackHelpers.cs
@@ -356,7 +356,7 @@ public static class StackHelpers
         List<string> allBranchesInStacks = [stack.SourceBranch, .. stack.Branches];
         var branchStatus = gitClient.GetBranchStatuses([.. allBranchesInStacks]);
 
-        foreach (var branch in allBranchesInStacks.Where(b => branchStatus[b].RemoteBranchExists))
+        foreach (var branch in allBranchesInStacks.Where(b => branchStatus.ContainsKey(b) && branchStatus[b].RemoteBranchExists))
         {
             outputProvider.Information($"Pulling changes for {branch.Branch()} from remote");
             gitClient.ChangeBranch(branch);


### PR DESCRIPTION
This PR fixes an issue where pulling changes using `stack pull` would fail with error `The given key '' was not present in the dictionary` if a branch doesn't exist locally.