### PR TITLE
Replace `--push` option with asking whether to push to remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ To create a stack:
 - Give your stack a name.
 - Select a branch to start your stack from.
 - Optionally either create a new branch from the source branch, or add an existing branch to the stack.
+- Optionally push a new branch to the remote repository.
 - If you chose to create or add a branch you can switch to that branch to start work.
 
-By default new branches are only created locally, you can either use the `--push` option or use the `stack push` command to push the branch to the remote.
+If a new branch was not pushed to the remote, you can use the `stack push` command to push the branch to the remote.
 
 ### Working within a stack
 
@@ -156,7 +157,6 @@ OPTIONS:
     -n, --name             The name of the stack. Must be unique
     -s, --source-branch    The source branch to use for the new branch. Defaults to the default branch for the repository
     -b, --branch           The name of the branch to create within the stack
-        --push             Push the new branch to the remote repository
 ```
 
 ### `stack list`
@@ -274,7 +274,6 @@ OPTIONS:
         --working-dir    The path to the directory containing the git repository. Defaults to the current directory
     -s, --stack          The name of the stack to create the branch in
     -n, --name           The name of the branch to create
-        --push           Push the new branch to the remote repository
 ```
 
 ### `stack branch add`

--- a/src/Stack.Tests/Commands/Branch/NewBranchCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Branch/NewBranchCommandHandlerTests.cs
@@ -41,6 +41,7 @@ public class NewBranchCommandHandlerTests
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
         inputProvider.Text(Questions.BranchName, Arg.Any<string>()).Returns(newBranch);
+        inputProvider.Confirm(Questions.ConfirmPushBranch).Returns(false);
         inputProvider.Confirm(Questions.ConfirmSwitchToBranch).Returns(true);
 
         // Act
@@ -131,7 +132,7 @@ public class NewBranchCommandHandlerTests
         inputProvider.Text(Questions.BranchName, Arg.Any<string>()).Returns(newBranch);
 
         // Act
-        await handler.Handle(new NewBranchCommandInputs("Stack1", null, false));
+        await handler.Handle(new NewBranchCommandInputs("Stack1", null));
 
         // Assert
         inputProvider.DidNotReceive().Select(Questions.SelectStack, Arg.Any<string[]>());
@@ -172,7 +173,7 @@ public class NewBranchCommandHandlerTests
         inputProvider.Text(Questions.BranchName, Arg.Any<string>()).Returns(newBranch);
 
         // Act
-        await handler.Handle(new NewBranchCommandInputs(null, null, false));
+        await handler.Handle(new NewBranchCommandInputs(null, null));
 
         // Assert
         inputProvider.DidNotReceive().Select(Questions.SelectStack, Arg.Any<string[]>());
@@ -209,7 +210,7 @@ public class NewBranchCommandHandlerTests
 
         // Act and assert
         var invalidStackName = Some.Name();
-        await handler.Invoking(async h => await h.Handle(new NewBranchCommandInputs(invalidStackName, null, false)))
+        await handler.Invoking(async h => await h.Handle(new NewBranchCommandInputs(invalidStackName, null)))
             .Should()
             .ThrowAsync<InvalidOperationException>()
             .WithMessage($"Stack '{invalidStackName}' not found.");
@@ -246,7 +247,7 @@ public class NewBranchCommandHandlerTests
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
 
         // Act
-        await handler.Handle(new NewBranchCommandInputs(null, newBranch, false));
+        await handler.Handle(new NewBranchCommandInputs(null, newBranch));
 
         // Assert
         stacks.Should().BeEquivalentTo(new List<Config.Stack>
@@ -285,7 +286,7 @@ public class NewBranchCommandHandlerTests
 
         // Act and assert
         var invalidBranchName = Some.Name();
-        await handler.Invoking(async h => await h.Handle(new NewBranchCommandInputs(null, anotherBranch, false)))
+        await handler.Invoking(async h => await h.Handle(new NewBranchCommandInputs(null, anotherBranch)))
             .Should()
             .ThrowAsync<InvalidOperationException>()
             .WithMessage($"Branch '{anotherBranch}' already exists locally.");
@@ -319,7 +320,7 @@ public class NewBranchCommandHandlerTests
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
 
         // Act and assert
-        await handler.Invoking(async h => await h.Handle(new NewBranchCommandInputs(null, newBranch, false)))
+        await handler.Invoking(async h => await h.Handle(new NewBranchCommandInputs(null, newBranch)))
             .Should()
             .ThrowAsync<InvalidOperationException>()
             .WithMessage($"Branch '{newBranch}' already exists in stack 'Stack1'.");
@@ -370,51 +371,6 @@ public class NewBranchCommandHandlerTests
     }
 
     [Fact]
