### PR TITLE
Removes `--force` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,6 @@ OPTIONS:
         --verbose        Show verbose output
         --working-dir    The path to the directory containing the git repository. Defaults to the current directory
     -n, --name           The name of the stack to delete
-    -f, --force          Force cleanup and delete the stack without prompting
 ```
 
 ## Branch commands
@@ -225,7 +224,6 @@ OPTIONS:
         --verbose        Show verbose output
         --working-dir    The path to the directory containing the git repository. Defaults to the current directory
     -n, --name           The name of the stack to update
-    -f, --force          Force the update of the stack
         --rebase         Use rebase when updating the stack. Overrides any setting in Git configuration
         --merge          Use merge when updating the stack. Overrides any setting in Git configuration
 ```
@@ -260,7 +258,6 @@ OPTIONS:
         --verbose        Show verbose output
         --working-dir    The path to the directory containing the git repository. Defaults to the current directory
     -n, --name           The name of the stack to cleanup
-    -f, --force          Cleanup the stack without prompting
 ```
 
 ### `stack branch new`
@@ -310,7 +307,6 @@ OPTIONS:
         --working-dir    The path to the directory containing the git repository. Defaults to the current directory
     -s, --stack          The name of the stack to create the branch in
     -n, --name           The name of the branch to add
-    -f, --force          Force removing the branch without prompting
 ```
 
 ## Remote commands
@@ -366,7 +362,6 @@ OPTIONS:
         --verbose           Show verbose output
         --working-dir       The path to the directory containing the git repository. Defaults to the current directory
     -n, --name              The name of the stack to update
-    -y, --yes               Don't ask for confirmation before syncing the stack
         --max-batch-size    The maximum number of branches to push changes for at once (default: 5)
         --rebase            Use rebase when updating the stack. Overrides any setting in Git configuration
         --merge             Use merge when updating the stack. Overrides any setting in Git configuration

--- a/src/Stack.Tests/Commands/Branch/NewBranchCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Branch/NewBranchCommandHandlerTests.cs
@@ -131,7 +131,7 @@ public class NewBranchCommandHandlerTests
         inputProvider.Text(Questions.BranchName, Arg.Any<string>()).Returns(newBranch);
 
         // Act
-        await handler.Handle(new NewBranchCommandInputs("Stack1", null, false, false));
+        await handler.Handle(new NewBranchCommandInputs("Stack1", null, false));
 
         // Assert
         inputProvider.DidNotReceive().Select(Questions.SelectStack, Arg.Any<string[]>());
@@ -172,7 +172,7 @@ public class NewBranchCommandHandlerTests
         inputProvider.Text(Questions.BranchName, Arg.Any<string>()).Returns(newBranch);
 
         // Act
-        await handler.Handle(new NewBranchCommandInputs(null, null, false, false));
+        await handler.Handle(new NewBranchCommandInputs(null, null, false));
 
         // Assert
         inputProvider.DidNotReceive().Select(Questions.SelectStack, Arg.Any<string[]>());
@@ -209,7 +209,7 @@ public class NewBranchCommandHandlerTests
 
         // Act and assert
         var invalidStackName = Some.Name();
-        await handler.Invoking(async h => await h.Handle(new NewBranchCommandInputs(invalidStackName, null, false, false)))
+        await handler.Invoking(async h => await h.Handle(new NewBranchCommandInputs(invalidStackName, null, false)))
             .Should()
             .ThrowAsync<InvalidOperationException>()
             .WithMessage($"Stack '{invalidStackName}' not found.");
@@ -246,7 +246,7 @@ public class NewBranchCommandHandlerTests
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
 
         // Act
