### PR TITLE
Adds support for rebase during update and sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The new branch will be created from the branch at the bottom of the stack and yo
 
 By default new branches are only created locally, you can either use the `--push` option or use the `stack push` command to push the branch to the remote.
 
-### Syncing a stack
+### Syncing a stack with the remote repository
 
 After working on a stack of branches for a while, you might need to incorporate changes that have happened to your source branch from others. To do this:
 
@@ -83,11 +83,27 @@ Branches in the stack will be updated by:
 - Updating branches in order in the stack, the equivalent of running `stack update`.
 - Pushing changes for all branches in the stack, the equivalent of running `stack push`.
 
-#### Rough edges
+### Update strategies
 
-Updating a stack, particularly if it has a number of branches in it, can result in lots of merge commits. I'm exploring whether there are any improvements that can be made here for merging. I'd also like to support updating via a rebase as well in the future.
+There are two strategies that can be used to update branches in a stack.
 
-If you merge a pull request using "Squash and merge" then you might find that the first update to a stack after that results in merge conflicts that you need to resolve. This is a bit of a pain, I'm exploring whether there are any improvements that can be made here, perhaps by first merging into the just-merged local branch instead of ignoring it.
+#### Merge
+
+The default strategy is to merge each branch in the stack into the one directly below it, starting with the source branch.
+
+**Rough edges**
+
+Updating a stack using merge, particularly if it has a number of branches in it, can result in lots of merge commits.
+
+If you merge a pull request using "Squash and merge" then you might find that the first update to a stack after that results in merge conflicts that you need to resolve. This can be a bit of a pain.
+
+#### Rebase
+
+Each branch in the stack can be rebased on it's parent branch by using the `--rebase` option in the `sync` and `update` commands. To push changes to the remote after rebasing you'll need to use the `--force-with-lease` option.
+
+**Rough edges**
+
+If you merge a pull request using "Squash and merge" then you might find that the first update to a stack after that results in merge conflicts that you need to resolve. This can be a bit of a pain, however for each commit that existed on the branch that was merged if you select to take the new single commit that now exists generally it isn't too bad.
 
 ### Creating pull requests for the stack
 
@@ -181,7 +197,7 @@ OPTIONS:
 
 ### `stack update`
 
-Updates the branches for a stack by merging each branch.
+Updates the branches for a stack by either merging or rebasing each branch.
 
 ```shell
 USAGE:
@@ -195,6 +211,7 @@ OPTIONS:
         --dry-run        Show what would happen without making any changes
     -n, --name           The name of the stack to update
     -f, --force          Force the update of the stack
+    --rebase             Use rebase instead of merge when updating the stack
 ```
 
 ### `stack switch`
@@ -341,6 +358,7 @@ OPTIONS:
     -n, --name              The name of the stack to update
     -y, --yes               Don't ask for confirmation before syncing the stack
         --max-batch-size    The maximum number of branches to push changes for at once (default: 5)
+        --rebase            Use rebase instead of merge when updating the stack
 ```
 
 ## GitHub commands

--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ OPTIONS:
         --dry-run             Show what would happen without making any changes
     -n, --name                The name of the stack to push changes from the remote for
         --max-batch-size      The maximum number of branches to push changes for at once (default: 5)
+        --force-with-lease    Force push changes with lease
 ```
 
 ### `stack sync`

--- a/src/Stack.Tests/Commands/Helpers/StackHelpersTests.cs
+++ b/src/Stack.Tests/Commands/Helpers/StackHelpersTests.cs
@@ -46,12 +46,13 @@ public class StackHelpersTests(ITestOutputHelper testOutputHelper)
 
         gitClient
             .When(g => g.MergeFromLocalSourceBranch(sourceBranch))
