### PR TITLE
Support selecting branches to create pull requests for

### DIFF
--- a/src/Stack.Tests/Commands/PullRequests/CreatePullRequestsCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/PullRequests/CreatePullRequestsCommandHandlerTests.cs
@@ -6,6 +6,7 @@ using Stack.Config;
 using Stack.Git;
 using Stack.Infrastructure;
 using Stack.Tests.Helpers;
+using static Stack.Commands.CreatePullRequestsCommandHandler;
 
 namespace Stack.Tests.Commands.PullRequests;
 
@@ -47,7 +48,10 @@ public class CreatePullRequestsCommandHandlerTests
             .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
-        inputProvider.Confirm(Questions.ConfirmStartCreatePullRequests(2)).Returns(true);
+        inputProvider
+            .MultiSelect(Questions.SelectPullRequestsToCreate, Arg.Any<PullRequestCreateAction[]>(), Arg.Any<Func<PullRequestCreateAction, string>>())
+            .Returns([new PullRequestCreateAction(branch1, sourceBranch), new PullRequestCreateAction(branch2, branch1)]);
+        inputProvider.Confirm(Questions.ConfirmStartCreatePullRequests).Returns(true);
         inputProvider.Confirm(Questions.ConfirmCreatePullRequests).Returns(true);
         inputProvider.Text(Questions.PullRequestTitle).Returns("PR Title");
 
@@ -105,7 +109,10 @@ public class CreatePullRequestsCommandHandlerTests
             .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
-        inputProvider.Confirm(Questions.ConfirmStartCreatePullRequests(2)).Returns(true);
+        inputProvider
+            .MultiSelect(Questions.SelectPullRequestsToCreate, Arg.Any<PullRequestCreateAction[]>(), Arg.Any<Func<PullRequestCreateAction, string>>())
+            .Returns([new PullRequestCreateAction(branch1, sourceBranch), new PullRequestCreateAction(branch2, branch1)]);
+        inputProvider.Confirm(Questions.ConfirmStartCreatePullRequests).Returns(true);
         inputProvider.Confirm(Questions.ConfirmCreatePullRequests).Returns(true);
         inputProvider.Text(Questions.PullRequestTitle).Returns("PR Title");
         inputProvider.Text(Questions.PullRequestStackDescription, Arg.Any<string>()).Returns("A custom description");
@@ -179,7 +186,10 @@ A custom description
             .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
-        inputProvider.Confirm(Questions.ConfirmStartCreatePullRequests(1)).Returns(true);
+        inputProvider
+            .MultiSelect(Questions.SelectPullRequestsToCreate, Arg.Any<PullRequestCreateAction[]>(), Arg.Any<Func<PullRequestCreateAction, string>>())
+            .Returns([new PullRequestCreateAction(branch2, branch1)]);
+        inputProvider.Confirm(Questions.ConfirmStartCreatePullRequests).Returns(true);
         inputProvider.Confirm(Questions.ConfirmCreatePullRequests).Returns(true);
         inputProvider.Text(Questions.PullRequestTitle).Returns("PR Title");
         inputProvider.Text(Questions.PullRequestStackDescription, Arg.Any<string>()).Returns("A custom description");
@@ -253,7 +263,10 @@ A custom description
             .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
-        inputProvider.Confirm(Questions.ConfirmStartCreatePullRequests(2)).Returns(true);
+        inputProvider
+            .MultiSelect(Questions.SelectPullRequestsToCreate, Arg.Any<PullRequestCreateAction[]>(), Arg.Any<Func<PullRequestCreateAction, string>>())
+            .Returns([new PullRequestCreateAction(branch1, sourceBranch), new PullRequestCreateAction(branch2, branch1)]);
+        inputProvider.Confirm(Questions.ConfirmStartCreatePullRequests).Returns(true);
         inputProvider.Confirm(Questions.ConfirmCreatePullRequests).Returns(true);
         inputProvider.Text(Questions.PullRequestTitle).Returns("PR Title");
 
@@ -306,7 +319,10 @@ A custom description
         ]);
         stackConfig.Load().Returns(stacks);
 
