### PR TITLE
Make options to select a stack consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ OPTIONS:
         --verbose          Show verbose output
         --working-dir      The path to the directory containing the git repository. Defaults to the current directory
     -n, --name             The name of the stack. Must be unique
-    -s, --source-branch    The source branch to use for the new branch. Defaults to the default branch for the repository
+        --source-branch    The source branch to use for the new branch. Defaults to the default branch for the repository
     -b, --branch           The name of the branch to create within the stack
 ```
 
@@ -187,7 +187,7 @@ OPTIONS:
     -v, --version        Prints version information
         --verbose        Show verbose output
         --working-dir    The path to the directory containing the git repository. Defaults to the current directory
-    -n, --name           The name of the stack to show the status of
+    -s, --stack          The name of the stack to show the status of
         --all            Show status of all stacks
         --full           Show full status including pull requests
 ```
@@ -205,7 +205,7 @@ OPTIONS:
     -v, --version        Prints version information
         --verbose        Show verbose output
         --working-dir    The path to the directory containing the git repository. Defaults to the current directory
-    -n, --name           The name of the stack to delete
+    -s, --stack          The name of the stack to delete
 ```
 
 ## Branch commands
@@ -223,7 +223,7 @@ OPTIONS:
     -v, --version        Prints version information
         --verbose        Show verbose output
         --working-dir    The path to the directory containing the git repository. Defaults to the current directory
-    -n, --name           The name of the stack to update
+    -s, --stack          The name of the stack to update
         --rebase         Use rebase when updating the stack. Overrides any setting in Git configuration
         --merge          Use merge when updating the stack. Overrides any setting in Git configuration
 ```
@@ -257,7 +257,7 @@ OPTIONS:
     -v, --version        Prints version information
         --verbose        Show verbose output
         --working-dir    The path to the directory containing the git repository. Defaults to the current directory
-    -n, --name           The name of the stack to cleanup
+    -s, --stack          The name of the stack to cleanup
 ```
 
 ### `stack branch new`
@@ -324,7 +324,7 @@ OPTIONS:
     -v, --version        Prints version information
         --verbose        Show verbose output
         --working-dir    The path to the directory containing the git repository. Defaults to the current directory
-    -n, --name           The name of the stack to pull changes from the remote for
+    -s, --stack          The name of the stack to pull changes from the remote for
 ```
 
 ### `stack push`
@@ -341,7 +341,7 @@ OPTIONS:
     -v, --version             Prints version information
         --verbose             Show verbose output
         --working-dir         The path to the directory containing the git repository. Defaults to the current directory
-    -n, --name                The name of the stack to push changes from the remote for
+    -s, --stack               The name of the stack to push changes from the remote for
         --max-batch-size      The maximum number of branches to push changes for at once (default: 5)
         --force-with-lease    Force push changes with lease
 ```
@@ -360,7 +360,7 @@ OPTIONS:
     -v, --version           Prints version information
         --verbose           Show verbose output
         --working-dir       The path to the directory containing the git repository. Defaults to the current directory
-    -n, --name              The name of the stack to update
+    -s, --stack             The name of the stack to update
         --max-batch-size    The maximum number of branches to push changes for at once (default: 5)
         --rebase            Use rebase when updating the stack. Overrides any setting in Git configuration
         --merge             Use merge when updating the stack. Overrides any setting in Git configuration
@@ -380,7 +380,7 @@ OPTIONS:
     -h, --help           Prints help information
         --verbose        Show verbose output
         --working-dir    The path to the directory containing the git repository. Defaults to the current directory
-    -n, --name           The name of the stack to create pull requests for
+    -s, --stack          The name of the stack to create pull requests for
 ```
 
 ### `stack pr open`
@@ -395,7 +395,7 @@ OPTIONS:
     -h, --help           Prints help information
         --verbose        Show verbose output
         --working-dir    The path to the directory containing the git repository. Defaults to the current directory