-    public async Task WhenPushIsProvided_CreatesAndAddsBranchToStack_AndPushesBranchToTheRemote()
-    {
-        // Arrange
-        var sourceBranch = Some.BranchName();
-        var anotherBranch = Some.BranchName();
-        var newBranch = Some.BranchName();
-        using var repo = new TestGitRepositoryBuilder()
-            .WithBranch(sourceBranch)
-            .WithBranch(anotherBranch)
-            .Build();
-
-        var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<IInputProvider>();
-        var outputProvider = Substitute.For<IOutputProvider>();
-        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
-        var handler = new NewBranchCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
-
-        var stacks = new List<Config.Stack>(
-        [
-            new("Stack1", repo.RemoteUri, sourceBranch, [anotherBranch]),
-            new("Stack2", repo.RemoteUri, sourceBranch, [])
-        ]);
-        stackConfig.Load().Returns(stacks);
-        stackConfig
-            .WhenForAnyArgs(s => s.Save(Arg.Any<List<Config.Stack>>()))
-            .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
-
-        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
-        inputProvider.Text(Questions.BranchName, Arg.Any<string>()).Returns(newBranch);
-        inputProvider.Confirm(Questions.ConfirmSwitchToBranch).Returns(false);
-
-        // Act
-        await handler.Handle(new NewBranchCommandInputs(null, null, true));
-
-        // Assert
-        stacks.Should().BeEquivalentTo(new List<Config.Stack>
-        {
-            new("Stack1", repo.RemoteUri, sourceBranch, [anotherBranch, newBranch]),
-            new("Stack2", repo.RemoteUri, sourceBranch, [])
-        });
-        gitClient.GetCurrentBranch().Should().NotBe(newBranch);
-        repo.GetBranches().Should().Contain(b => b.FriendlyName == newBranch && b.IsTracking);
-    }
-
-    [Fact]
     public async Task WhenAskedWhetherToPushToTheRemote_AndTheAnswerIsYes_PushesTheNewBranch()
     {
         // Arrange
@@ -448,7 +404,7 @@ public class NewBranchCommandHandlerTests
         inputProvider.Confirm(Questions.ConfirmSwitchToBranch).Returns(false);
 
         // Act
-        await handler.Handle(new NewBranchCommandInputs(null, null, false));
+        await handler.Handle(new NewBranchCommandInputs(null, null));
 
         // Assert
         stacks.Should().BeEquivalentTo(new List<Config.Stack>

--- a/src/Stack.Tests/Commands/Stack/NewStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/NewStackCommandHandlerTests.cs
@@ -38,6 +38,7 @@ public class NewStackCommandHandlerTests
         inputProvider.Confirm(Questions.ConfirmAddOrCreateBranch).Returns(true);
         inputProvider.Select(Questions.AddOrCreateBranch, Arg.Any<BranchAction[]>(), Arg.Any<Func<BranchAction, string>>()).Returns(BranchAction.Create);
         inputProvider.Text(Questions.BranchName, Arg.Any<string>()).Returns(newBranch);
+        inputProvider.Confirm(Questions.ConfirmPushBranch).Returns(false);
         inputProvider.Confirm(Questions.ConfirmSwitchToBranch).Returns(true);
 
         // Act
@@ -82,6 +83,7 @@ public class NewStackCommandHandlerTests
         inputProvider.Confirm(Questions.ConfirmAddOrCreateBranch).Returns(true);
         inputProvider.Select(Questions.AddOrCreateBranch, Arg.Any<BranchAction[]>(), Arg.Any<Func<BranchAction, string>>()).Returns(BranchAction.Add);
         inputProvider.Select(Questions.SelectBranch, Arg.Any<string[]>()).Returns(existingBranch);
+        inputProvider.Confirm(Questions.ConfirmPushBranch).Returns(false);
         inputProvider.Confirm(Questions.ConfirmSwitchToBranch).Returns(true);
 
         // Act
@@ -170,6 +172,7 @@ public class NewStackCommandHandlerTests
         inputProvider.Confirm(Questions.ConfirmAddOrCreateBranch).Returns(true);
         inputProvider.Select(Questions.AddOrCreateBranch, Arg.Any<BranchAction[]>(), Arg.Any<Func<BranchAction, string>>()).Returns(BranchAction.Create);
         inputProvider.Text(Questions.BranchName, Arg.Any<string>()).Returns(newBranch);
+        inputProvider.Confirm(Questions.ConfirmPushBranch).Returns(false);
         inputProvider.Confirm(Questions.ConfirmSwitchToBranch).Returns(false);
 
         // Act
@@ -416,6 +419,7 @@ public class NewStackCommandHandlerTests
         inputProvider.Confirm(Questions.ConfirmAddOrCreateBranch).Returns(true);
         inputProvider.Select(Questions.AddOrCreateBranch, Arg.Any<BranchAction[]>(), Arg.Any<Func<BranchAction, string>>()).Returns(BranchAction.Create);
         inputProvider.Text(Questions.BranchName, "a-stack-with-multiple-words-1").Returns(newBranch);
+        inputProvider.Confirm(Questions.ConfirmPushBranch).Returns(false);
         inputProvider.Confirm(Questions.ConfirmSwitchToBranch).Returns(true);
 
         // Act
@@ -432,7 +436,7 @@ public class NewStackCommandHandlerTests
     }
 
     [Fact]
-    public async Task WithANewBranch_AndPushingTheBranchToTheRemote_TheStackIsCreatedAndTheBranchExistsOnTheRemote()
+    public async Task WithANewBranch_AndPushIsProvided_TheStackIsCreatedAndTheBranchExistsOnTheRemote()
     {
         // Arrange
         var sourceBranch = Some.BranchName();
@@ -458,6 +462,50 @@ public class NewStackCommandHandlerTests
         inputProvider.Confirm(Questions.ConfirmAddOrCreateBranch).Returns(true);
         inputProvider.Select(Questions.AddOrCreateBranch, Arg.Any<BranchAction[]>(), Arg.Any<Func<BranchAction, string>>()).Returns(BranchAction.Create);
         inputProvider.Text(Questions.BranchName, Arg.Any<string>()).Returns(newBranch);
+        inputProvider.Confirm(Questions.ConfirmSwitchToBranch).Returns(false);
+
+        // Act
+        var response = await handler.Handle(new NewStackCommandInputs(null, null, null, true));
+
+        // Assert
+        response.Should().BeEquivalentTo(new NewStackCommandResponse("Stack1", sourceBranch, BranchAction.Create, newBranch));
+        stacks.Should().BeEquivalentTo(new List<Config.Stack>
+        {
+            new("Stack1", repo.RemoteUri, sourceBranch, [newBranch])
+        });
+
+        repo.GetBranches().Should().Contain(b => b.FriendlyName == newBranch && b.IsTracking);
+        inputProvider.DidNotReceive().Confirm(Questions.ConfirmPushBranch);
+    }
+
+    [Fact]
+    public async Task WithANewBranch_AndAskedToPushToTheRemote_TheStackIsCreatedAndTheBranchExistsOnTheRemote()
+    {
+        // Arrange
+        var sourceBranch = Some.BranchName();
+        var newBranch = Some.BranchName();
+        using var repo = new TestGitRepositoryBuilder()
+            .WithBranch(sourceBranch)
+            .Build();
+
+        var stackConfig = Substitute.For<IStackConfig>();
+        var inputProvider = Substitute.For<IInputProvider>();
+        var outputProvider = Substitute.For<IOutputProvider>();
+        var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
+        var handler = new NewStackCommandHandler(inputProvider, outputProvider, gitClient, stackConfig);
+
+        var stacks = new List<Config.Stack>();
+        stackConfig.Load().Returns(stacks);
+        stackConfig
+            .WhenForAnyArgs(s => s.Save(Arg.Any<List<Config.Stack>>()))
+            .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
+
+        inputProvider.Text(Questions.StackName).Returns("Stack1");
+        inputProvider.Select(Questions.SelectSourceBranch, Arg.Any<string[]>()).Returns(sourceBranch);
+        inputProvider.Confirm(Questions.ConfirmAddOrCreateBranch).Returns(true);
+        inputProvider.Select(Questions.AddOrCreateBranch, Arg.Any<BranchAction[]>(), Arg.Any<Func<BranchAction, string>>()).Returns(BranchAction.Create);
+        inputProvider.Text(Questions.BranchName, Arg.Any<string>()).Returns(newBranch);
+        inputProvider.Confirm(Questions.ConfirmPushBranch).Returns(true);
         inputProvider.Confirm(Questions.ConfirmSwitchToBranch).Returns(false);
 
         // Act

--- a/src/Stack/Commands/Branch/NewBranchCommand.cs
+++ b/src/Stack/Commands/Branch/NewBranchCommand.cs
@@ -17,10 +17,6 @@ public class NewBranchCommandSettings : CommandSettingsBase
     [Description("The name of the branch to create.")]
     [CommandOption("-n|--name")]
     public string? Name { get; init; }
-
-    [Description("Push the new branch to the remote repository.")]
-    [CommandOption("--push")]
-    public bool Push { get; init; }
 }
 
 public class NewBranchCommand : AsyncCommand<NewBranchCommandSettings>
@@ -38,15 +34,15 @@ public class NewBranchCommand : AsyncCommand<NewBranchCommandSettings>
             new GitClient(outputProvider, settings.GetGitClientSettings()),
             new StackConfig());
 