-        inputProvider.Confirm(Questions.ConfirmStartCreatePullRequests(2)).Returns(true);
+        inputProvider
+            .MultiSelect(Questions.SelectPullRequestsToCreate, Arg.Any<PullRequestCreateAction[]>(), Arg.Any<Func<PullRequestCreateAction, string>>())
+            .Returns([new PullRequestCreateAction(branch1, sourceBranch), new PullRequestCreateAction(branch2, branch1)]);
+        inputProvider.Confirm(Questions.ConfirmStartCreatePullRequests).Returns(true);
         inputProvider.Confirm(Questions.ConfirmCreatePullRequests).Returns(true);
         inputProvider.Text(Questions.PullRequestTitle).Returns("PR Title");
 
@@ -404,7 +420,10 @@ A custom description
             .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
-        inputProvider.Confirm(Questions.ConfirmStartCreatePullRequests(1)).Returns(true);
+        inputProvider
+            .MultiSelect(Questions.SelectPullRequestsToCreate, Arg.Any<PullRequestCreateAction[]>(), Arg.Any<Func<PullRequestCreateAction, string>>())
+            .Returns([new PullRequestCreateAction(branch2, sourceBranch)]);
+        inputProvider.Confirm(Questions.ConfirmStartCreatePullRequests).Returns(true);
         inputProvider.Confirm(Questions.ConfirmCreatePullRequests).Returns(true);
         inputProvider.Text(Questions.PullRequestTitle).Returns("PR Title");
         inputProvider.Text(Questions.PullRequestStackDescription, Arg.Any<string>()).Returns("A custom description");
@@ -480,7 +499,10 @@ A custom description
             .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
-        inputProvider.Confirm(Questions.ConfirmStartCreatePullRequests(1)).Returns(true);
+        inputProvider
+            .MultiSelect(Questions.SelectPullRequestsToCreate, Arg.Any<PullRequestCreateAction[]>(), Arg.Any<Func<PullRequestCreateAction, string>>())
+            .Returns([new PullRequestCreateAction(branch1, sourceBranch)]);
+        inputProvider.Confirm(Questions.ConfirmStartCreatePullRequests).Returns(true);
         inputProvider.Confirm(Questions.ConfirmCreatePullRequests).Returns(true);
         inputProvider.Text(Questions.PullRequestTitle).Returns("PR Title");
 
@@ -535,7 +557,10 @@ A custom description
             .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
-        inputProvider.Confirm(Questions.ConfirmStartCreatePullRequests(1)).Returns(true);
+        inputProvider
+            .MultiSelect(Questions.SelectPullRequestsToCreate, Arg.Any<PullRequestCreateAction[]>(), Arg.Any<Func<PullRequestCreateAction, string>>())
+            .Returns([new PullRequestCreateAction(branch1, sourceBranch)]);
+        inputProvider.Confirm(Questions.ConfirmStartCreatePullRequests).Returns(true);
         inputProvider.Confirm(Questions.ConfirmCreatePullRequests).Returns(true);
         inputProvider.Text(Questions.PullRequestTitle).Returns("PR Title");
 
@@ -589,7 +614,10 @@ A custom description
             .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
-        inputProvider.Confirm(Questions.ConfirmStartCreatePullRequests(2)).Returns(true);
+        inputProvider
+            .MultiSelect(Questions.SelectPullRequestsToCreate, Arg.Any<PullRequestCreateAction[]>(), Arg.Any<Func<PullRequestCreateAction, string>>())
+            .Returns([new PullRequestCreateAction(branch1, sourceBranch), new PullRequestCreateAction(branch2, branch1)]);
+        inputProvider.Confirm(Questions.ConfirmStartCreatePullRequests).Returns(true);
         inputProvider.Confirm(Questions.ConfirmCreatePullRequests).Returns(true);
         inputProvider.Confirm(Questions.CreatePullRequestAsDraft, false).Returns(true);
         inputProvider.Text(Questions.PullRequestTitle).Returns("PR Title");