-        await handler.Handle(new NewBranchCommandInputs(null, newBranch, false, false));
+        await handler.Handle(new NewBranchCommandInputs(null, newBranch, false));
 
         // Assert
         stacks.Should().BeEquivalentTo(new List<Config.Stack>
@@ -285,7 +285,7 @@ public class NewBranchCommandHandlerTests
 
         // Act and assert
         var invalidBranchName = Some.Name();
-        await handler.Invoking(async h => await h.Handle(new NewBranchCommandInputs(null, anotherBranch, false, false)))
+        await handler.Invoking(async h => await h.Handle(new NewBranchCommandInputs(null, anotherBranch, false)))
             .Should()
             .ThrowAsync<InvalidOperationException>()
             .WithMessage($"Branch '{anotherBranch}' already exists locally.");
@@ -319,50 +319,10 @@ public class NewBranchCommandHandlerTests
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
 
         // Act and assert
-        await handler.Invoking(async h => await h.Handle(new NewBranchCommandInputs(null, newBranch, false, false)))
+        await handler.Invoking(async h => await h.Handle(new NewBranchCommandInputs(null, newBranch, false)))
             .Should()
             .ThrowAsync<InvalidOperationException>()
             .WithMessage($"Branch '{newBranch}' already exists in stack 'Stack1'.");
-    }
-
-    [Fact]
-    public async Task WhenAllInputsProvided_DoesNotAskForAnything_CreatesAndAddsBranchFromStackAndChangesToBranch()
-    {
-        // Arrange
-        var sourceBranch = Some.BranchName();
-        var anotherBranch = Some.BranchName();
-        var newBranch = Some.BranchName();
-        using var repo = new TestGitRepositoryBuilder()
-            .WithBranch(sourceBranch)
-            .WithBranch(anotherBranch)
-            .Build();
-
-        var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<IInputProvider>();
-        var outputProvider = Substitute.For<IOutputProvider>();
-        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
-        var handler = new NewBranchCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
-
-        var stacks = new List<Config.Stack>(
-        [
-            new("Stack1", repo.RemoteUri, sourceBranch, [anotherBranch]),
-            new("Stack2", repo.RemoteUri, sourceBranch, [])
-        ]);
-        stackConfig.Load().Returns(stacks);
-        stackConfig
-            .WhenForAnyArgs(s => s.Save(Arg.Any<List<Config.Stack>>()))
-            .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
-
-        // Act
-        await handler.Handle(new NewBranchCommandInputs("Stack1", newBranch, true, false));
-
-        // Assert
-        stacks.Should().BeEquivalentTo(new List<Config.Stack>
-        {
-            new("Stack1", repo.RemoteUri, sourceBranch, [anotherBranch, newBranch]),
-            new("Stack2", repo.RemoteUri, sourceBranch, [])
-        });
-        inputProvider.ReceivedCalls().Should().BeEmpty();
     }
 
     [Fact]
@@ -442,7 +402,7 @@ public class NewBranchCommandHandlerTests
         inputProvider.Confirm(Questions.ConfirmSwitchToBranch).Returns(false);
 
         // Act