-            .Throws(new MergeConflictException());
+            .Throws(new ConflictException());
 
         // Act
         StackHelpers.UpdateStack(
             stack,
             stackStatus,
+            UpdateStrategy.Merge,
             gitClient,
             inputProvider,
             outputProvider
@@ -92,7 +93,7 @@ public class StackHelpersTests(ITestOutputHelper testOutputHelper)
 
         gitClient
             .When(g => g.MergeFromLocalSourceBranch(sourceBranch))
-            .Throws(new MergeConflictException());
+            .Throws(new ConflictException());
 
         inputProvider
             .Select(
@@ -105,6 +106,7 @@ public class StackHelpersTests(ITestOutputHelper testOutputHelper)
         var updateAction = () => StackHelpers.UpdateStack(
             stack,
             stackStatus,
+            UpdateStrategy.Merge,
             gitClient,
             inputProvider,
             outputProvider

--- a/src/Stack.Tests/Commands/Remote/PushStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Remote/PushStackCommandHandlerTests.cs
@@ -93,7 +93,7 @@ public class PushStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
 
         // Act
-        await handler.Handle(new PushStackCommandInputs("Stack1", 5));
+        await handler.Handle(new PushStackCommandInputs("Stack1", 5, false));
 
         // Assert
         repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfBranch1);
@@ -139,7 +139,7 @@ public class PushStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
 
         // Act and assert
         var invalidStackName = Some.Name();
-        await handler.Invoking(async h => await h.Handle(new PushStackCommandInputs(invalidStackName, 5)))
+        await handler.Invoking(async h => await h.Handle(new PushStackCommandInputs(invalidStackName, 5, false)))
             .Should().ThrowAsync<InvalidOperationException>()
             .WithMessage($"Stack '{invalidStackName}' not found.");
     }
@@ -224,7 +224,7 @@ public class PushStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
 
         // Act
-        await handler.Handle(new PushStackCommandInputs(null, 1));
+        await handler.Handle(new PushStackCommandInputs(null, 1, false));
 
         // Assert
         repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfBranch1);

--- a/src/Stack.Tests/Commands/Remote/SyncStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Remote/SyncStackCommandHandlerTests.cs
@@ -47,7 +47,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Confirm(Questions.ConfirmSyncStack).Returns(true);
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs(null, false, 5));
+        await handler.Handle(new SyncStackCommandInputs(null, false, 5, false));
 
         // Assert
         repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfRemoteSourceBranch);
@@ -88,7 +88,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Confirm(Questions.ConfirmSyncStack).Returns(true);
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs("Stack1", false, 5));
+        await handler.Handle(new SyncStackCommandInputs("Stack1", false, 5, false));
 
         // Assert
         repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfRemoteSourceBranch);
@@ -130,7 +130,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs(null, true, 5));
+        await handler.Handle(new SyncStackCommandInputs(null, true, 5, false));
 
         // Assert
         repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfRemoteSourceBranch);
@@ -171,7 +171,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
 
         // Act and assert
         var invalidStackName = Some.Name();
-        await handler.Invoking(async h => await h.Handle(new SyncStackCommandInputs(invalidStackName, false, 5)))
+        await handler.Invoking(async h => await h.Handle(new SyncStackCommandInputs(invalidStackName, false, 5, false)))
             .Should().ThrowAsync<InvalidOperationException>()
             .WithMessage($"Stack '{invalidStackName}' not found.");
     }
@@ -212,7 +212,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Confirm(Questions.ConfirmSyncStack).Returns(true);
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs(null, false, 5));
+        await handler.Handle(new SyncStackCommandInputs(null, false, 5, false));
 
         // Assert
         repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfRemoteSourceBranch);
@@ -253,7 +253,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Confirm(Questions.ConfirmSyncStack).Returns(true);
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs(null, false, 5));
+        await handler.Handle(new SyncStackCommandInputs(null, false, 5, false));
 
         // Assert
         repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfRemoteSourceBranch);

--- a/src/Stack.Tests/Commands/Remote/SyncStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Remote/SyncStackCommandHandlerTests.cs
@@ -262,4 +262,49 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
 
         inputProvider.DidNotReceive().Select(Questions.SelectStack, Arg.Any<string[]>());
     }