-        await handler.Handle(new NewBranchCommandInputs(settings.Stack, settings.Name, settings.Push));
+        await handler.Handle(new NewBranchCommandInputs(settings.Stack, settings.Name));
 
         return 0;
     }
 }
 
-public record NewBranchCommandInputs(string? StackName, string? BranchName, bool Push)
+public record NewBranchCommandInputs(string? StackName, string? BranchName)
 {
-    public static NewBranchCommandInputs Empty => new(null, null, false);
+    public static NewBranchCommandInputs Empty => new(null, null);
 }
 
 public record NewBranchCommandResponse();
@@ -106,7 +102,7 @@ public class NewBranchCommandHandler(
 
         outputProvider.Information($"Branch {branchName.Branch()} created.");
 
-        if (inputs.Push || inputProvider.Confirm(Questions.ConfirmPushBranch))
+        if (inputProvider.Confirm(Questions.ConfirmPushBranch))
         {
             gitClient.PushNewBranch(branchName);
         }

--- a/src/Stack/Commands/Branch/NewBranchCommand.cs
+++ b/src/Stack/Commands/Branch/NewBranchCommand.cs
@@ -104,14 +104,13 @@ public class NewBranchCommandHandler(
 
         stackConfig.Save(stacks);
 
-        if (inputs.Push)
+        outputProvider.Information($"Branch {branchName.Branch()} created.");
+
+        if (inputs.Push || inputProvider.Confirm(Questions.ConfirmPushBranch))
         {
             gitClient.PushNewBranch(branchName);
         }
-
-        outputProvider.Information($"Branch {branchName.Branch()} created.");
-
-        if (!inputs.Push)
+        else
         {
             outputProvider.Information($"Use {$"stack push --name \"{stack.Name}\"".Example()} to push the branch to the remote repository.");
         }

--- a/src/Stack/Commands/Helpers/Questions.cs
+++ b/src/Stack/Commands/Helpers/Questions.cs
@@ -17,6 +17,7 @@ public static class Questions
     public const string ConfirmAddOrCreateBranch = "Do you want to add an existing branch or create a new branch and add it to the stack?";
     public const string AddOrCreateBranch = "Add or create a branch:";
     public const string ConfirmSwitchToBranch = "Do you want to switch to the new branch?";
+    public const string ConfirmPushBranch = "Do you want to push the new branch to the remote repository?";
     public static string ConfirmStartCreatePullRequests(int numberOfBranchesWithoutPullRequests) => $"There {"are".ToQuantity(numberOfBranchesWithoutPullRequests, ShowQuantityAs.None)} {"branch".ToQuantity(numberOfBranchesWithoutPullRequests)} to create pull requests for. Do you want to continue?";
     public const string ConfirmCreatePullRequests = "Are you sure you want to create pull requests for branches in this stack?";
     public const string PullRequestTitle = "Title:";

--- a/src/Stack/Commands/Stack/NewStackCommand.cs
+++ b/src/Stack/Commands/Stack/NewStackCommand.cs
@@ -103,9 +103,13 @@ public class NewStackCommandHandler(
 
                 gitClient.CreateNewBranch(branchName, sourceBranch);
 
-                if (inputs.Push)
+                if (inputs.Push || inputProvider.Confirm(Questions.ConfirmPushBranch))
                 {
                     gitClient.PushNewBranch(branchName);
+                }
+                else
+                {
+                    outputProvider.Information($"Use {$"stack push --name \"{name}\"".Example()} to push the branch to the remote repository.");
                 }
             }
             else
@@ -131,11 +135,6 @@ public class NewStackCommandHandler(
         if (branchAction is BranchAction.Create)
         {
             outputProvider.Information($"Stack {name.Stack()} created from source branch {sourceBranch.Branch()} with new branch {branchName!.Branch()}");
-
-            if (!inputs.Push)
-            {
-                outputProvider.Information($"Use {$"stack push --name \"{name}\"".Example()} to push the branch to the remote repository.");
-            }
         }
         else if (branchAction is BranchAction.Add)
         {

--- a/src/Stack/Commands/Stack/NewStackCommand.cs
+++ b/src/Stack/Commands/Stack/NewStackCommand.cs
@@ -24,10 +24,6 @@ public class NewStackCommandSettings : CommandSettingsBase
     [Description("The name of the branch to create within the stack.")]
     [CommandOption("-b|--branch")]
     public string? BranchName { get; init; }
-
-    [Description("Push the new branch to the remote repository.")]
-    [CommandOption("--push")]
-    public bool Push { get; init; }
 }
 
 public enum BranchAction
@@ -53,15 +49,15 @@ public class NewStackCommand : AsyncCommand<NewStackCommandSettings>
             new StackConfig());
 
         await handler.Handle(
-            new NewStackCommandInputs(settings.Name, settings.SourceBranch, settings.BranchName, settings.Push));
+            new NewStackCommandInputs(settings.Name, settings.SourceBranch, settings.BranchName));
 
         return 0;
     }
 }
 