-        await handler.Handle(new NewBranchCommandInputs(null, null, false, true));
+        await handler.Handle(new NewBranchCommandInputs(null, null, true));
 
         // Assert
         stacks.Should().BeEquivalentTo(new List<Config.Stack>

--- a/src/Stack.Tests/Commands/Branch/RemoveBranchCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Branch/RemoveBranchCommandHandlerTests.cs
@@ -43,7 +43,7 @@ public class RemoveBranchCommandHandlerTests
         inputProvider.Confirm(Questions.ConfirmRemoveBranch).Returns(true);
 
         // Act
-        await handler.Handle(new RemoveBranchCommandInputs(null, null, false));
+        await handler.Handle(new RemoveBranchCommandInputs(null, null));
 
         // Assert
         stacks.Should().BeEquivalentTo(new List<Config.Stack>
@@ -84,7 +84,7 @@ public class RemoveBranchCommandHandlerTests
         inputProvider.Confirm(Questions.ConfirmRemoveBranch).Returns(true);
 
         // Act
-        await handler.Handle(new RemoveBranchCommandInputs("Stack1", null, false));
+        await handler.Handle(new RemoveBranchCommandInputs("Stack1", null));
 
         // Assert
         inputProvider.DidNotReceive().Select(Questions.SelectStack, Arg.Any<string[]>());
@@ -121,7 +121,7 @@ public class RemoveBranchCommandHandlerTests
 
         // Act and assert
         var invalidStackName = Some.Name();
-        await handler.Invoking(async h => await h.Handle(new RemoveBranchCommandInputs(invalidStackName, null, false)))
+        await handler.Invoking(async h => await h.Handle(new RemoveBranchCommandInputs(invalidStackName, null)))
             .Should()
             .ThrowAsync<InvalidOperationException>()
             .WithMessage($"Stack '{invalidStackName}' not found.");
@@ -158,7 +158,7 @@ public class RemoveBranchCommandHandlerTests
         inputProvider.Confirm(Questions.ConfirmRemoveBranch).Returns(true);
 
         // Act
-        await handler.Handle(new RemoveBranchCommandInputs(null, branchToRemove, false));
+        await handler.Handle(new RemoveBranchCommandInputs(null, branchToRemove));
 
         // Assert
         stacks.Should().BeEquivalentTo(new List<Config.Stack>
@@ -197,91 +197,10 @@ public class RemoveBranchCommandHandlerTests
 
         // Act and assert
         var invalidBranchName = Some.Name();
-        await handler.Invoking(async h => await h.Handle(new RemoveBranchCommandInputs(null, invalidBranchName, false)))
+        await handler.Invoking(async h => await h.Handle(new RemoveBranchCommandInputs(null, invalidBranchName)))
             .Should()
             .ThrowAsync<InvalidOperationException>()
             .WithMessage($"Branch '{invalidBranchName}' not found in stack 'Stack1'.");
-    }
-
-    [Fact]
-    public async Task WhenForceProvided_DoesNotAskForConfirmation_RemovesBranchFromStack()
-    {
-        // Arrange
-        var sourceBranch = Some.BranchName();
-        var branchToRemove = Some.BranchName();
-        using var repo = new TestGitRepositoryBuilder()
-            .WithBranch(sourceBranch)
-            .WithBranch(branchToRemove)
-            .Build();
-
-        var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<IInputProvider>();
-        var outputProvider = Substitute.For<IOutputProvider>();
-        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
-        var handler = new RemoveBranchCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
-
-        var stacks = new List<Config.Stack>(
-        [
-            new("Stack1", repo.RemoteUri, sourceBranch, [branchToRemove]),
-            new("Stack2", repo.RemoteUri, sourceBranch, [])
-        ]);
-        stackConfig.Load().Returns(stacks);
-        stackConfig
-            .WhenForAnyArgs(s => s.Save(Arg.Any<List<Config.Stack>>()))
-            .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
-
-        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
-        inputProvider.Select(Questions.SelectBranch, Arg.Any<string[]>()).Returns(branchToRemove);
-
-        // Act
-        await handler.Handle(new RemoveBranchCommandInputs(null, null, true));
-
-        // Assert
-        stacks.Should().BeEquivalentTo(new List<Config.Stack>
-        {
-            new("Stack1", repo.RemoteUri, sourceBranch, []),
-            new("Stack2", repo.RemoteUri, sourceBranch, [])
-        });
-        inputProvider.DidNotReceive().Confirm(Questions.ConfirmRemoveBranch);
-    }
-
-    [Fact]
-    public async Task WhenAllInputsProvided_DoesNotAskForAnything_RemovesBranchFromStack()
-    {
-        // Arrange
-        var sourceBranch = Some.BranchName();
-        var branchToRemove = Some.BranchName();
-        using var repo = new TestGitRepositoryBuilder()
-            .WithBranch(sourceBranch)
-            .WithBranch(branchToRemove)
-            .Build();
-
-        var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<IInputProvider>();
-        var outputProvider = Substitute.For<IOutputProvider>();
-        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
-        var handler = new RemoveBranchCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
-
-        var stacks = new List<Config.Stack>(
-        [
-            new("Stack1", repo.RemoteUri, sourceBranch, [branchToRemove]),
-            new("Stack2", repo.RemoteUri, sourceBranch, [])
-        ]);
-        stackConfig.Load().Returns(stacks);
-        stackConfig
-            .WhenForAnyArgs(s => s.Save(Arg.Any<List<Config.Stack>>()))
-            .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
-
-        // Act
-        await handler.Handle(new RemoveBranchCommandInputs("Stack1", branchToRemove, true));
-
-        // Assert
-        stacks.Should().BeEquivalentTo(new List<Config.Stack>
-        {
-            new("Stack1", repo.RemoteUri, sourceBranch, []),
-            new("Stack2", repo.RemoteUri, sourceBranch, [])
-        });
-        inputProvider.ReceivedCalls().Should().BeEmpty();
     }
 
     [Fact]
@@ -314,7 +233,7 @@ public class RemoveBranchCommandHandlerTests
         inputProvider.Confirm(Questions.ConfirmRemoveBranch).Returns(true);
 
         // Act
-        await handler.Handle(new RemoveBranchCommandInputs(null, null, false));
+        await handler.Handle(new RemoveBranchCommandInputs(null, null));
 
         // Assert
         stacks.Should().BeEquivalentTo(new List<Config.Stack>

--- a/src/Stack.Tests/Commands/Remote/SyncStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Remote/SyncStackCommandHandlerTests.cs
@@ -47,7 +47,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Confirm(Questions.ConfirmSyncStack).Returns(true);
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs(null, false, 5, false, false));
+        await handler.Handle(new SyncStackCommandInputs(null, 5, false, false));
 
         // Assert
         repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfRemoteSourceBranch);
@@ -88,54 +88,12 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Confirm(Questions.ConfirmSyncStack).Returns(true);
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs("Stack1", false, 5, false, false));
+        await handler.Handle(new SyncStackCommandInputs("Stack1", 5, false, false));
 
         // Assert
         repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfRemoteSourceBranch);
         repo.GetCommitsReachableFromRemoteBranch(branch2).Should().Contain(tipOfRemoteSourceBranch);
         inputProvider.DidNotReceive().Select(Questions.SelectStack, Arg.Any<string[]>());