+
+    [Fact]
+    public async Task WhenUsingRebase_ChangesExistOnTheSourceBranchOnTheRemote_PullsChanges_UpdatesBranches_AndPushesToRemote()
+    {
+        // Arrange
+        var sourceBranch = Some.BranchName();
+        var branch1 = Some.BranchName();
+        var branch2 = Some.BranchName();
+        using var repo = new TestGitRepositoryBuilder()
+            .WithBranch(builder => builder.WithName(sourceBranch).PushToRemote())
+            .WithBranch(builder => builder.WithName(branch1).FromSourceBranch(sourceBranch).WithNumberOfEmptyCommits(10).PushToRemote())
+            .WithBranch(builder => builder.WithName(branch2).FromSourceBranch(branch1).WithNumberOfEmptyCommits(1).PushToRemote())
+            .WithNumberOfEmptyCommitsOnRemoteTrackingBranchOf(sourceBranch, 5, b => b.PushToRemote())
+            .WithNumberOfEmptyCommits(b => b.OnBranch(branch1), 3)
+            .Build();
+
+        var tipOfRemoteSourceBranch = repo.GetTipOfRemoteBranch(sourceBranch);
+        repo.GetCommitsReachableFromBranch(sourceBranch).Should().NotContain(tipOfRemoteSourceBranch);
+
+        var stackConfig = Substitute.For<IStackConfig>();
+        var inputProvider = Substitute.For<IInputProvider>();
+        var outputProvider = new TestOutputProvider(testOutputHelper);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var gitHubClient = Substitute.For<IGitHubClient>();
+        var handler = new SyncStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, stackConfig);
+
+        gitClient.ChangeBranch(branch1);
+
+        var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
+        var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, []);
+        var stacks = new List<Config.Stack>([stack1, stack2]);
+        stackConfig.Load().Returns(stacks);
+
+        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
+        inputProvider.Confirm(Questions.ConfirmSyncStack).Returns(true);
+
+        // Act
+        await handler.Handle(new SyncStackCommandInputs(null, false, 5, true));
+
+        // Assert
+        var tipOfBranch1 = repo.GetTipOfBranch(branch1);
+        repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfRemoteSourceBranch);
+        repo.GetCommitsReachableFromRemoteBranch(branch2).Should().Contain(tipOfRemoteSourceBranch);
+        repo.GetCommitsReachableFromRemoteBranch(branch2).Should().Contain(tipOfBranch1);
+    }
 }

--- a/src/Stack.Tests/Commands/Stack/UpdateStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/UpdateStackCommandHandlerTests.cs
@@ -331,5 +331,6 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         repo.GetCommitsReachableFromBranch(branch1).Should().Contain(tipOfSourceBranch);
         repo.GetCommitsReachableFromBranch(branch2).Should().Contain(tipOfSourceBranch);
         repo.GetCommitsReachableFromBranch(branch2).Should().Contain(tipOfBranch1);
+        repo.GetAheadBehind(branch2).Should().Be((20, 12));
     }
 }

--- a/src/Stack.Tests/Commands/Stack/UpdateStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/UpdateStackCommandHandlerTests.cs
@@ -45,7 +45,7 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
 
         // Act
-        await handler.Handle(new UpdateStackCommandInputs(null));
+        await handler.Handle(new UpdateStackCommandInputs(null, false));
 
         // Assert
         repo.GetCommitsReachableFromBranch(branch1).Should().Contain(tipOfSourceBranch);
@@ -84,7 +84,7 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
 
         // Act
-        await handler.Handle(new UpdateStackCommandInputs(null));
+        await handler.Handle(new UpdateStackCommandInputs(null, false));
 
         // Assert
         repo.GetCommitsReachableFromBranch(branch2).Should().Contain(tipOfSourceBranch);
@@ -123,7 +123,7 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         gitHubClient.GetPullRequest(branch1).Returns(new GitHubPullRequest(1, Some.Name(), Some.Name(), GitHubPullRequestStates.Merged, Some.HttpsUri(), false));
 
         // Act
-        await handler.Handle(new UpdateStackCommandInputs(null));
+        await handler.Handle(new UpdateStackCommandInputs(null, false));
 
         // Assert
         repo.GetCommitsReachableFromBranch(branch2).Should().Contain(tipOfSourceBranch);
@@ -160,7 +160,7 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         stackConfig.Load().Returns(stacks);
 
         // Act
-        await handler.Handle(new UpdateStackCommandInputs("Stack1"));
+        await handler.Handle(new UpdateStackCommandInputs("Stack1", false));
 
         // Assert
         repo.GetCommitsReachableFromBranch(branch1).Should().Contain(tipOfSourceBranch);
@@ -201,7 +201,7 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
 
         // Act and assert
         var invalidStackName = Some.Name();
-        await handler.Invoking(async h => await h.Handle(new UpdateStackCommandInputs(invalidStackName)))
+        await handler.Invoking(async h => await h.Handle(new UpdateStackCommandInputs(invalidStackName, false)))
             .Should().ThrowAsync<InvalidOperationException>()
             .WithMessage($"Stack '{invalidStackName}' not found.");
     }