-public record NewStackCommandInputs(string? Name, string? SourceBranch, string? BranchName, bool Push)
+public record NewStackCommandInputs(string? Name, string? SourceBranch, string? BranchName)
 {
-    public static NewStackCommandInputs Empty => new(null, null, null, false);
+    public static NewStackCommandInputs Empty => new(null, null, null);
 }
 
 public record NewStackCommandResponse(string StackName, string SourceBranch, BranchAction? BranchAction, string? BranchName);
@@ -103,7 +99,7 @@ public class NewStackCommandHandler(
 
                 gitClient.CreateNewBranch(branchName, sourceBranch);
 
-                if (inputs.Push || inputProvider.Confirm(Questions.ConfirmPushBranch))
+                if (inputProvider.Confirm(Questions.ConfirmPushBranch))
                 {
                     gitClient.PushNewBranch(branchName);
                 }


### PR DESCRIPTION
As part of https://github.com/geofflamrock/stack/pull/165 a new `--push` option was added to the `new` and `branch new` commands to push the newly created branch to the remote repository. The default was also changed on the command to not do this to better support offline operations. 

This is proving to be a pain, I always forget to add `--push` and then need to run `stack push` all the time. So this PR instead asks if you want to push the new branch to the remote to make it easier, removing the `--push` option altogether. I might replace it at some point as part of adding support for non-interactive workflows.