-    }
-
-    [Fact]
-    public async Task WhenNoConfirmIsProvided_DoesNotAskForConfirmation()
-    {
-        // Arrange
-        var sourceBranch = Some.BranchName();
-        var branch1 = Some.BranchName();
-        var branch2 = Some.BranchName();
-        using var repo = new TestGitRepositoryBuilder()
-            .WithBranch(builder => builder.WithName(sourceBranch).PushToRemote())
-            .WithBranch(builder => builder.WithName(branch1).FromSourceBranch(sourceBranch).WithNumberOfEmptyCommits(10).PushToRemote())
-            .WithBranch(builder => builder.WithName(branch2).FromSourceBranch(branch1).WithNumberOfEmptyCommits(1).PushToRemote())
-            .WithNumberOfEmptyCommitsOnRemoteTrackingBranchOf(sourceBranch, 5, b => b.PushToRemote())
-            .Build();
-
-        var tipOfRemoteSourceBranch = repo.GetTipOfRemoteBranch(sourceBranch);
-        repo.GetCommitsReachableFromBranch(sourceBranch).Should().NotContain(tipOfRemoteSourceBranch);
-
-        var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<IInputProvider>();
-        var outputProvider = new TestOutputProvider(testOutputHelper);
-        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
-        var gitHubClient = Substitute.For<IGitHubClient>();
-        var handler = new SyncStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, stackConfig);
-
-        gitClient.ChangeBranch(branch1);
-
-        var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
-        var stack2 = new Config.Stack("Stack2", repo.RemoteUri, sourceBranch, []);
-        var stacks = new List<Config.Stack>([stack1, stack2]);
-        stackConfig.Load().Returns(stacks);
-
-        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
-
-        // Act
-        await handler.Handle(new SyncStackCommandInputs(null, true, 5, false, false));
-
-        // Assert
-        repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfRemoteSourceBranch);
-        repo.GetCommitsReachableFromRemoteBranch(branch2).Should().Contain(tipOfRemoteSourceBranch);
-        inputProvider.DidNotReceive().Confirm(Questions.ConfirmSyncStack);
     }
 
     [Fact]
@@ -171,7 +129,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
 
         // Act and assert
         var invalidStackName = Some.Name();
-        await handler.Invoking(async h => await h.Handle(new SyncStackCommandInputs(invalidStackName, false, 5, false, false)))
+        await handler.Invoking(async h => await h.Handle(new SyncStackCommandInputs(invalidStackName, 5, false, false)))
             .Should().ThrowAsync<InvalidOperationException>()
             .WithMessage($"Stack '{invalidStackName}' not found.");
     }
@@ -212,7 +170,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Confirm(Questions.ConfirmSyncStack).Returns(true);
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs(null, false, 5, false, false));
+        await handler.Handle(new SyncStackCommandInputs(null, 5, false, false));
 
         // Assert
         repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfRemoteSourceBranch);
@@ -253,7 +211,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Confirm(Questions.ConfirmSyncStack).Returns(true);
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs(null, false, 5, false, false));
+        await handler.Handle(new SyncStackCommandInputs(null, 5, false, false));
 
         // Assert
         repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfRemoteSourceBranch);
@@ -300,7 +258,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Confirm(Questions.ConfirmSyncStack).Returns(true);
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs(null, false, 5, true, false));
+        await handler.Handle(new SyncStackCommandInputs(null, 5, true, false));
 
         // Assert
         var tipOfBranch1 = repo.GetTipOfBranch(branch1);
