### PR TITLE
Improves merge conflict handling

### DIFF
--- a/src/Stack.Tests/Commands/Helpers/StackHelpersTests.cs
+++ b/src/Stack.Tests/Commands/Helpers/StackHelpersTests.cs
@@ -1,0 +1,119 @@
+using FluentAssertions;
+using NSubstitute;
+using Stack.Commands.Helpers;
+using Stack.Git;
+using Stack.Infrastructure;
+using Xunit.Abstractions;
+
+namespace Stack.Tests.Helpers;
+
+public class StackHelpersTests(ITestOutputHelper testOutputHelper)
+{
+    [Fact]
+    public void UpdateStack_WhenThereAreConflictsMergingBranches_AndUpdateIsContinued_TheUpdateCompletesSuccessfully()
+    {
+        // Arrange
+        var sourceBranch = Some.BranchName();
+        var branch1 = Some.BranchName();
+        var branch2 = Some.BranchName();
+
+        var outputProvider = new TestOutputProvider(testOutputHelper);
+        var gitClient = Substitute.For<IGitClient>();
+        var inputProvider = Substitute.For<IInputProvider>();
+
+        var stack = new Config.Stack("Stack1", Some.HttpsUri().ToString(), sourceBranch, [branch1, branch2]);
+        var branchDetail1 = new BranchDetail
+        {
+            Status = new BranchStatus(true, true, true, false, 0, 0, 0, 0, null)
+        };
+        var branchDetail2 = new BranchDetail
+        {
+            Status = new BranchStatus(true, true, true, false, 0, 0, 0, 0, null)
+        };
+
+        var stackStatus = new StackStatus(new Dictionary<string, BranchDetail>
+        {
+            { branch1, branchDetail1 },
+            { branch2, branchDetail2 },
+        });
+
+        inputProvider
+            .Select(
+                Arg.Any<string>(),
+                Arg.Any<MergeConflictAction[]>(),
+                Arg.Any<Func<MergeConflictAction, string>>())
+            .Returns(MergeConflictAction.Continue);
+
+        gitClient
+            .When(g => g.MergeFromLocalSourceBranch(sourceBranch))
+            .Throws(new MergeConflictException());
+
+        // Act
+        StackHelpers.UpdateStack(
+            stack,
+            stackStatus,
+            gitClient,
+            inputProvider,
+            outputProvider
+        );
+
+        // Assert
+        gitClient.Received().ChangeBranch(branch2);
+        gitClient.Received().MergeFromLocalSourceBranch(branch1);
+    }
+
+    [Fact]
+    public void UpdateStack_WhenThereAreConflictsMergingBranches_AndUpdateIsAborted_AnExceptionIsThrown()
+    {
+        // Arrange
+        var sourceBranch = Some.BranchName();
+        var branch1 = Some.BranchName();
+        var branch2 = Some.BranchName();
+
+        var inputProvider = Substitute.For<IInputProvider>();
+        var gitClient = Substitute.For<IGitClient>();
+        var outputProvider = new TestOutputProvider(testOutputHelper);
+
+        var stack = new Config.Stack("Stack1", Some.HttpsUri().ToString(), sourceBranch, [branch1, branch2]);
+        var branchDetail1 = new BranchDetail
+        {
+            Status = new BranchStatus(true, true, true, false, 0, 0, 0, 0, null)
+        };
+        var branchDetail2 = new BranchDetail
+        {
+            Status = new BranchStatus(true, true, true, false, 0, 0, 0, 0, null)
+        };
+
+        var stackStatus = new StackStatus(new Dictionary<string, BranchDetail>
+        {
+            { branch1, branchDetail1 },
+            { branch2, branchDetail2 },
+        });
+
+        gitClient
+            .When(g => g.MergeFromLocalSourceBranch(sourceBranch))
+            .Throws(new MergeConflictException());
+
+        inputProvider
+            .Select(
+                Arg.Any<string>(),
+                Arg.Any<MergeConflictAction[]>(),
+                Arg.Any<Func<MergeConflictAction, string>>())
+            .Returns(MergeConflictAction.Abort);
+
+        // Act
+        var updateAction = () => StackHelpers.UpdateStack(
+            stack,
+            stackStatus,
+            gitClient,
+            inputProvider,
+            outputProvider
+        );
+
+        // Assert
+        updateAction.Should().Throw<Exception>().WithMessage("Merge aborted due to conflicts.");
+        gitClient.Received().AbortMerge();
+        gitClient.DidNotReceive().ChangeBranch(branch2);
+        gitClient.DidNotReceive().MergeFromLocalSourceBranch(branch1);
+    }
+}

