### PR TITLE
Add support for selecting merge or rebase using git config

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,18 @@ Branches in the stack will be updated by:
 
 There are two strategies that can be used to update branches in a stack.
 
+The Git configuration key `stack.update.strategy` can be used to control the default update strategy on a global or per-repository basis.
+
+The `merge` update strategy is used by default if no configuration is supplied.
+
 #### Merge
 
-The default strategy is to merge each branch in the stack into the one directly below it, starting with the source branch.
+When using the merge update strategy, each branch in the stack is merged into the one directly below it, starting with the source branch.
+
+To use the merge strategy, either:
+
+- Supply the `--merge` option to the `sync` or `update` command.
+- Configure `stack.update.strategy` to be `merge` in Git configuration using `git config stack.update.strategy merge`.
 
 **Rough edges**
 
@@ -99,7 +108,14 @@ If you merge a pull request using "Squash and merge" then you might find that th
 
 #### Rebase
 
-Each branch in the stack can be rebased on it's parent branch by using the `--rebase` option in the `sync` and `update` commands. To push changes to the remote after rebasing you'll need to use the `--force-with-lease` option.
+When using the rebase update strategy, each branch in the stack is rebased on it's parent branch.
+
+To use the rebase strategy, either:
+
+- Supply the `--rebase` option to the `sync` or `update` command.
+- Configure `stack.update.strategy` to be `rebase` in Git configuration using `git config stack.update.strategy rebase`.
+
+To push changes to the remote after rebasing you'll need to use the `--force-with-lease` option.
 
 **Rough edges**
 
@@ -211,7 +227,8 @@ OPTIONS:
         --dry-run        Show what would happen without making any changes
     -n, --name           The name of the stack to update
     -f, --force          Force the update of the stack
-    --rebase             Use rebase instead of merge when updating the stack
+    --rebase             Use rebase when updating the stack. Overrides any setting in Git configuration
+    --merge              Use merge when updating the stack. Overrides any setting in Git configuration
 ```
 
 ### `stack switch`
@@ -359,7 +376,8 @@ OPTIONS:
     -n, --name              The name of the stack to update
     -y, --yes               Don't ask for confirmation before syncing the stack
         --max-batch-size    The maximum number of branches to push changes for at once (default: 5)
-        --rebase            Use rebase instead of merge when updating the stack
+        --rebase            Use rebase when updating the stack. Overrides any setting in Git configuration
+        --merge             Use merge when updating the stack. Overrides any setting in Git configuration
 ```
 
 ## GitHub commands

--- a/README.md
+++ b/README.md
@@ -227,8 +227,8 @@ OPTIONS:
         --dry-run        Show what would happen without making any changes
     -n, --name           The name of the stack to update
     -f, --force          Force the update of the stack