@@ -347,7 +305,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Confirm(Questions.ConfirmSyncStack).Returns(true);
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs(null, false, 5, false, true));
+        await handler.Handle(new SyncStackCommandInputs(null, 5, false, true));
 
         // Assert
         var tipOfBranch1 = repo.GetTipOfBranch(branch1);
@@ -395,7 +353,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Confirm(Questions.ConfirmSyncStack).Returns(true);
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs(null, false, 5, null, null));
+        await handler.Handle(new SyncStackCommandInputs(null, 5, null, null));
 
         // Assert
         var tipOfBranch1 = repo.GetTipOfBranch(branch1);
@@ -443,7 +401,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Confirm(Questions.ConfirmSyncStack).Returns(true);
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs(null, false, 5, null, null));
+        await handler.Handle(new SyncStackCommandInputs(null, 5, null, null));
 
         // Assert
         var tipOfBranch1 = repo.GetTipOfBranch(branch1);
@@ -491,7 +449,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Confirm(Questions.ConfirmSyncStack).Returns(true);
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs(null, false, 5, true, null));
+        await handler.Handle(new SyncStackCommandInputs(null, 5, true, null));
 
         // Assert
         var tipOfBranch1 = repo.GetTipOfBranch(branch1);
@@ -539,7 +497,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Confirm(Questions.ConfirmSyncStack).Returns(true);
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs(null, false, 5, null, true));
+        await handler.Handle(new SyncStackCommandInputs(null, 5, null, true));
 
         // Assert
         var tipOfBranch1 = repo.GetTipOfBranch(branch1);
@@ -562,7 +520,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
 
         // Act and assert
         await handler
-            .Invoking(h => h.Handle(new SyncStackCommandInputs(null, false, 5, true, true)))
+            .Invoking(h => h.Handle(new SyncStackCommandInputs(null, 5, true, true)))
             .Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("Cannot specify both rebase and merge.");
     }

--- a/src/Stack.Tests/Commands/Stack/CleanupStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/CleanupStackCommandHandlerTests.cs
@@ -154,46 +154,10 @@ public class CleanupStackCommandHandlerTests
         inputProvider.Confirm(Questions.ConfirmDeleteBranches).Returns(true);
 
         // Act
-        await handler.Handle(new CleanupStackCommandInputs("Stack1", false));
+        await handler.Handle(new CleanupStackCommandInputs("Stack1"));
 
         // Assert
         inputProvider.DidNotReceive().Select(Questions.SelectStack, Arg.Any<string[]>());
-    }
-
-    [Fact]
-    public async Task WhenForceIsProvided_ItIsNotAskedFor()
-    {
-        // Arrange
-        var sourceBranch = Some.BranchName();
-        var branchToCleanup = Some.BranchName();
-        var branchToKeep = Some.BranchName();
-        using var repo = new TestGitRepositoryBuilder()
-            .WithBranch(sourceBranch, true)
-            .WithBranch(branchToCleanup, false)
-            .WithBranch(branchToKeep, true)
-            .Build();
-
-        var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<IInputProvider>();
-        var outputProvider = Substitute.For<IOutputProvider>();
-        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
-        var gitHubClient = Substitute.For<IGitHubClient>();
-        var handler = new CleanupStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, stackConfig);
-
-        var stacks = new List<Config.Stack>(
-        [
-            new("Stack1", repo.RemoteUri, sourceBranch, [branchToCleanup, branchToKeep]),
-            new("Stack2", repo.RemoteUri, sourceBranch, [])
-        ]);
-        stackConfig.Load().Returns(stacks);
-
-        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
-
-        // Act
-        await handler.Handle(new CleanupStackCommandInputs(null, true));
-
-        // Assert
-        inputProvider.DidNotReceive().Confirm(Questions.ConfirmDeleteBranches);
     }
 
     [Fact]
@@ -227,7 +191,7 @@ public class CleanupStackCommandHandlerTests
 
         // Act and assert
         var invalidStackName = Some.Name();
-        await handler.Invoking(async h => await h.Handle(new CleanupStackCommandInputs(invalidStackName, false)))
+        await handler.Invoking(async h => await h.Handle(new CleanupStackCommandInputs(invalidStackName)))
             .Should()
             .ThrowAsync<InvalidOperationException>()
             .WithMessage($"Stack '{invalidStackName}' not found.");