--- a/src/Stack.Tests/Commands/Helpers/StackHelpersTests.cs
+++ b/src/Stack.Tests/Commands/Helpers/StackHelpersTests.cs
@@ -39,7 +39,7 @@ public class StackHelpersTests(ITestOutputHelper testOutputHelper)
 
         inputProvider
             .Select(
-                Arg.Any<string>(),
+                Questions.ContinueOrAbortMerge,
                 Arg.Any<MergeConflictAction[]>(),
                 Arg.Any<Func<MergeConflictAction, string>>())
             .Returns(MergeConflictAction.Continue);
@@ -96,7 +96,7 @@ public class StackHelpersTests(ITestOutputHelper testOutputHelper)
 
         inputProvider
             .Select(
-                Arg.Any<string>(),
+                Questions.ContinueOrAbortMerge,
                 Arg.Any<MergeConflictAction[]>(),
                 Arg.Any<Func<MergeConflictAction, string>>())
             .Returns(MergeConflictAction.Abort);

--- a/src/Stack.Tests/Git/GitClientTests.cs
+++ b/src/Stack.Tests/Git/GitClientTests.cs
@@ -18,19 +18,20 @@ public class GitClientTests(ITestOutputHelper testOutputHelper)
             .WithBranch(builder => builder.WithName(branch2).FromSourceBranch(branch1))
             .Build();
 
-        var filePath = Path.Join(repo.LocalDirectoryPath, Some.Name());
+        var relativeFilePath = Some.Name();
+        var filePath = Path.Join(repo.LocalDirectoryPath, relativeFilePath);
 
         var outputProvider = new TestOutputProvider(testOutputHelper);
         var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
 
         gitClient.ChangeBranch(branch1);
         File.WriteAllText(filePath, Some.Name());
-        repo.Stage(filePath);
+        repo.Stage(relativeFilePath);
         repo.Commit();
 
         gitClient.ChangeBranch(branch2);
         File.WriteAllText(filePath, Some.Name());
-        repo.Stage(filePath);
+        repo.Stage(relativeFilePath);
         repo.Commit();
 
         // Act

--- a/src/Stack.Tests/Git/GitClientTests.cs
+++ b/src/Stack.Tests/Git/GitClientTests.cs
@@ -41,4 +41,42 @@ public class GitClientTests(ITestOutputHelper testOutputHelper)
         // Assert
         merge.Should().Throw<MergeConflictException>();
     }
+
+    [Fact]
+    public void MergeFromLocalSourceBranch_WhenConflictsDoNotOccur_DoesNotThrow()
+    {
+        // Arrange
+        var branch1 = Some.BranchName();
+        var branch2 = Some.BranchName();
+        using var repo = new TestGitRepositoryBuilder()
+            .WithBranch(builder => builder.WithName(branch1))
+            .WithBranch(builder => builder.WithName(branch2).FromSourceBranch(branch1))
+            .Build();
+
+        var outputProvider = new TestOutputProvider(testOutputHelper);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+
+        var relativeFilePath1 = Some.Name();
+        var filePath1 = Path.Join(repo.LocalDirectoryPath, relativeFilePath1);
+
+        gitClient.ChangeBranch(branch1);
+        File.WriteAllText(filePath1, Some.Name());
+        repo.Stage(relativeFilePath1);
+        repo.Commit();
+
+        var relativeFilePath2 = Some.Name();
+        var filePath2 = Path.Join(repo.LocalDirectoryPath, relativeFilePath2);
+
+        gitClient.ChangeBranch(branch2);
+        File.WriteAllText(filePath2, Some.Name());
+        repo.Stage(relativeFilePath2);
+        repo.Commit();
+
+        // Act
+        gitClient.ChangeBranch(branch1);
+        var merge = () => gitClient.MergeFromLocalSourceBranch(branch2);
+
+        // Assert
+        merge.Should().NotThrow();
+    }
 }