--- a/src/Stack/Commands/Helpers/Questions.cs
+++ b/src/Stack/Commands/Helpers/Questions.cs
@@ -18,7 +18,8 @@ public static class Questions
     public const string AddOrCreateBranch = "Add or create a branch:";
     public const string ConfirmSwitchToBranch = "Do you want to switch to the new branch?";
     public const string ConfirmPushBranch = "Do you want to push the new branch to the remote repository?";
-    public static string ConfirmStartCreatePullRequests(int numberOfBranchesWithoutPullRequests) => $"There {"are".ToQuantity(numberOfBranchesWithoutPullRequests, ShowQuantityAs.None)} {"branch".ToQuantity(numberOfBranchesWithoutPullRequests)} to create pull requests for. Do you want to continue?";
+    public const string ConfirmStartCreatePullRequests = "Do you want to create pull requests for these branches?";
+    public const string SelectPullRequestsToCreate = "Select branches to create pull requests for:";
     public const string ConfirmCreatePullRequests = "Are you sure you want to create pull requests for branches in this stack?";
     public const string PullRequestTitle = "Title:";
     public const string PullRequestStackDescription = "Stack description for pull request:";

--- a/src/Stack/Commands/Helpers/Questions.cs
+++ b/src/Stack/Commands/Helpers/Questions.cs
@@ -18,7 +18,6 @@ public static class Questions
     public const string AddOrCreateBranch = "Add or create a branch:";
     public const string ConfirmSwitchToBranch = "Do you want to switch to the new branch?";
     public const string ConfirmPushBranch = "Do you want to push the new branch to the remote repository?";
-    public const string ConfirmStartCreatePullRequests = "Do you want to create pull requests for these branches?";
     public const string SelectPullRequestsToCreate = "Select branches to create pull requests for:";
     public const string ConfirmCreatePullRequests = "Are you sure you want to create pull requests for branches in this stack?";
     public const string PullRequestTitle = "Title:";

--- a/src/Stack/Infrastructure/ConsoleInputProvider.cs
+++ b/src/Stack/Infrastructure/ConsoleInputProvider.cs
@@ -10,6 +10,7 @@ public interface IInputProvider
     string Select(string prompt, string[] choices);
     T Select<T>(string prompt, T[] choices, Func<T, string>? converter = null) where T : notnull;
     T SelectGrouped<T>(string prompt, ChoiceGroup<T>[] choices, Func<T, string>? converter = null) where T : notnull;
+    IEnumerable<T> MultiSelect<T>(string prompt, T[] choices, Func<T, string>? converter = null) where T : notnull;
     bool Confirm(string prompt, bool defaultValue = true);
 }
 
@@ -63,6 +64,19 @@ public class ConsoleInputProvider(IAnsiConsole console) : IInputProvider
         {
             select.AddChoiceGroup(group.Group, group.Choices);
         }
+
+        return console.Prompt(select);
+    }
+
+    public IEnumerable<T> MultiSelect<T>(string prompt, T[] choices, Func<T, string>? converter = null)
+        where T : notnull
+    {
+        var select = new MultiSelectionPrompt<T>()
+            .Title(prompt)
+            .PageSize(10)
+            .AddChoices(choices)
+            .Required()
+            .UseConverter(converter);
 
         return console.Prompt(select);
     }

--- a/src/Stack/Infrastructure/ConsoleOutputProvider.cs
+++ b/src/Stack/Infrastructure/ConsoleOutputProvider.cs
@@ -55,4 +55,5 @@ public static class OutputStyleExtensionMethods
     public static string Branch(this string name) => $"[{Color.Blue}]{name}[/]";
     public static string Muted(this string name) => $"[{Color.Grey}]{name}[/]";
     public static string Example(this string name) => $"[{Color.Aqua}]{name}[/]";
+    public static string Highlighted(this string name) => $"[{Color.Green}]{name}[/]";
 }


### PR DESCRIPTION
## Background

<!-- stack-pr-list -->
This PR is part of a series that makes some more improvements to pull request creation:

- https://github.com/geofflamrock/stack/pull/202
- https://github.com/geofflamrock/stack/pull/203
<!-- /stack-pr-list -->

## Changes

This PR adds support for selecting specific branches to create pull requests for, rather than forcing all branches without a PR to be created.