@@ -242,7 +242,7 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
 
         // Act
-        await handler.Handle(new UpdateStackCommandInputs(null));
+        await handler.Handle(new UpdateStackCommandInputs(null, false));
 
         // Assert
         repo.GetCommitsReachableFromBranch(branch1).Should().Contain(tipOfSourceBranch);
@@ -281,7 +281,7 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         stackConfig.Load().Returns(stacks);
 
         // Act
-        await handler.Handle(new UpdateStackCommandInputs(null));
+        await handler.Handle(new UpdateStackCommandInputs(null, false));
 
         // Assert
         repo.GetCommitsReachableFromBranch(branch1).Should().Contain(tipOfSourceBranch);

--- a/src/Stack.Tests/Git/GitClientTests.cs
+++ b/src/Stack.Tests/Git/GitClientTests.cs
@@ -39,7 +39,7 @@ public class GitClientTests(ITestOutputHelper testOutputHelper)
         var merge = () => gitClient.MergeFromLocalSourceBranch(branch2);
 
         // Assert
-        merge.Should().Throw<MergeConflictException>();
+        merge.Should().Throw<ConflictException>();
     }
 
     [Fact]

--- a/src/Stack.Tests/Helpers/TestGitRepositoryBuilder.cs
+++ b/src/Stack.Tests/Helpers/TestGitRepositoryBuilder.cs
@@ -314,6 +314,14 @@ public class TestGitRepository(TemporaryDirectory LocalDirectory, TemporaryDirec
         LibGit2Sharp.Commands.Stage(LocalRepository, path);
     }
 
+    public void RebaseCommits(string branchName, string sourceBranchName)
+    {
+        var branch = LocalRepository.Branches[branchName];
+        var sourceBranch = LocalRepository.Branches[sourceBranchName];
+        var remoteBranchName = branch.TrackedBranch.CanonicalName;
+        LocalRepository.Rebase.Start(branch, LocalRepository.Branches[remoteBranchName], sourceBranch, new Identity(Some.Name(), Some.Email()), new RebaseOptions());
+    }
+
     public void Dispose()
     {
         GC.SuppressFinalize(this);

--- a/src/Stack/Commands/Helpers/Questions.cs
+++ b/src/Stack/Commands/Helpers/Questions.cs
@@ -25,4 +25,5 @@ public static class Questions
     public const string CreatePullRequestAsDraft = "Create pull request as draft?";
     public const string EditPullRequestBody = "Edit pull request body? This will open a file in your default editor.";
     public const string ContinueOrAbortMerge = "Merge conflict(s) detected. Please either resolve the conflicts, commit the result and Continue, or Abort.";
+    public const string ContinueOrAbortRebase = "Merge conflict(s) detected. Please either resolve the conflicts and Continue, or Abort.";
 }

--- a/src/Stack/Commands/Helpers/Questions.cs
+++ b/src/Stack/Commands/Helpers/Questions.cs
@@ -24,6 +24,6 @@ public static class Questions
     public const string OpenPullRequests = "Open new pull requests in a browser?";
     public const string CreatePullRequestAsDraft = "Create pull request as draft?";
     public const string EditPullRequestBody = "Edit pull request body? This will open a file in your default editor.";
-    public const string ContinueOrAbortMerge = "Merge conflict(s) detected. Please either resolve the conflicts, commit the result and Continue, or Abort.";
-    public const string ContinueOrAbortRebase = "Merge conflict(s) detected. Please either resolve the conflicts and Continue, or Abort.";
+    public const string ContinueOrAbortMerge = "Conflict(s) detected during merge. Please either resolve the conflicts, commit the result and select Continue to continue merging, or Abort.";
+    public const string ContinueOrAbortRebase = "Conflict(s) detected during rebase. Please either resolve the conflicts and select Continue to continue rebasing, or Abort.";
 }


### PR DESCRIPTION
<!-- stack-pr-list -->
This PR is part of a series that add support for using rebase instead of merge

- https://github.com/geofflamrock/stack/pull/178
- https://github.com/geofflamrock/stack/pull/179
<!-- /stack-pr-list -->

This PR adds support for using rebase instead of merge to the following commands:

- `sync`: A new `--rebase` option
- `update`: A new `--rebase` option
- `push`: A new `--force-with-lease` option