--- a/src/Stack.Tests/Git/GitClientTests.cs
+++ b/src/Stack.Tests/Git/GitClientTests.cs
@@ -1,0 +1,43 @@
+using FluentAssertions;
+using Stack.Git;
+using Stack.Tests.Helpers;
+using Xunit.Abstractions;
+
+namespace Stack.Tests.Git;
+
+public class GitClientTests(ITestOutputHelper testOutputHelper)
+{
+    [Fact]
+    public void MergeFromLocalSourceBranch_WhenConflictsOccur_ThrowsMergeConflictException()
+    {
+        // Arrange
+        var branch1 = Some.BranchName();
+        var branch2 = Some.BranchName();
+        using var repo = new TestGitRepositoryBuilder()
+            .WithBranch(builder => builder.WithName(branch1))
+            .WithBranch(builder => builder.WithName(branch2).FromSourceBranch(branch1))
+            .Build();
+
+        var filePath = Path.Join(repo.LocalDirectoryPath, Some.Name());
+
+        var outputProvider = new TestOutputProvider(testOutputHelper);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+
+        gitClient.ChangeBranch(branch1);
+        File.WriteAllText(filePath, Some.Name());
+        repo.Stage(filePath);
+        repo.Commit();
+
+        gitClient.ChangeBranch(branch2);
+        File.WriteAllText(filePath, Some.Name());
+        repo.Stage(filePath);
+        repo.Commit();
+
+        // Act
+        gitClient.ChangeBranch(branch1);
+        var merge = () => gitClient.MergeFromLocalSourceBranch(branch2);
+
+        // Assert
+        merge.Should().Throw<MergeConflictException>();
+    }
+}

