### PR TITLE
Escape markup in status command

### DIFF
--- a/src/Stack/Commands/Helpers/StackHelpers.cs
+++ b/src/Stack/Commands/Helpers/StackHelpers.cs
@@ -268,7 +268,7 @@ public static class StackHelpers
 
         if (branchDetail.Status.Tip is not null)
         {
-            branchNameBuilder.Append($"   {branchDetail.Status.Tip.Sha[..7]} {branchDetail.Status.Tip.Message}");
+            branchNameBuilder.Append($"   {branchDetail.Status.Tip.Sha[..7]} {Markup.Escape(branchDetail.Status.Tip.Message)}");
         }
 
         return branchNameBuilder.ToString();

--- a/src/Stack/Git/GitHubClient.cs
+++ b/src/Stack/Git/GitHubClient.cs
@@ -37,7 +37,7 @@ public static class GitHubPullRequestExtensionMethods
 
     public static string GetPullRequestDisplay(this GitHubPullRequest pullRequest)
     {
-        return $"[{pullRequest.GetPullRequestColor()} link={pullRequest.Url}]#{pullRequest.Number}: {pullRequest.Title}[/]";
+        return $"[{pullRequest.GetPullRequestColor()} link={pullRequest.Url}]#{pullRequest.Number}: {Markup.Escape(pullRequest.Title)}[/]";
     }
 }
 


### PR DESCRIPTION
Fixes #188 

For both commit message and PR title as this may also contain formatting markup.