-    --rebase             Use rebase when updating the stack. Overrides any setting in Git configuration
-    --merge              Use merge when updating the stack. Overrides any setting in Git configuration
+        --rebase         Use rebase when updating the stack. Overrides any setting in Git configuration
+        --merge          Use merge when updating the stack. Overrides any setting in Git configuration
 ```
 
 ### `stack switch`

--- a/src/Stack.Tests/Commands/Remote/SyncStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Remote/SyncStackCommandHandlerTests.cs
@@ -275,10 +275,11 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
             .WithBranch(builder => builder.WithName(branch1).FromSourceBranch(sourceBranch).WithNumberOfEmptyCommits(10).PushToRemote())
             .WithBranch(builder => builder.WithName(branch2).FromSourceBranch(branch1).WithNumberOfEmptyCommits(1).PushToRemote())
             .WithNumberOfEmptyCommitsOnRemoteTrackingBranchOf(sourceBranch, 5, b => b.PushToRemote())
-            .WithNumberOfEmptyCommits(b => b.OnBranch(branch1), 3)
+            .WithNumberOfEmptyCommitsOnRemoteTrackingBranchOf(branch1, 3, b => b.PushToRemote())
             .Build();
 
         var tipOfRemoteSourceBranch = repo.GetTipOfRemoteBranch(sourceBranch);
+        var tipOfRemoteBranch1 = repo.GetTipOfRemoteBranch(branch1);
         repo.GetCommitsReachableFromBranch(sourceBranch).Should().NotContain(tipOfRemoteSourceBranch);
 
         var stackConfig = Substitute.For<IStackConfig>();
@@ -306,5 +307,149 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfRemoteSourceBranch);
         repo.GetCommitsReachableFromRemoteBranch(branch2).Should().Contain(tipOfRemoteSourceBranch);
         repo.GetCommitsReachableFromRemoteBranch(branch2).Should().Contain(tipOfBranch1);
+        repo.GetCommitsReachableFromRemoteBranch(branch1).Should().NotContain(tipOfRemoteBranch1); // When doing a rebase we should no longer have the previous tip
+    }
+
+    [Fact]
+    public async Task WhenUsingMerge_ChangesExistOnTheSourceBranchOnTheRemote_PullsChanges_UpdatesBranches_AndPushesToRemote()
+    {
+        // Arrange
+        var sourceBranch = Some.BranchName();
+        var branch1 = Some.BranchName();
+        var branch2 = Some.BranchName();
+        using var repo = new TestGitRepositoryBuilder()
+            .WithBranch(builder => builder.WithName(sourceBranch).PushToRemote())
+            .WithBranch(builder => builder.WithName(branch1).FromSourceBranch(sourceBranch).WithNumberOfEmptyCommits(10).PushToRemote())
+            .WithBranch(builder => builder.WithName(branch2).FromSourceBranch(branch1).WithNumberOfEmptyCommits(1).PushToRemote())
+            .WithNumberOfEmptyCommitsOnRemoteTrackingBranchOf(sourceBranch, 5, b => b.PushToRemote())
+            .WithNumberOfEmptyCommitsOnRemoteTrackingBranchOf(branch1, 3, b => b.PushToRemote())
+            .Build();
+
+        var tipOfRemoteSourceBranch = repo.GetTipOfRemoteBranch(sourceBranch);
+        var tipOfRemoteBranch1 = repo.GetTipOfRemoteBranch(branch1);
+        repo.GetCommitsReachableFromBranch(sourceBranch).Should().NotContain(tipOfRemoteSourceBranch);
+
+        var stackConfig = Substitute.For<IStackConfig>();
+        var inputProvider = Substitute.For<IInputProvider>();
+        var outputProvider = new TestOutputProvider(testOutputHelper);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var gitHubClient = Substitute.For<IGitHubClient>();
+        var handler = new SyncStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, stackConfig);
+
+        gitClient.ChangeBranch(branch1);
+
+        var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
+        var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, []);
+        var stacks = new List<Config.Stack>([stack1, stack2]);
+        stackConfig.Load().Returns(stacks);
+
+        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
+        inputProvider.Confirm(Questions.ConfirmSyncStack).Returns(true);
+
+        // Act
+        await handler.Handle(new SyncStackCommandInputs(null, false, 5, false, true));
+
+        // Assert
+        var tipOfBranch1 = repo.GetTipOfBranch(branch1);
+        repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfRemoteSourceBranch);
+        repo.GetCommitsReachableFromRemoteBranch(branch2).Should().Contain(tipOfRemoteSourceBranch);
+        repo.GetCommitsReachableFromRemoteBranch(branch2).Should().Contain(tipOfBranch1);
+        repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfRemoteBranch1); // The merge should retain the tip of the branch
+    }
+
+    [Fact]
+    public async Task WhenNotSpecifyingRebaseOrMerge_AndUpdateSettingIsRebase_DoesSyncUsingRebase()
+    {
+        // Arrange
+        var sourceBranch = Some.BranchName();
+        var branch1 = Some.BranchName();
+        var branch2 = Some.BranchName();
+        using var repo = new TestGitRepositoryBuilder()
+            .WithBranch(builder => builder.WithName(sourceBranch).PushToRemote())
+            .WithBranch(builder => builder.WithName(branch1).FromSourceBranch(sourceBranch).WithNumberOfEmptyCommits(10).PushToRemote())
+            .WithBranch(builder => builder.WithName(branch2).FromSourceBranch(branch1).WithNumberOfEmptyCommits(1).PushToRemote())
+            .WithNumberOfEmptyCommitsOnRemoteTrackingBranchOf(sourceBranch, 5, b => b.PushToRemote())
+            .WithNumberOfEmptyCommitsOnRemoteTrackingBranchOf(branch1, 3, b => b.PushToRemote())
+            .WithConfig("stack.update.strategy", "rebase")
+            .Build();
+
+        var tipOfRemoteSourceBranch = repo.GetTipOfRemoteBranch(sourceBranch);
+        var tipOfRemoteBranch1 = repo.GetTipOfRemoteBranch(branch1);
+        repo.GetCommitsReachableFromBranch(sourceBranch).Should().NotContain(tipOfRemoteSourceBranch);
+
+        var stackConfig = Substitute.For<IStackConfig>();
+        var inputProvider = Substitute.For<IInputProvider>();
+        var outputProvider = new TestOutputProvider(testOutputHelper);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var gitHubClient = Substitute.For<IGitHubClient>();
+        var handler = new SyncStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, stackConfig);
+
+        gitClient.ChangeBranch(branch1);
+
+        var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
+        var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, []);
+        var stacks = new List<Config.Stack>([stack1, stack2]);
+        stackConfig.Load().Returns(stacks);
+
+        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
+        inputProvider.Confirm(Questions.ConfirmSyncStack).Returns(true);
+
+        // Act
+        await handler.Handle(new SyncStackCommandInputs(null, false, 5, null, null));
+
+        // Assert
+        var tipOfBranch1 = repo.GetTipOfBranch(branch1);
+        repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfRemoteSourceBranch);
+        repo.GetCommitsReachableFromRemoteBranch(branch2).Should().Contain(tipOfRemoteSourceBranch);
+        repo.GetCommitsReachableFromRemoteBranch(branch2).Should().Contain(tipOfBranch1);
+        repo.GetCommitsReachableFromRemoteBranch(branch1).Should().NotContain(tipOfRemoteBranch1); // When doing a rebase we should no longer have the previous tip
+    }
+
+    [Fact]
+    public async Task WhenNotSpecifyingRebaseOrMerge_AndUpdateSettingIsMerge_DoesSyncUsingMerge()
+    {
+        // Arrange
+        var sourceBranch = Some.BranchName();
+        var branch1 = Some.BranchName();
+        var branch2 = Some.BranchName();
+        using var repo = new TestGitRepositoryBuilder()
+            .WithBranch(builder => builder.WithName(sourceBranch).PushToRemote())
+            .WithBranch(builder => builder.WithName(branch1).FromSourceBranch(sourceBranch).WithNumberOfEmptyCommits(10).PushToRemote())
+            .WithBranch(builder => builder.WithName(branch2).FromSourceBranch(branch1).WithNumberOfEmptyCommits(1).PushToRemote())
+            .WithNumberOfEmptyCommitsOnRemoteTrackingBranchOf(sourceBranch, 5, b => b.PushToRemote())
+            .WithNumberOfEmptyCommitsOnRemoteTrackingBranchOf(branch1, 3, b => b.PushToRemote())
+            .WithConfig("stack.update.strategy", "merge")
+            .Build();
+
+        var tipOfRemoteSourceBranch = repo.GetTipOfRemoteBranch(sourceBranch);
+        var tipOfRemoteBranch1 = repo.GetTipOfRemoteBranch(branch1);
+        repo.GetCommitsReachableFromBranch(sourceBranch).Should().NotContain(tipOfRemoteSourceBranch);
+
+        var stackConfig = Substitute.For<IStackConfig>();
+        var inputProvider = Substitute.For<IInputProvider>();
+        var outputProvider = new TestOutputProvider(testOutputHelper);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var gitHubClient = Substitute.For<IGitHubClient>();
+        var handler = new SyncStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, stackConfig);
+
+        gitClient.ChangeBranch(branch1);
+
+        var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
+        var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, []);
+        var stacks = new List<Config.Stack>([stack1, stack2]);
+        stackConfig.Load().Returns(stacks);
+
+        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
+        inputProvider.Confirm(Questions.ConfirmSyncStack).Returns(true);
+
+        // Act
+        await handler.Handle(new SyncStackCommandInputs(null, false, 5, null, null));
+
+        // Assert
+        var tipOfBranch1 = repo.GetTipOfBranch(branch1);
+        repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfRemoteSourceBranch);
+        repo.GetCommitsReachableFromRemoteBranch(branch2).Should().Contain(tipOfRemoteSourceBranch);
+        repo.GetCommitsReachableFromRemoteBranch(branch2).Should().Contain(tipOfBranch1);
+        repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfRemoteBranch1); // The merge should retain the tip of the branch
     }
 }

--- a/src/Stack.Tests/Commands/Remote/SyncStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Remote/SyncStackCommandHandlerTests.cs
@@ -47,7 +47,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Confirm(Questions.ConfirmSyncStack).Returns(true);
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs(null, false, 5, false));
+        await handler.Handle(new SyncStackCommandInputs(null, false, 5, false, false));
 
         // Assert
         repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfRemoteSourceBranch);
@@ -88,7 +88,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Confirm(Questions.ConfirmSyncStack).Returns(true);
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs("Stack1", false, 5, false));
+        await handler.Handle(new SyncStackCommandInputs("Stack1", false, 5, false, false));
 
         // Assert
         repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfRemoteSourceBranch);
@@ -130,7 +130,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs(null, true, 5, false));
+        await handler.Handle(new SyncStackCommandInputs(null, true, 5, false, false));
 
         // Assert
         repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfRemoteSourceBranch);
@@ -171,7 +171,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
 
         // Act and assert
         var invalidStackName = Some.Name();
-        await handler.Invoking(async h => await h.Handle(new SyncStackCommandInputs(invalidStackName, false, 5, false)))
+        await handler.Invoking(async h => await h.Handle(new SyncStackCommandInputs(invalidStackName, false, 5, false, false)))
             .Should().ThrowAsync<InvalidOperationException>()
             .WithMessage($"Stack '{invalidStackName}' not found.");
     }
@@ -212,7 +212,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Confirm(Questions.ConfirmSyncStack).Returns(true);
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs(null, false, 5, false));
+        await handler.Handle(new SyncStackCommandInputs(null, false, 5, false, false));
 
         // Assert
         repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfRemoteSourceBranch);
@@ -253,7 +253,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Confirm(Questions.ConfirmSyncStack).Returns(true);
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs(null, false, 5, false));
+        await handler.Handle(new SyncStackCommandInputs(null, false, 5, false, false));
 
         // Assert
         repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfRemoteSourceBranch);

--- a/src/Stack.Tests/Commands/Remote/SyncStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Remote/SyncStackCommandHandlerTests.cs
@@ -548,4 +548,22 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         repo.GetCommitsReachableFromRemoteBranch(branch2).Should().Contain(tipOfBranch1);
         repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfRemoteBranch1); // The merge should retain the tip of the branch
     }
+
+    [Fact]
+    public async Task WhenBothRebaseAndMergeAreSpecified_AnErrorIsThrown()
+    {
+        // Arrange
+        var stackConfig = Substitute.For<IStackConfig>();
+        var inputProvider = Substitute.For<IInputProvider>();
+        var outputProvider = new TestOutputProvider(testOutputHelper);
+        var gitClient = Substitute.For<IGitClient>();
+        var gitHubClient = Substitute.For<IGitHubClient>();
+        var handler = new SyncStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, stackConfig);
+
+        // Act and assert
+        await handler
+            .Invoking(h => h.Handle(new SyncStackCommandInputs(null, false, 5, true, true)))
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Cannot specify both rebase and merge.");
+    }
 }

--- a/src/Stack.Tests/Commands/Remote/SyncStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Remote/SyncStackCommandHandlerTests.cs
@@ -299,7 +299,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Confirm(Questions.ConfirmSyncStack).Returns(true);
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs(null, false, 5, true));
+        await handler.Handle(new SyncStackCommandInputs(null, false, 5, true, false));
 
         // Assert
         var tipOfBranch1 = repo.GetTipOfBranch(branch1);

--- a/src/Stack.Tests/Commands/Remote/SyncStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Remote/SyncStackCommandHandlerTests.cs
@@ -452,4 +452,100 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         repo.GetCommitsReachableFromRemoteBranch(branch2).Should().Contain(tipOfBranch1);
         repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfRemoteBranch1); // The merge should retain the tip of the branch
     }
+
+    [Fact]
+    public async Task WhenGitConfigValueIsSetToMerge_ButRebaseIsSpecified_DoesSyncUsingRebase()
+    {
+        // Arrange
+        var sourceBranch = Some.BranchName();
+        var branch1 = Some.BranchName();
+        var branch2 = Some.BranchName();
+        using var repo = new TestGitRepositoryBuilder()
+            .WithBranch(builder => builder.WithName(sourceBranch).PushToRemote())
+            .WithBranch(builder => builder.WithName(branch1).FromSourceBranch(sourceBranch).WithNumberOfEmptyCommits(10).PushToRemote())
+            .WithBranch(builder => builder.WithName(branch2).FromSourceBranch(branch1).WithNumberOfEmptyCommits(1).PushToRemote())
+            .WithNumberOfEmptyCommitsOnRemoteTrackingBranchOf(sourceBranch, 5, b => b.PushToRemote())
+            .WithNumberOfEmptyCommitsOnRemoteTrackingBranchOf(branch1, 3, b => b.PushToRemote())
+            .WithConfig("stack.update.strategy", "merge")
+            .Build();
+
+        var tipOfRemoteSourceBranch = repo.GetTipOfRemoteBranch(sourceBranch);
+        var tipOfRemoteBranch1 = repo.GetTipOfRemoteBranch(branch1);
+        repo.GetCommitsReachableFromBranch(sourceBranch).Should().NotContain(tipOfRemoteSourceBranch);
+
+        var stackConfig = Substitute.For<IStackConfig>();
+        var inputProvider = Substitute.For<IInputProvider>();
+        var outputProvider = new TestOutputProvider(testOutputHelper);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var gitHubClient = Substitute.For<IGitHubClient>();
+        var handler = new SyncStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, stackConfig);
+
+        gitClient.ChangeBranch(branch1);
+
+        var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
+        var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, []);
+        var stacks = new List<Config.Stack>([stack1, stack2]);
+        stackConfig.Load().Returns(stacks);
+
+        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
+        inputProvider.Confirm(Questions.ConfirmSyncStack).Returns(true);
+
+        // Act
+        await handler.Handle(new SyncStackCommandInputs(null, false, 5, true, null));
+
+        // Assert
+        var tipOfBranch1 = repo.GetTipOfBranch(branch1);
+        repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfRemoteSourceBranch);
+        repo.GetCommitsReachableFromRemoteBranch(branch2).Should().Contain(tipOfRemoteSourceBranch);
+        repo.GetCommitsReachableFromRemoteBranch(branch2).Should().Contain(tipOfBranch1);
+        repo.GetCommitsReachableFromRemoteBranch(branch1).Should().NotContain(tipOfRemoteBranch1); // When doing a rebase we should no longer have the previous tip
+    }
+
+    [Fact]
+    public async Task WhenGitConfigValueIsSetToRebase_ButMergeIsSpecified_DoesSyncUsingMerge()
+    {
+        // Arrange
+        var sourceBranch = Some.BranchName();
+        var branch1 = Some.BranchName();
+        var branch2 = Some.BranchName();
+        using var repo = new TestGitRepositoryBuilder()
+            .WithBranch(builder => builder.WithName(sourceBranch).PushToRemote())
+            .WithBranch(builder => builder.WithName(branch1).FromSourceBranch(sourceBranch).WithNumberOfEmptyCommits(10).PushToRemote())
+            .WithBranch(builder => builder.WithName(branch2).FromSourceBranch(branch1).WithNumberOfEmptyCommits(1).PushToRemote())
+            .WithNumberOfEmptyCommitsOnRemoteTrackingBranchOf(sourceBranch, 5, b => b.PushToRemote())
+            .WithNumberOfEmptyCommitsOnRemoteTrackingBranchOf(branch1, 3, b => b.PushToRemote())
+            .WithConfig("stack.update.strategy", "rebase")
+            .Build();
+
+        var tipOfRemoteSourceBranch = repo.GetTipOfRemoteBranch(sourceBranch);
+        var tipOfRemoteBranch1 = repo.GetTipOfRemoteBranch(branch1);
+        repo.GetCommitsReachableFromBranch(sourceBranch).Should().NotContain(tipOfRemoteSourceBranch);
+
+        var stackConfig = Substitute.For<IStackConfig>();
+        var inputProvider = Substitute.For<IInputProvider>();
+        var outputProvider = new TestOutputProvider(testOutputHelper);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var gitHubClient = Substitute.For<IGitHubClient>();
+        var handler = new SyncStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, stackConfig);
+
+        gitClient.ChangeBranch(branch1);
+
+        var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
+        var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, []);
+        var stacks = new List<Config.Stack>([stack1, stack2]);
+        stackConfig.Load().Returns(stacks);
+
+        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
+        inputProvider.Confirm(Questions.ConfirmSyncStack).Returns(true);
+
+        // Act
+        await handler.Handle(new SyncStackCommandInputs(null, false, 5, null, true));
+
+        // Assert
+        var tipOfBranch1 = repo.GetTipOfBranch(branch1);
+        repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfRemoteSourceBranch);
+        repo.GetCommitsReachableFromRemoteBranch(branch2).Should().Contain(tipOfRemoteSourceBranch);
+        repo.GetCommitsReachableFromRemoteBranch(branch2).Should().Contain(tipOfBranch1);
+        repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfRemoteBranch1); // The merge should retain the tip of the branch
+    }
 }

--- a/src/Stack.Tests/Commands/Stack/UpdateStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/UpdateStackCommandHandlerTests.cs
@@ -377,4 +377,136 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         repo.GetCommitsReachableFromBranch(branch2).Should().Contain(tipOfBranch1);
         repo.GetAheadBehind(branch2).Should().Be((20, 12));
     }
+
+    [Fact]
+    public async Task WhenGitConfigValueIsSetToRebase_ButMergeIsSpecified_AllBranchesInStackAreUpdatedUsingMerge()
+    {
+        // Arrange
+        var sourceBranch = Some.BranchName();
+        var branch1 = Some.BranchName();
+        var branch2 = Some.BranchName();
+        using var repo = new TestGitRepositoryBuilder()
+            .WithBranch(builder => builder.WithName(sourceBranch).PushToRemote())
+            .WithBranch(builder => builder.WithName(branch1).FromSourceBranch(sourceBranch).WithNumberOfEmptyCommits(10).PushToRemote())
+            .WithBranch(builder => builder.WithName(branch2).FromSourceBranch(branch1).WithNumberOfEmptyCommits(1).PushToRemote())
+            .WithNumberOfEmptyCommits(b => b.OnBranch(sourceBranch).PushToRemote(), 5)
+            .WithNumberOfEmptyCommits(b => b.OnBranch(branch1).PushToRemote(), 3)
+            .WithNumberOfEmptyCommits(b => b.OnBranch(branch2).PushToRemote(), 1)
+            .WithConfig("stack.update.strategy", "rebase")
+            .Build();
+
+        var stackConfig = Substitute.For<IStackConfig>();
+        var inputProvider = Substitute.For<IInputProvider>();
+        var outputProvider = new TestOutputProvider(testOutputHelper);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var gitHubClient = Substitute.For<IGitHubClient>();
+        var handler = new UpdateStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, stackConfig);
+
+        var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
+        var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, []);
+        var stacks = new List<Config.Stack>([stack1, stack2]);
+        stackConfig.Load().Returns(stacks);
+
+        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
+
+        // Act
+        await handler.Handle(new UpdateStackCommandInputs(null, null, true));
+
+        // Assert
+        var tipOfSourceBranch = repo.GetTipOfBranch(sourceBranch);
+        var tipOfBranch1 = repo.GetTipOfBranch(branch1);
+
+        repo.GetCommitsReachableFromBranch(branch1).Should().Contain(tipOfSourceBranch);
+        repo.GetCommitsReachableFromBranch(branch2).Should().Contain(tipOfSourceBranch);
+        repo.GetCommitsReachableFromBranch(branch2).Should().Contain(tipOfBranch1);
+        repo.GetAheadBehind(branch2).Should().Be((10, 0));
+    }
+
+    [Fact]
+    public async Task WhenGitConfigValueIsSetToMerge_AllBranchesInStackAreUpdatedUsingMerge()
+    {
+        // Arrange
+        var sourceBranch = Some.BranchName();
+        var branch1 = Some.BranchName();
+        var branch2 = Some.BranchName();
+        using var repo = new TestGitRepositoryBuilder()
+            .WithBranch(builder => builder.WithName(sourceBranch).PushToRemote())
+            .WithBranch(builder => builder.WithName(branch1).FromSourceBranch(sourceBranch).WithNumberOfEmptyCommits(10).PushToRemote())
+            .WithBranch(builder => builder.WithName(branch2).FromSourceBranch(branch1).WithNumberOfEmptyCommits(1).PushToRemote())
+            .WithNumberOfEmptyCommits(b => b.OnBranch(sourceBranch).PushToRemote(), 5)
+            .WithNumberOfEmptyCommits(b => b.OnBranch(branch1).PushToRemote(), 3)
+            .WithNumberOfEmptyCommits(b => b.OnBranch(branch2).PushToRemote(), 1)
+            .WithConfig("stack.update.strategy", "merge")
+            .Build();
+
+        var stackConfig = Substitute.For<IStackConfig>();
+        var inputProvider = Substitute.For<IInputProvider>();
+        var outputProvider = new TestOutputProvider(testOutputHelper);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var gitHubClient = Substitute.For<IGitHubClient>();
+        var handler = new UpdateStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, stackConfig);
+
+        var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
+        var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, []);
+        var stacks = new List<Config.Stack>([stack1, stack2]);
+        stackConfig.Load().Returns(stacks);
+
+        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
+
+        // Act
+        await handler.Handle(new UpdateStackCommandInputs(null, null, null));
+
+        // Assert
+        var tipOfSourceBranch = repo.GetTipOfBranch(sourceBranch);
+        var tipOfBranch1 = repo.GetTipOfBranch(branch1);
+
+        repo.GetCommitsReachableFromBranch(branch1).Should().Contain(tipOfSourceBranch);
+        repo.GetCommitsReachableFromBranch(branch2).Should().Contain(tipOfSourceBranch);
+        repo.GetCommitsReachableFromBranch(branch2).Should().Contain(tipOfBranch1);
+        repo.GetAheadBehind(branch2).Should().Be((10, 0));
+    }
+
+    [Fact]
+    public async Task WhenGitConfigValueIsSetToMerge_ButRebaseIsSpecified_AllBranchesInStackAreUpdatedUsingRebase()
+    {
+        // Arrange
+        var sourceBranch = Some.BranchName();
+        var branch1 = Some.BranchName();
+        var branch2 = Some.BranchName();
+        using var repo = new TestGitRepositoryBuilder()
+            .WithBranch(builder => builder.WithName(sourceBranch).PushToRemote())
+            .WithBranch(builder => builder.WithName(branch1).FromSourceBranch(sourceBranch).WithNumberOfEmptyCommits(10).PushToRemote())
+            .WithBranch(builder => builder.WithName(branch2).FromSourceBranch(branch1).WithNumberOfEmptyCommits(1).PushToRemote())
+            .WithNumberOfEmptyCommits(b => b.OnBranch(sourceBranch).PushToRemote(), 5)
+            .WithNumberOfEmptyCommits(b => b.OnBranch(branch1).PushToRemote(), 3)
+            .WithNumberOfEmptyCommits(b => b.OnBranch(branch2).PushToRemote(), 1)
+            .WithConfig("stack.update.strategy", "merge")
+            .Build();
+
+        var stackConfig = Substitute.For<IStackConfig>();
+        var inputProvider = Substitute.For<IInputProvider>();
+        var outputProvider = new TestOutputProvider(testOutputHelper);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var gitHubClient = Substitute.For<IGitHubClient>();
+        var handler = new UpdateStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, stackConfig);
+
+        var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
+        var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, []);
+        var stacks = new List<Config.Stack>([stack1, stack2]);
+        stackConfig.Load().Returns(stacks);
+
+        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
+
+        // Act
+        await handler.Handle(new UpdateStackCommandInputs(null, true, null));
+
+        // Assert
+        var tipOfSourceBranch = repo.GetTipOfBranch(sourceBranch);
+        var tipOfBranch1 = repo.GetTipOfBranch(branch1);
+
+        repo.GetCommitsReachableFromBranch(branch1).Should().Contain(tipOfSourceBranch);
+        repo.GetCommitsReachableFromBranch(branch2).Should().Contain(tipOfSourceBranch);
+        repo.GetCommitsReachableFromBranch(branch2).Should().Contain(tipOfBranch1);
+        repo.GetAheadBehind(branch2).Should().Be((20, 12));
+    }
 }

--- a/src/Stack.Tests/Commands/Stack/UpdateStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/UpdateStackCommandHandlerTests.cs
@@ -509,4 +509,22 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         repo.GetCommitsReachableFromBranch(branch2).Should().Contain(tipOfBranch1);
         repo.GetAheadBehind(branch2).Should().Be((20, 12));
     }
+
+    [Fact]
+    public async Task WhenBothRebaseAndMergeAreSpecified_AnErrorIsThrown()
+    {
+        // Arrange
+        var stackConfig = Substitute.For<IStackConfig>();
+        var inputProvider = Substitute.For<IInputProvider>();
+        var outputProvider = new TestOutputProvider(testOutputHelper);
+        var gitClient = Substitute.For<IGitClient>();
+        var gitHubClient = Substitute.For<IGitHubClient>();
+        var handler = new UpdateStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, stackConfig);
+
+        // Act and assert
+        await handler
+            .Invoking(h => h.Handle(new UpdateStackCommandInputs(null, true, true)))
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Cannot specify both rebase and merge.");
+    }
 }

--- a/src/Stack.Tests/Commands/Stack/UpdateStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/UpdateStackCommandHandlerTests.cs
@@ -322,7 +322,51 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
 
         // Act
-        await handler.Handle(new UpdateStackCommandInputs(null, true));
+        await handler.Handle(new UpdateStackCommandInputs(null, true, false));
+
+        // Assert
+        var tipOfSourceBranch = repo.GetTipOfBranch(sourceBranch);
+        var tipOfBranch1 = repo.GetTipOfBranch(branch1);
+
+        repo.GetCommitsReachableFromBranch(branch1).Should().Contain(tipOfSourceBranch);
+        repo.GetCommitsReachableFromBranch(branch2).Should().Contain(tipOfSourceBranch);
+        repo.GetCommitsReachableFromBranch(branch2).Should().Contain(tipOfBranch1);
+        repo.GetAheadBehind(branch2).Should().Be((20, 12));
+    }
+
+    [Fact]
+    public async Task WhenGitConfigValueIsSetToRebase_AllBranchesInStackAreUpdatedUsingRebase()
+    {
+        // Arrange
+        var sourceBranch = Some.BranchName();
+        var branch1 = Some.BranchName();
+        var branch2 = Some.BranchName();
+        using var repo = new TestGitRepositoryBuilder()
+            .WithBranch(builder => builder.WithName(sourceBranch).PushToRemote())
+            .WithBranch(builder => builder.WithName(branch1).FromSourceBranch(sourceBranch).WithNumberOfEmptyCommits(10).PushToRemote())
+            .WithBranch(builder => builder.WithName(branch2).FromSourceBranch(branch1).WithNumberOfEmptyCommits(1).PushToRemote())
+            .WithNumberOfEmptyCommits(b => b.OnBranch(sourceBranch).PushToRemote(), 5)
+            .WithNumberOfEmptyCommits(b => b.OnBranch(branch1).PushToRemote(), 3)
+            .WithNumberOfEmptyCommits(b => b.OnBranch(branch2).PushToRemote(), 1)
+            .WithConfig("stack.update.strategy", "rebase")
+            .Build();
+
+        var stackConfig = Substitute.For<IStackConfig>();
+        var inputProvider = Substitute.For<IInputProvider>();
+        var outputProvider = new TestOutputProvider(testOutputHelper);
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var gitHubClient = Substitute.For<IGitHubClient>();
+        var handler = new UpdateStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, stackConfig);
+
+        var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
+        var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, []);
+        var stacks = new List<Config.Stack>([stack1, stack2]);
+        stackConfig.Load().Returns(stacks);
+
+        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
+
+        // Act
+        await handler.Handle(new UpdateStackCommandInputs(null, null, null));
 
         // Assert
         var tipOfSourceBranch = repo.GetTipOfBranch(sourceBranch);

--- a/src/Stack.Tests/Commands/Stack/UpdateStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/UpdateStackCommandHandlerTests.cs
@@ -45,7 +45,7 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
 
         // Act
-        await handler.Handle(new UpdateStackCommandInputs(null, false));
+        await handler.Handle(new UpdateStackCommandInputs(null, false, false));
 
         // Assert
         repo.GetCommitsReachableFromBranch(branch1).Should().Contain(tipOfSourceBranch);
@@ -84,7 +84,7 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
 
         // Act
-        await handler.Handle(new UpdateStackCommandInputs(null, false));
+        await handler.Handle(new UpdateStackCommandInputs(null, false, false));
 
         // Assert
         repo.GetCommitsReachableFromBranch(branch2).Should().Contain(tipOfSourceBranch);
@@ -123,7 +123,7 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         gitHubClient.GetPullRequest(branch1).Returns(new GitHubPullRequest(1, Some.Name(), Some.Name(), GitHubPullRequestStates.Merged, Some.HttpsUri(), false));
 
         // Act
-        await handler.Handle(new UpdateStackCommandInputs(null, false));
+        await handler.Handle(new UpdateStackCommandInputs(null, false, false));
 
         // Assert
         repo.GetCommitsReachableFromBranch(branch2).Should().Contain(tipOfSourceBranch);
@@ -160,7 +160,7 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         stackConfig.Load().Returns(stacks);
 
         // Act
-        await handler.Handle(new UpdateStackCommandInputs("Stack1", false));
+        await handler.Handle(new UpdateStackCommandInputs("Stack1", false, false));
 
         // Assert
         repo.GetCommitsReachableFromBranch(branch1).Should().Contain(tipOfSourceBranch);
@@ -201,7 +201,7 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
 
         // Act and assert
         var invalidStackName = Some.Name();
-        await handler.Invoking(async h => await h.Handle(new UpdateStackCommandInputs(invalidStackName, false)))
+        await handler.Invoking(async h => await h.Handle(new UpdateStackCommandInputs(invalidStackName, false, false)))
             .Should().ThrowAsync<InvalidOperationException>()
             .WithMessage($"Stack '{invalidStackName}' not found.");
     }
@@ -242,7 +242,7 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
 
         // Act
-        await handler.Handle(new UpdateStackCommandInputs(null, false));
+        await handler.Handle(new UpdateStackCommandInputs(null, false, false));
 
         // Assert
         repo.GetCommitsReachableFromBranch(branch1).Should().Contain(tipOfSourceBranch);
@@ -281,7 +281,7 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         stackConfig.Load().Returns(stacks);
 
         // Act
-        await handler.Handle(new UpdateStackCommandInputs(null, false));
+        await handler.Handle(new UpdateStackCommandInputs(null, false, false));
 
         // Assert
         repo.GetCommitsReachableFromBranch(branch1).Should().Contain(tipOfSourceBranch);

--- a/src/Stack/Commands/Remote/SyncStackCommand.cs
+++ b/src/Stack/Commands/Remote/SyncStackCommand.cs
@@ -23,11 +23,11 @@ public class SyncStackCommandSettings : DryRunCommandSettingsBase
     [DefaultValue(5)]
     public int MaxBatchSize { get; init; } = 5;
 
-    [Description("Use rebase when updating the stack.")]
+    [Description("Use rebase when updating the stack. Overrides any setting in Git configuration.")]
     [CommandOption("--rebase")]
     public bool? Rebase { get; init; }
 
-    [Description("Use merge when updating the stack.")]
+    [Description("Use merge when updating the stack. Overrides any setting in Git configuration.")]
     [CommandOption("--merge")]
     public bool? Merge { get; init; }
 }

--- a/src/Stack/Commands/Remote/SyncStackCommand.cs
+++ b/src/Stack/Commands/Remote/SyncStackCommand.cs
@@ -23,9 +23,13 @@ public class SyncStackCommandSettings : DryRunCommandSettingsBase
     [DefaultValue(5)]
     public int MaxBatchSize { get; init; } = 5;
 
-    [Description("Use rebase instead of merge when updating the stack.")]
+    [Description("Use rebase when updating the stack.")]
     [CommandOption("--rebase")]
-    public bool Rebase { get; init; }
+    public bool? Rebase { get; init; }
+
+    [Description("Use merge when updating the stack.")]
+    [CommandOption("--merge")]
+    public bool? Merge { get; init; }
 }
 
 public class SyncStackCommand : AsyncCommand<SyncStackCommandSettings>
@@ -46,7 +50,8 @@ public class SyncStackCommand : AsyncCommand<SyncStackCommandSettings>
             settings.Name,
             settings.NoConfirm,
             settings.MaxBatchSize,
-            settings.Rebase));
+            settings.Rebase,
+            settings.Merge));
 
         return 0;
     }
@@ -56,9 +61,10 @@ public record SyncStackCommandInputs(
     string? Name,
     bool NoConfirm,
     int MaxBatchSize,
-    bool Rebase)
+    bool? Rebase,
+    bool? Merge)
 {
-    public static SyncStackCommandInputs Empty => new(null, false, 5, false);
+    public static SyncStackCommandInputs Empty => new(null, false, 5, null, null);
 }
 
 public record SyncStackCommandResponse();
@@ -114,12 +120,14 @@ public class SyncStackCommandHandler(
             StackHelpers.UpdateStack(
                 stack,
                 status,
-                inputs.Rebase ? UpdateStrategy.Rebase : UpdateStrategy.Merge,
+                inputs.Merge == true ? UpdateStrategy.Merge : inputs.Rebase == true ? UpdateStrategy.Rebase : null,
                 gitClient,
                 inputProvider,
                 outputProvider);
 
-            StackHelpers.PushChanges(stack, inputs.MaxBatchSize, inputs.Rebase, gitClient, outputProvider);
+            var forceWithLease = inputs.Rebase == true || StackHelpers.GetUpdateStrategyConfigValue(gitClient) == UpdateStrategy.Rebase;
+
+            StackHelpers.PushChanges(stack, inputs.MaxBatchSize, forceWithLease, gitClient, outputProvider);
 
             if (stack.SourceBranch.Equals(currentBranch, StringComparison.InvariantCultureIgnoreCase) ||
                 stack.Branches.Contains(currentBranch, StringComparer.OrdinalIgnoreCase))

--- a/src/Stack/Commands/Remote/SyncStackCommand.cs
+++ b/src/Stack/Commands/Remote/SyncStackCommand.cs
@@ -79,6 +79,10 @@ public class SyncStackCommandHandler(
     public async Task<SyncStackCommandResponse> Handle(SyncStackCommandInputs inputs)
     {
         await Task.CompletedTask;
+
+        if (inputs.Rebase == true && inputs.Merge == true)
+            throw new InvalidOperationException("Cannot specify both rebase and merge.");
+
         var stacks = stackConfig.Load();
 
         var remoteUri = gitClient.GetRemoteUri();

--- a/src/Stack/Commands/Stack/UpdateStackCommand.cs
+++ b/src/Stack/Commands/Stack/UpdateStackCommand.cs
@@ -15,9 +15,13 @@ public class UpdateStackCommandSettings : DryRunCommandSettingsBase
     [CommandOption("-n|--name")]
     public string? Name { get; init; }
 
-    [Description("Use rebase instead of merge when updating the stack.")]
+    [Description("Use rebase when updating the stack.")]
     [CommandOption("--rebase")]
-    public bool Rebase { get; init; }
+    public bool? Rebase { get; init; }
+
+    [Description("Use merge when updating the stack.")]
+    [CommandOption("--merge")]
+    public bool? Merge { get; init; }
 }
 
 public class UpdateStackCommand : AsyncCommand<UpdateStackCommandSettings>
@@ -34,15 +38,15 @@ public class UpdateStackCommand : AsyncCommand<UpdateStackCommandSettings>
             new GitHubClient(outputProvider, settings.GetGitHubClientSettings()),
             new StackConfig());
 
-        await handler.Handle(new UpdateStackCommandInputs(settings.Name, settings.Rebase));
+        await handler.Handle(new UpdateStackCommandInputs(settings.Name, settings.Rebase, settings.Merge));
 
         return 0;
     }
 }
 
-public record UpdateStackCommandInputs(string? Name, bool Rebase)
+public record UpdateStackCommandInputs(string? Name, bool? Rebase, bool? Merge)
 {
-    public static UpdateStackCommandInputs Empty => new(null, false);
+    public static UpdateStackCommandInputs Empty => new(null, null, null);
 }
 
 public record UpdateStackCommandResponse();
@@ -86,7 +90,7 @@ public class UpdateStackCommandHandler(
         StackHelpers.UpdateStack(
             stack,
             status,
-            inputs.Rebase ? UpdateStrategy.Rebase : UpdateStrategy.Merge,
+            inputs.Merge == true ? UpdateStrategy.Merge : inputs.Rebase == true ? UpdateStrategy.Rebase : null,
             gitClient,
             inputProvider,
             outputProvider);

--- a/src/Stack/Commands/Stack/UpdateStackCommand.cs
+++ b/src/Stack/Commands/Stack/UpdateStackCommand.cs
@@ -61,6 +61,10 @@ public class UpdateStackCommandHandler(
     public async Task<UpdateStackCommandResponse> Handle(UpdateStackCommandInputs inputs)
     {
         await Task.CompletedTask;
+
+        if (inputs.Rebase == true && inputs.Merge == true)
+            throw new InvalidOperationException("Cannot specify both rebase and merge.");
+
         var stacks = stackConfig.Load();
 
         var remoteUri = gitClient.GetRemoteUri();

--- a/src/Stack/Commands/Stack/UpdateStackCommand.cs
+++ b/src/Stack/Commands/Stack/UpdateStackCommand.cs
@@ -15,11 +15,11 @@ public class UpdateStackCommandSettings : DryRunCommandSettingsBase
     [CommandOption("-n|--name")]
     public string? Name { get; init; }
 
-    [Description("Use rebase when updating the stack.")]
+    [Description("Use rebase when updating the stack. Overrides any setting in Git configuration.")]
     [CommandOption("--rebase")]
     public bool? Rebase { get; init; }
 
-    [Description("Use merge when updating the stack.")]
+    [Description("Use merge when updating the stack. Overrides any setting in Git configuration.")]
     [CommandOption("--merge")]
     public bool? Merge { get; init; }
 }


### PR DESCRIPTION
<!-- stack-pr-list -->
This PR is part of a series that add support for using rebase instead of merge

- https://github.com/geofflamrock/stack/pull/178
- https://github.com/geofflamrock/stack/pull/179
<!-- /stack-pr-list -->

This PR adds support for a git config setting `stack.update.strategy` to control whether to use merge or rebase during update/sync. The default value if not set is still merge. A new option `--merge` has been added to the `sync` and `update` commands to support specifying merge specifically even if the setting is set to rebase.