--- a/src/Stack.Tests/Helpers/TestGitRepositoryBuilder.cs
+++ b/src/Stack.Tests/Helpers/TestGitRepositoryBuilder.cs
@@ -271,6 +271,7 @@ public class TestGitRepositoryBuilder
 public class TestGitRepository(TemporaryDirectory LocalDirectory, TemporaryDirectory RemoteDirectory, Repository LocalRepository) : IDisposable
 {
     public string RemoteUri => RemoteDirectory.DirectoryPath;
+    public string LocalDirectoryPath => LocalDirectory.DirectoryPath;
     public GitClientSettings GitClientSettings => new GitClientSettings(false, true, LocalDirectory.DirectoryPath);
 
     public LibGit2Sharp.Commit GetTipOfBranch(string branchName)
@@ -300,6 +301,17 @@ public class TestGitRepository(TemporaryDirectory LocalDirectory, TemporaryDirec
     public List<LibGit2Sharp.Branch> GetBranches()
     {
         return [.. LocalRepository.Branches];
+    }
+
+    public LibGit2Sharp.Commit Commit(string? message = null)
+    {
+        var signature = new Signature(Some.Name(), Some.Name(), DateTimeOffset.Now);
+        return LocalRepository.Commit(message ?? Some.Name(), signature, signature);
+    }
+
+    public void Stage(string path)
+    {
+        LibGit2Sharp.Commands.Stage(LocalRepository, path);
     }
 
     public void Dispose()

--- a/src/Stack/Commands/Helpers/Questions.cs
+++ b/src/Stack/Commands/Helpers/Questions.cs
@@ -24,4 +24,5 @@ public static class Questions
     public const string OpenPullRequests = "Open new pull requests in a browser?";
     public const string CreatePullRequestAsDraft = "Create pull request as draft?";
     public const string EditPullRequestBody = "Edit pull request body? This will open a file in your default editor.";
+    public const string ContinueOrAbortMerge = "Merge conflict(s) detected. Please either resolve the conflicts, commit the result and Continue, or Abort.";
 }

--- a/src/Stack/Commands/Helpers/StackHelpers.cs
+++ b/src/Stack/Commands/Helpers/StackHelpers.cs
@@ -402,7 +402,7 @@ public static class StackHelpers
         catch (MergeConflictException)
         {
             var action = inputProvider.Select(
-                "Merge conflict detected. Please resolve the conflicts, commit any changes if required and select an option below.",
+                Questions.ContinueOrAbortMerge,
                 [MergeConflictAction.Continue, MergeConflictAction.Abort],
                 a => a switch
                 {

--- a/src/Stack/Commands/Helpers/StackHelpers.cs
+++ b/src/Stack/Commands/Helpers/StackHelpers.cs
@@ -324,15 +324,9 @@ public static class StackHelpers
         Config.Stack stack,
         StackStatus status,
         IGitClient gitClient,
+        IInputProvider inputProvider,
         IOutputProvider outputProvider)
     {
-        void MergeFromSourceBranch(string branch, string sourceBranchName)
-        {
-            outputProvider.Information($"Merging {sourceBranchName.Branch()} into {branch.Branch()}");
-            gitClient.ChangeBranch(branch);
-            gitClient.MergeFromLocalSourceBranch(sourceBranchName);
-        }
-
         var sourceBranch = stack.SourceBranch;
 
         foreach (var branch in stack.Branches)
@@ -341,7 +335,7 @@ public static class StackHelpers
 
             if (branchDetail.IsActive)
             {
-                MergeFromSourceBranch(branch, sourceBranch);
+                MergeFromSourceBranch(branch, sourceBranch, gitClient, inputProvider, outputProvider);
                 sourceBranch = branch;
             }
             else
@@ -395,4 +389,39 @@ public static class StackHelpers
             gitClient.PushBranches([.. branches]);
         }
     }
+
+    static void MergeFromSourceBranch(string branch, string sourceBranchName, IGitClient gitClient, IInputProvider inputProvider, IOutputProvider outputProvider)
+    {
+        outputProvider.Information($"Merging {sourceBranchName.Branch()} into {branch.Branch()}");
+        gitClient.ChangeBranch(branch);
+
+        try
+        {
+            gitClient.MergeFromLocalSourceBranch(sourceBranchName);
+        }
+        catch (MergeConflictException)
+        {
+            var action = inputProvider.Select(
+                "Merge conflict detected. Please resolve the conflicts, commit any changes if required and select an option below.",
+                [MergeConflictAction.Continue, MergeConflictAction.Abort],
+                a => a switch
+                {
+                    MergeConflictAction.Continue => "Continue",
+                    MergeConflictAction.Abort => "Abort",
+                    _ => throw new InvalidOperationException("Invalid merge conflict action.")
+                }); ;
+
+            if (action == MergeConflictAction.Abort)
+            {
+                gitClient.AbortMerge();
+                throw new Exception("Merge aborted due to conflicts.");
+            }
+        }
+    }
+}
+
+public enum MergeConflictAction
+{
+    Abort,
+    Continue
 }

--- a/src/Stack/Commands/Remote/SyncStackCommand.cs
+++ b/src/Stack/Commands/Remote/SyncStackCommand.cs
@@ -99,7 +99,7 @@ public class SyncStackCommandHandler(
 
             StackHelpers.PullChanges(stack, gitClient, outputProvider);
 
-            StackHelpers.UpdateStack(stack, status, gitClient, outputProvider);
+            StackHelpers.UpdateStack(stack, status, gitClient, inputProvider, outputProvider);
 
             StackHelpers.PushChanges(stack, inputs.MaxBatchSize, gitClient, outputProvider);
 

--- a/src/Stack/Commands/Stack/UpdateStackCommand.cs
+++ b/src/Stack/Commands/Stack/UpdateStackCommand.cs
@@ -79,7 +79,7 @@ public class UpdateStackCommandHandler(
             gitHubClient,
             false);
 
-        StackHelpers.UpdateStack(stack, status, gitClient, outputProvider);
+        StackHelpers.UpdateStack(stack, status, gitClient, inputProvider, outputProvider);
 
         if (stack.SourceBranch.Equals(currentBranch, StringComparison.InvariantCultureIgnoreCase) ||
             stack.Branches.Contains(currentBranch, StringComparer.OrdinalIgnoreCase))


### PR DESCRIPTION
This PR improves the handling when conflicts occur during merge in `update` and `sync` commands to detect conflicts and ask the user whether they want to continue after resolving the conflicts or abort.