@@ -262,7 +226,7 @@ public class CleanupStackCommandHandlerTests
         inputProvider.Confirm(Questions.ConfirmDeleteBranches).Returns(true);
 
         // Act
-        await handler.Handle(new CleanupStackCommandInputs(null, true));
+        await handler.Handle(new CleanupStackCommandInputs(null));
 
         // Assert
         inputProvider.DidNotReceive().Select(Questions.SelectStack, Arg.Any<string[]>());

--- a/src/Stack.Tests/Commands/Stack/DeleteStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/DeleteStackCommandHandlerTests.cs
@@ -115,7 +115,7 @@ public class DeleteStackCommandHandlerTests
         inputProvider.Confirm(Questions.ConfirmDeleteStack).Returns(true);
 
         // Act
-        var response = await handler.Handle(new DeleteStackCommandInputs("Stack1", false));
+        var response = await handler.Handle(new DeleteStackCommandInputs("Stack1"));
 
         // Assert
         response.Should().Be(new DeleteStackCommandResponse("Stack1"));
@@ -125,82 +125,6 @@ public class DeleteStackCommandHandlerTests
         });
 
         inputProvider.DidNotReceive().Select(Questions.SelectStack, Arg.Any<string[]>());
-    }
-
-    [Fact]
-    public async Task WhenForceIsProvided_DoesNotAskForConfirmation_AndDeletesStack()
-    {
-        // Arrange
-        var sourceBranch = Some.BranchName();
-        using var repo = new TestGitRepositoryBuilder().Build();
-
-        var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<IInputProvider>();
-        var outputProvider = Substitute.For<IOutputProvider>();
-        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
-        var gitHubClient = Substitute.For<IGitHubClient>();
-        var handler = new DeleteStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, stackConfig);
-
-        var stacks = new List<Config.Stack>(
-        [
-            new("Stack1", repo.RemoteUri, sourceBranch, []),
-            new("Stack2", repo.RemoteUri, sourceBranch, [])
-        ]);
-        stackConfig.Load().Returns(stacks);
-        stackConfig
-            .WhenForAnyArgs(s => s.Save(Arg.Any<List<Config.Stack>>()))
-            .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
-
-        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
-
-        // Act
-        var response = await handler.Handle(new DeleteStackCommandInputs(null, true));
-
-        // Assert
-        response.Should().Be(new DeleteStackCommandResponse("Stack1"));
-        stacks.Should().BeEquivalentTo(new List<Config.Stack>
-        {
-            new("Stack2", repo.RemoteUri, sourceBranch, [])
-        });
-
-        inputProvider.DidNotReceive().Confirm(Questions.ConfirmDeleteStack);
-    }
-
-    [Fact]
-    public async Task WhenNameAndForceAreProvided_DoesNotAskForAnyInput_AndDeletesStack()
-    {
-        // Arrange
-        var sourceBranch = Some.BranchName();
-        using var repo = new TestGitRepositoryBuilder().Build();
-
-        var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<IInputProvider>();
-        var outputProvider = Substitute.For<IOutputProvider>();
-        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
-        var gitHubClient = Substitute.For<IGitHubClient>();
-        var handler = new DeleteStackCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, stackConfig);
-
-        var stacks = new List<Config.Stack>(
-        [
-            new("Stack1", repo.RemoteUri, sourceBranch, []),
-            new("Stack2", repo.RemoteUri, sourceBranch, [])
-        ]);
-        stackConfig.Load().Returns(stacks);
-        stackConfig
-            .WhenForAnyArgs(s => s.Save(Arg.Any<List<Config.Stack>>()))
-            .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
-
-        // Act
-        var response = await handler.Handle(new DeleteStackCommandInputs("Stack1", true));
-
-        // Assert
-        response.Should().Be(new DeleteStackCommandResponse("Stack1"));
-        stacks.Should().BeEquivalentTo(new List<Config.Stack>
-        {
-            new("Stack2", repo.RemoteUri, sourceBranch, [])
-        });
-
-        inputProvider.ReceivedCalls().Should().BeEmpty();
     }
 
     [Fact]
@@ -231,7 +155,7 @@ public class DeleteStackCommandHandlerTests
 
         // Act and assert
         await handler