-    -n, --name           The name of the stack to open PRs for
+    -s, --stack          The name of the stack to open PRs for
 ```
 
 ## Advanced commands

--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ OPTIONS:
     -v, --version           Prints version information
         --verbose           Show verbose output
         --working-dir       The path to the directory containing the git repository. Defaults to the current directory
-    -s, --stack             The name of the stack to update
+    -s, --stack             The name of the stack to sync with the remote
         --max-batch-size    The maximum number of branches to push changes for at once (default: 5)
         --rebase            Use rebase when updating the stack. Overrides any setting in Git configuration
         --merge             Use merge when updating the stack. Overrides any setting in Git configuration

--- a/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
+++ b/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
@@ -11,8 +11,8 @@ namespace Stack.Commands;
 public class CreatePullRequestsCommandSettings : CommandSettingsBase
 {
     [Description("The name of the stack to create pull requests for.")]
-    [CommandOption("-n|--name")]
-    public string? Name { get; init; }
+    [CommandOption("-s|--stack")]
+    public string? Stack { get; init; }
 }
 
 public class CreatePullRequestsCommand : AsyncCommand<CreatePullRequestsCommandSettings>
@@ -30,13 +30,13 @@ public class CreatePullRequestsCommand : AsyncCommand<CreatePullRequestsCommandS
             new FileOperations(),
             new StackConfig());
 
-        await handler.Handle(new CreatePullRequestsCommandInputs(settings.Name));
+        await handler.Handle(new CreatePullRequestsCommandInputs(settings.Stack));
 
         return 0;
     }
 }
 
-public record CreatePullRequestsCommandInputs(string? StackName)
+public record CreatePullRequestsCommandInputs(string? Stack)
 {
     public static CreatePullRequestsCommandInputs Empty => new((string?)null);
 }
@@ -68,11 +68,11 @@ public class CreatePullRequestsCommandHandler(
         }
 
         var currentBranch = gitClient.GetCurrentBranch();
-        var stack = inputProvider.SelectStack(outputProvider, inputs.StackName, stacksForRemote, currentBranch);
+        var stack = inputProvider.SelectStack(outputProvider, inputs.Stack, stacksForRemote, currentBranch);
 
         if (stack is null)
         {
-            throw new InvalidOperationException($"Stack '{inputs.StackName}' not found.");
+            throw new InvalidOperationException($"Stack '{inputs.Stack}' not found.");
         }
 
         var status = StackHelpers.GetStackStatus(

--- a/src/Stack/Commands/PullRequests/OpenPullRequestsCommand.cs
+++ b/src/Stack/Commands/PullRequests/OpenPullRequestsCommand.cs
@@ -11,8 +11,8 @@ namespace Stack.Commands;
 public class OpenPullRequestsCommandSettings : CommandSettingsBase
 {
     [Description("The name of the stack to open PRs for.")]
-    [CommandOption("-n|--name")]
-    public string? Name { get; init; }
+    [CommandOption("-s|--stack")]
+    public string? Stack { get; init; }
 }
 
 public class OpenPullRequestsCommand : AsyncCommand<OpenPullRequestsCommandSettings>
@@ -29,13 +29,13 @@ public class OpenPullRequestsCommand : AsyncCommand<OpenPullRequestsCommandSetti
             new GitHubClient(outputProvider, settings.GetGitHubClientSettings()),
             new StackConfig());
 
-        await handler.Handle(new OpenPullRequestsCommandInputs(settings.Name));
+        await handler.Handle(new OpenPullRequestsCommandInputs(settings.Stack));
 
         return 0;
     }
 }
 
-public record OpenPullRequestsCommandInputs(string? StackName)
+public record OpenPullRequestsCommandInputs(string? Stack)
 {
     public static OpenPullRequestsCommandInputs Empty => new((string?)null);
 }
@@ -65,11 +65,11 @@ public class OpenPullRequestsCommandHandler(
         }
 
         var currentBranch = gitClient.GetCurrentBranch();
-        var stack = inputProvider.SelectStack(outputProvider, inputs.StackName, stacksForRemote, currentBranch);
+        var stack = inputProvider.SelectStack(outputProvider, inputs.Stack, stacksForRemote, currentBranch);
 
         if (stack is null)
         {
-            throw new InvalidOperationException($"Stack '{inputs.StackName}' not found.");
+            throw new InvalidOperationException($"Stack '{inputs.Stack}' not found.");
         }
 
         var pullRequestsInStack = new List<GitHubPullRequest>();

--- a/src/Stack/Commands/Remote/PullStackCommand.cs
+++ b/src/Stack/Commands/Remote/PullStackCommand.cs
@@ -11,8 +11,8 @@ namespace Stack.Commands;
 public class PullStackCommandSettings : CommandSettingsBase
 {
     [Description("The name of the stack to pull changes from the remote for.")]
-    [CommandOption("-n|--name")]
-    public string? Name { get; init; }
+    [CommandOption("-s|--stack")]
+    public string? Stack { get; init; }
 }
 
 public class PullStackCommand : AsyncCommand<PullStackCommandSettings>
@@ -28,13 +28,13 @@ public class PullStackCommand : AsyncCommand<PullStackCommandSettings>
             new GitClient(outputProvider, settings.GetGitClientSettings()),
             new StackConfig());
 
-        await handler.Handle(new PullStackCommandInputs(settings.Name));
+        await handler.Handle(new PullStackCommandInputs(settings.Stack));
 
         return 0;
     }
 }
 
-public record PullStackCommandInputs(string? Name);
+public record PullStackCommandInputs(string? Stack);
 public class PullStackCommandHandler(
     IInputProvider inputProvider,
     IOutputProvider outputProvider,
@@ -57,10 +57,10 @@ public class PullStackCommandHandler(
 
         var currentBranch = gitClient.GetCurrentBranch();
 
-        var stack = inputProvider.SelectStack(outputProvider, inputs.Name, stacksForRemote, currentBranch);
+        var stack = inputProvider.SelectStack(outputProvider, inputs.Stack, stacksForRemote, currentBranch);
 
         if (stack is null)
-            throw new InvalidOperationException($"Stack '{inputs.Name}' not found.");
+            throw new InvalidOperationException($"Stack '{inputs.Stack}' not found.");
 
         StackHelpers.PullChanges(stack, gitClient, outputProvider);
 

--- a/src/Stack/Commands/Remote/PushStackCommand.cs
+++ b/src/Stack/Commands/Remote/PushStackCommand.cs
@@ -11,8 +11,8 @@ namespace Stack.Commands;
 public class PushStackCommandSettings : CommandSettingsBase
 {
     [Description("The name of the stack to push changes from the remote for.")]
-    [CommandOption("-n|--name")]
-    public string? Name { get; init; }
+    [CommandOption("-s|--stack")]
+    public string? Stack { get; init; }
 
     [Description("The maximum number of branches to push changes for at once.")]
     [CommandOption("--max-batch-size")]
@@ -38,7 +38,7 @@ public class PushStackCommand : AsyncCommand<PushStackCommandSettings>
             new StackConfig());
 
         await handler.Handle(new PushStackCommandInputs(
-            settings.Name,
+            settings.Stack,
             settings.MaxBatchSize,
             settings.ForceWithLease));
 
@@ -46,7 +46,7 @@ public class PushStackCommand : AsyncCommand<PushStackCommandSettings>
     }
 }
 
-public record PushStackCommandInputs(string? Name, int MaxBatchSize, bool ForceWithLease)
+public record PushStackCommandInputs(string? Stack, int MaxBatchSize, bool ForceWithLease)
 {
     public static PushStackCommandInputs Default => new(null, 5, false);
 }
@@ -73,10 +73,10 @@ public class PushStackCommandHandler(
 
         var currentBranch = gitClient.GetCurrentBranch();
 
-        var stack = inputProvider.SelectStack(outputProvider, inputs.Name, stacksForRemote, currentBranch);
+        var stack = inputProvider.SelectStack(outputProvider, inputs.Stack, stacksForRemote, currentBranch);
 
         if (stack is null)
-            throw new InvalidOperationException($"Stack '{inputs.Name}' not found.");
+            throw new InvalidOperationException($"Stack '{inputs.Stack}' not found.");
 
         StackHelpers.PushChanges(stack, inputs.MaxBatchSize, inputs.ForceWithLease, gitClient, outputProvider);
     }

--- a/src/Stack/Commands/Remote/SyncStackCommand.cs
+++ b/src/Stack/Commands/Remote/SyncStackCommand.cs
@@ -10,9 +10,9 @@ namespace Stack.Commands;
 
 public class SyncStackCommandSettings : CommandSettingsBase
 {
-    [Description("The name of the stack to update.")]
-    [CommandOption("-n|--name")]
-    public string? Name { get; init; }
+    [Description("The name of the stack to sync with the remote.")]
+    [CommandOption("-s|--stack")]
+    public string? Stack { get; init; }
 
     [Description("The maximum number of branches to push changes for at once.")]
     [CommandOption("--max-batch-size")]
@@ -43,7 +43,7 @@ public class SyncStackCommand : AsyncCommand<SyncStackCommandSettings>
             new StackConfig());
 
         await handler.Handle(new SyncStackCommandInputs(
-            settings.Name,
+            settings.Stack,
             settings.MaxBatchSize,
             settings.Rebase,
             settings.Merge));
@@ -53,7 +53,7 @@ public class SyncStackCommand : AsyncCommand<SyncStackCommandSettings>
 }
 
 public record SyncStackCommandInputs(
-    string? Name,
+    string? Stack,
     int MaxBatchSize,
     bool? Rebase,
     bool? Merge)
@@ -90,10 +90,10 @@ public class SyncStackCommandHandler(
 
         var currentBranch = gitClient.GetCurrentBranch();
 
-        var stack = inputProvider.SelectStack(outputProvider, inputs.Name, stacksForRemote, currentBranch);
+        var stack = inputProvider.SelectStack(outputProvider, inputs.Stack, stacksForRemote, currentBranch);
 
         if (stack is null)
-            throw new InvalidOperationException($"Stack '{inputs.Name}' not found.");
+            throw new InvalidOperationException($"Stack '{inputs.Stack}' not found.");
 
         FetchChanges();
 

--- a/src/Stack/Commands/Stack/CleanupStackCommand.cs
+++ b/src/Stack/Commands/Stack/CleanupStackCommand.cs
@@ -12,8 +12,8 @@ namespace Stack.Commands;
 public class CleanupStackCommandSettings : CommandSettingsBase
 {
     [Description("The name of the stack to cleanup.")]
-    [CommandOption("-n|--name")]
-    public string? Name { get; init; }
+    [CommandOption("-s|--stack")]
+    public string? Stack { get; init; }
 }
 
 public class CleanupStackCommand : AsyncCommand<CleanupStackCommandSettings>
@@ -32,13 +32,13 @@ public class CleanupStackCommand : AsyncCommand<CleanupStackCommandSettings>
             new GitHubClient(outputProvider, settings.GetGitHubClientSettings()),
             new StackConfig());
 
-        await handler.Handle(new CleanupStackCommandInputs(settings.Name));
+        await handler.Handle(new CleanupStackCommandInputs(settings.Stack));
 
         return 0;
     }
 }
 
-public record CleanupStackCommandInputs(string? Name)
+public record CleanupStackCommandInputs(string? Stack)
 {
     public static CleanupStackCommandInputs Empty => new((string?)null);
 }
@@ -62,11 +62,11 @@ public class CleanupStackCommandHandler(
 
         var stacksForRemote = stacks.Where(s => s.RemoteUri.Equals(remoteUri, StringComparison.OrdinalIgnoreCase)).ToList();
 
-        var stack = inputProvider.SelectStack(outputProvider, inputs.Name, stacksForRemote, currentBranch);
+        var stack = inputProvider.SelectStack(outputProvider, inputs.Stack, stacksForRemote, currentBranch);
 
         if (stack is null)
         {
-            throw new InvalidOperationException($"Stack '{inputs.Name}' not found.");
+            throw new InvalidOperationException($"Stack '{inputs.Stack}' not found.");
         }
 
         var branchesInTheStackThatExistLocally = gitClient.GetBranchesThatExistLocally([.. stack.Branches]);

--- a/src/Stack/Commands/Stack/DeleteStackCommand.cs
+++ b/src/Stack/Commands/Stack/DeleteStackCommand.cs
@@ -12,8 +12,8 @@ namespace Stack.Commands;
 public class DeleteStackCommandSettings : CommandSettingsBase
 {
     [Description("The name of the stack to delete.")]
-    [CommandOption("-n|--name")]
-    public string? Name { get; init; }
+    [CommandOption("-s|--stack")]
+    public string? Stack { get; init; }
 }
 
 public class DeleteStackCommand : AsyncCommand<DeleteStackCommandSettings>
@@ -32,7 +32,7 @@ public class DeleteStackCommand : AsyncCommand<DeleteStackCommandSettings>
             new GitHubClient(outputProvider, settings.GetGitHubClientSettings()),
             new StackConfig());
 
-        var response = await handler.Handle(new DeleteStackCommandInputs(settings.Name));
+        var response = await handler.Handle(new DeleteStackCommandInputs(settings.Stack));
 
         if (response.DeletedStackName is not null)
             console.MarkupLine($"Stack {response.DeletedStackName.Stack()} deleted");
@@ -41,7 +41,7 @@ public class DeleteStackCommand : AsyncCommand<DeleteStackCommandSettings>
     }
 }
 
-public record DeleteStackCommandInputs(string? Name)
+public record DeleteStackCommandInputs(string? Stack)
 {
     public static DeleteStackCommandInputs Empty => new((string?)null);
 }
@@ -65,7 +65,7 @@ public class DeleteStackCommandHandler(
 
         var stacksForRemote = stacks.Where(s => s.RemoteUri.Equals(remoteUri, StringComparison.OrdinalIgnoreCase)).ToList();
 
-        var stack = inputProvider.SelectStack(outputProvider, inputs.Name, stacksForRemote, currentBranch);
+        var stack = inputProvider.SelectStack(outputProvider, inputs.Stack, stacksForRemote, currentBranch);
 
         if (stack is null)
         {

--- a/src/Stack/Commands/Stack/NewStackCommand.cs
+++ b/src/Stack/Commands/Stack/NewStackCommand.cs
@@ -18,7 +18,7 @@ public class NewStackCommandSettings : CommandSettingsBase
     public string? Name { get; init; }
 
     [Description("The source branch to use for the new branch. Defaults to the default branch for the repository.")]
-    [CommandOption("-s|--source-branch")]
+    [CommandOption("--source-branch")]
     public string? SourceBranch { get; init; }
 
     [Description("The name of the branch to create within the stack.")]

--- a/src/Stack/Commands/Stack/StackStatusCommand.cs
+++ b/src/Stack/Commands/Stack/StackStatusCommand.cs
@@ -11,8 +11,8 @@ namespace Stack.Commands;
 public class StackStatusCommandSettings : CommandSettingsBase
 {
     [Description("The name of the stack to show the status of.")]
-    [CommandOption("-n|--name")]
-    public string? Name { get; init; }
+    [CommandOption("-s|--stack")]
+    public string? Stack { get; init; }
 
     [Description("Show status of all stacks.")]
     [CommandOption("--all")]
@@ -37,13 +37,13 @@ public class StackStatusCommand : AsyncCommand<StackStatusCommandSettings>
             new GitHubClient(outputProvider, settings.GetGitHubClientSettings()),
             new StackConfig());
 
-        await handler.Handle(new StackStatusCommandInputs(settings.Name, settings.All, settings.Full));
+        await handler.Handle(new StackStatusCommandInputs(settings.Stack, settings.All, settings.Full));
 
         return 0;
     }
 }
 
-public record StackStatusCommandInputs(string? Name, bool All, bool Full);
+public record StackStatusCommandInputs(string? Stack, bool All, bool Full);
 public record StackStatusCommandResponse(Dictionary<Config.Stack, StackStatus> Statuses);
 
 public class StackStatusCommandHandler(
@@ -70,11 +70,11 @@ public class StackStatusCommandHandler(
         }
         else
         {
-            var stack = inputProvider.SelectStack(outputProvider, inputs.Name, stacksForRemote, currentBranch);
+            var stack = inputProvider.SelectStack(outputProvider, inputs.Stack, stacksForRemote, currentBranch);
 
             if (stack is null)
             {
-                throw new InvalidOperationException($"Stack '{inputs.Name}' not found.");
+                throw new InvalidOperationException($"Stack '{inputs.Stack}' not found.");
             }
 
             stacksToCheckStatusFor.Add(stack);

--- a/src/Stack/Commands/Stack/UpdateStackCommand.cs
+++ b/src/Stack/Commands/Stack/UpdateStackCommand.cs
@@ -12,8 +12,8 @@ namespace Stack.Commands;
 public class UpdateStackCommandSettings : CommandSettingsBase
 {
     [Description("The name of the stack to update.")]
-    [CommandOption("-n|--name")]
-    public string? Name { get; init; }
+    [CommandOption("-s|--stack")]
+    public string? Stack { get; init; }
 
     [Description("Use rebase when updating the stack. Overrides any setting in Git configuration.")]
     [CommandOption("--rebase")]
@@ -38,13 +38,13 @@ public class UpdateStackCommand : AsyncCommand<UpdateStackCommandSettings>
             new GitHubClient(outputProvider, settings.GetGitHubClientSettings()),
             new StackConfig());
 
-        await handler.Handle(new UpdateStackCommandInputs(settings.Name, settings.Rebase, settings.Merge));
+        await handler.Handle(new UpdateStackCommandInputs(settings.Stack, settings.Rebase, settings.Merge));
 
         return 0;
     }
 }
 
-public record UpdateStackCommandInputs(string? Name, bool? Rebase, bool? Merge)
+public record UpdateStackCommandInputs(string? Stack, bool? Rebase, bool? Merge)
 {
     public static UpdateStackCommandInputs Empty => new(null, null, null);
 }
@@ -78,10 +78,10 @@ public class UpdateStackCommandHandler(
 
         var currentBranch = gitClient.GetCurrentBranch();
 
-        var stack = inputProvider.SelectStack(outputProvider, inputs.Name, stacksForRemote, currentBranch);
+        var stack = inputProvider.SelectStack(outputProvider, inputs.Stack, stacksForRemote, currentBranch);
 
         if (stack is null)
-            throw new InvalidOperationException($"Stack '{inputs.Name}' not found.");
+            throw new InvalidOperationException($"Stack '{inputs.Stack}' not found.");
 
         var status = StackHelpers.GetStackStatus(
             stack,


### PR DESCRIPTION
Currently the options to select a stack are inconsistent across commands, most use `--name` and a few use `--stack`. This PR makes all commands use `--stack` as this feels the most clear.