-            .Invoking(h => h.Handle(new DeleteStackCommandInputs(Some.Name(), false)))
+            .Invoking(h => h.Handle(new DeleteStackCommandInputs(Some.Name())))
             .Should()
             .ThrowAsync<InvalidOperationException>();
     }
@@ -309,7 +233,7 @@ public class DeleteStackCommandHandlerTests
         inputProvider.Confirm(Questions.ConfirmDeleteStack).Returns(true);
 
         // Act
-        var response = await handler.Handle(new DeleteStackCommandInputs("Stack1", false));
+        var response = await handler.Handle(new DeleteStackCommandInputs("Stack1"));
 
         // Assert
         response.Should().Be(new DeleteStackCommandResponse("Stack1"));

--- a/src/Stack/Commands/Branch/NewBranchCommand.cs
+++ b/src/Stack/Commands/Branch/NewBranchCommand.cs
@@ -18,10 +18,6 @@ public class NewBranchCommandSettings : CommandSettingsBase
     [CommandOption("-n|--name")]
     public string? Name { get; init; }
 
-    [Description("Force creating the branch without prompting.")]
-    [CommandOption("-f|--force")]
-    public bool Force { get; init; }
-
     [Description("Push the new branch to the remote repository.")]
     [CommandOption("--push")]
     public bool Push { get; init; }
@@ -42,15 +38,15 @@ public class NewBranchCommand : AsyncCommand<NewBranchCommandSettings>
             new GitClient(outputProvider, settings.GetGitClientSettings()),
             new StackConfig());
 
-        await handler.Handle(new NewBranchCommandInputs(settings.Stack, settings.Name, settings.Force, settings.Push));
+        await handler.Handle(new NewBranchCommandInputs(settings.Stack, settings.Name, settings.Push));
 
         return 0;
     }
 }
 
-public record NewBranchCommandInputs(string? StackName, string? BranchName, bool Force, bool Push)
+public record NewBranchCommandInputs(string? StackName, string? BranchName, bool Push)
 {
-    public static NewBranchCommandInputs Empty => new(null, null, false, false);
+    public static NewBranchCommandInputs Empty => new(null, null, false);
 }
 
 public record NewBranchCommandResponse();
@@ -120,7 +116,7 @@ public class NewBranchCommandHandler(
             outputProvider.Information($"Use {$"stack push --name \"{stack.Name}\"".Example()} to push the branch to the remote repository.");
         }
 
-        if (inputs.Force || inputProvider.Confirm(Questions.ConfirmSwitchToBranch))
+        if (inputProvider.Confirm(Questions.ConfirmSwitchToBranch))
         {
             gitClient.ChangeBranch(branchName);
         }

--- a/src/Stack/Commands/Branch/RemoveBranchCommand.cs
+++ b/src/Stack/Commands/Branch/RemoveBranchCommand.cs
@@ -17,10 +17,6 @@ public class RemoveBranchCommandSettings : CommandSettingsBase
     [Description("The name of the branch to add.")]
     [CommandOption("-n|--name")]
     public string? Name { get; init; }
-
-    [Description("Force removing the branch without prompting.")]
-    [CommandOption("-f|--force")]
-    public bool Force { get; init; }
 }
 
 public class RemoveBranchCommand : AsyncCommand<RemoveBranchCommandSettings>
@@ -38,15 +34,15 @@ public class RemoveBranchCommand : AsyncCommand<RemoveBranchCommandSettings>
             new GitClient(outputProvider, settings.GetGitClientSettings()),
             new StackConfig());
 
-        await handler.Handle(new RemoveBranchCommandInputs(settings.Stack, settings.Name, settings.Force));
+        await handler.Handle(new RemoveBranchCommandInputs(settings.Stack, settings.Name));
 
         return 0;
     }
 }
 
-public record RemoveBranchCommandInputs(string? StackName, string? BranchName, bool Force)
+public record RemoveBranchCommandInputs(string? StackName, string? BranchName)
 {
-    public static RemoveBranchCommandInputs Empty => new(null, null, false);
+    public static RemoveBranchCommandInputs Empty => new(null, null);
 }
 
 public record RemoveBranchCommandResponse();
@@ -80,7 +76,7 @@ public class RemoveBranchCommandHandler(
             throw new InvalidOperationException($"Branch '{branchName}' not found in stack '{stack.Name}'.");
         }
 
-        if (inputs.Force || inputProvider.Confirm(Questions.ConfirmRemoveBranch))
+        if (inputProvider.Confirm(Questions.ConfirmRemoveBranch))
         {
             stack.Branches.Remove(branchName);
             stackConfig.Save(stacks);

--- a/src/Stack/Commands/Remote/SyncStackCommand.cs
+++ b/src/Stack/Commands/Remote/SyncStackCommand.cs
@@ -14,10 +14,6 @@ public class SyncStackCommandSettings : CommandSettingsBase
     [CommandOption("-n|--name")]
     public string? Name { get; init; }
 
-    [Description("Don't ask for confirmation before syncing the stack.")]
-    [CommandOption("-y|--yes")]
-    public bool NoConfirm { get; init; }
-
     [Description("The maximum number of branches to push changes for at once.")]
     [CommandOption("--max-batch-size")]
     [DefaultValue(5)]
@@ -48,7 +44,6 @@ public class SyncStackCommand : AsyncCommand<SyncStackCommandSettings>
 
         await handler.Handle(new SyncStackCommandInputs(
             settings.Name,
-            settings.NoConfirm,
             settings.MaxBatchSize,
             settings.Rebase,
             settings.Merge));
@@ -59,12 +54,11 @@ public class SyncStackCommand : AsyncCommand<SyncStackCommandSettings>
 
 public record SyncStackCommandInputs(
     string? Name,
-    bool NoConfirm,
     int MaxBatchSize,
     bool? Rebase,
     bool? Merge)
 {
-    public static SyncStackCommandInputs Empty => new(null, false, 5, null, null);
+    public static SyncStackCommandInputs Empty => new(null, 5, null, null);
 }
 
 public record SyncStackCommandResponse();
@@ -115,7 +109,7 @@ public class SyncStackCommandHandler(
 
         outputProvider.NewLine();
 
-        if (inputs.NoConfirm || inputProvider.Confirm(Questions.ConfirmSyncStack))
+        if (inputProvider.Confirm(Questions.ConfirmSyncStack))
         {
             outputProvider.Information($"Syncing stack {stack.Name.Stack()} with the remote repository");
 

--- a/src/Stack/Commands/Stack/CleanupStackCommand.cs
+++ b/src/Stack/Commands/Stack/CleanupStackCommand.cs
@@ -14,10 +14,6 @@ public class CleanupStackCommandSettings : CommandSettingsBase
     [Description("The name of the stack to cleanup.")]
     [CommandOption("-n|--name")]
     public string? Name { get; init; }
-
-    [Description("Cleanup the stack without prompting.")]
-    [CommandOption("-f|--force")]
-    public bool Force { get; init; }
 }
 
 public class CleanupStackCommand : AsyncCommand<CleanupStackCommandSettings>
@@ -36,15 +32,15 @@ public class CleanupStackCommand : AsyncCommand<CleanupStackCommandSettings>
             new GitHubClient(outputProvider, settings.GetGitHubClientSettings()),
             new StackConfig());
 
-        await handler.Handle(new CleanupStackCommandInputs(settings.Name, settings.Force));
+        await handler.Handle(new CleanupStackCommandInputs(settings.Name));
 
         return 0;
     }
 }
 
-public record CleanupStackCommandInputs(string? Name, bool Force)
+public record CleanupStackCommandInputs(string? Name)
 {
-    public static CleanupStackCommandInputs Empty => new(null, false);
+    public static CleanupStackCommandInputs Empty => new((string?)null);
 }
 
 public record CleanupStackCommandResponse(string? CleanedUpStackName);
@@ -84,12 +80,9 @@ public class CleanupStackCommandHandler(
             return;
         }
 
-        if (!inputs.Force)
-        {
-            OutputBranchesNeedingCleanup(outputProvider, branchesToCleanUp);
-        }
+        OutputBranchesNeedingCleanup(outputProvider, branchesToCleanUp);
 
-        if (inputs.Force || inputProvider.Confirm(Questions.ConfirmDeleteBranches))
+        if (inputProvider.Confirm(Questions.ConfirmDeleteBranches))
         {
             CleanupBranches(gitClient, outputProvider, branchesToCleanUp);
 


### PR DESCRIPTION
This PR removes the `--force` option from all commands that had it, it was inconsistently applied, clashes with the option that Git uses when force pushing changes and is generally only useful in automation scenarios which are not well supported at the moment anyway.