### PR TITLE
Improve way that stack PR list is handled in pull request body

### DIFF
--- a/src/Stack.Tests/Commands/PullRequests/CreatePullRequestsCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/PullRequests/CreatePullRequestsCommandHandlerTests.cs
@@ -71,7 +71,6 @@ A custom description
             [branch2] = new GitHubPullRequest(2, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false)
         };
 
-
         gitHubClient.PullRequests.Should().BeEquivalentTo(expectedPullRequests,
             opt => opt.Excluding(member =>
                 member.DeclaringType == typeof(GitHubPullRequest) && member.Name.Equals(nameof(GitHubPullRequest.Url))
@@ -91,11 +90,11 @@ A custom description
             .WithBranch(branch2, true)
             .Build();
 
-        var gitHubClient = Substitute.For<IGitHubClient>();
+        var gitHubClient = new TestGitHubRepositoryBuilder().Build();
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var fileOperations = Substitute.For<IFileOperations>();
+        var fileOperations = new FileOperations();
         var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, fileOperations, stackConfig);
 
@@ -121,37 +120,17 @@ A custom description
         inputProvider.Text(Questions.PullRequestTitle).Returns("PR Title");
         inputProvider.Text(Questions.PullRequestStackDescription, Arg.Any<string>()).Returns("A custom description");
 
-        var prForBranch1 = new GitHubPullRequest(1, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
-        gitHubClient
-            .CreatePullRequest(branch1, sourceBranch, "PR Title", Arg.Any<string>(), false)
-            .Returns(prForBranch1);
-
-        var prForBranch2 = new GitHubPullRequest(2, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
-        gitHubClient
-            .CreatePullRequest(branch2, branch1, "PR Title", Arg.Any<string>(), false)
-            .Returns(prForBranch2);
-
-        gitHubClient
-            .When(g => g.EditPullRequest(1, Arg.Any<string>()))
-            .Do(ci => prForBranch1 = prForBranch1 with { Body = ci.ArgAt<string>(1) });
-
-        gitHubClient
-            .When(g => g.EditPullRequest(2, Arg.Any<string>()))
-            .Do(ci => prForBranch2 = prForBranch2 with { Body = ci.ArgAt<string>(1) });
-
         // Act
         await handler.Handle(CreatePullRequestsCommandInputs.Empty);
 
         // Assert
-        var expectedStackDescription = $@"<!-- stack-pr-list -->
+        var expectedStackDescription = $@"{StackConstants.StackMarkerStart}
 A custom description
 
-- {prForBranch1.Url}
-- {prForBranch2.Url}
-<!-- /stack-pr-list -->";
+{string.Join(Environment.NewLine, gitHubClient.PullRequests.Values.Select(pr => $"- {pr.Url}"))}
+{StackConstants.StackMarkerEnd}";
 
-        prForBranch1.Body.Should().Be(expectedStackDescription);
-        prForBranch2.Body.Should().Be(expectedStackDescription);
+        gitHubClient.PullRequests.Should().AllSatisfy(pr => pr.Value.Body.Should().Be(expectedStackDescription));
     }
 
     [Fact]
@@ -199,6 +178,7 @@ A custom description
         inputProvider.Confirm(Questions.ConfirmCreatePullRequests).Returns(true);
         inputProvider.Text(Questions.PullRequestTitle).Returns("PR Title");
         inputProvider.Text(Questions.PullRequestStackDescription, Arg.Any<string>()).Returns("A custom description");
+
         // Act
         await handler.Handle(CreatePullRequestsCommandInputs.Empty);
 
@@ -226,11 +206,11 @@ A custom description
             .WithBranch(branch2, true)
             .Build();
 
-        var gitHubClient = Substitute.For<IGitHubClient>();
+        var gitHubClient = new TestGitHubRepositoryBuilder().Build();
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var fileOperations = Substitute.For<IFileOperations>();
+        var fileOperations = new FileOperations();
         var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, fileOperations, stackConfig);
 
@@ -254,23 +234,28 @@ A custom description
             .Returns([new PullRequestCreateAction(branch1, sourceBranch), new PullRequestCreateAction(branch2, branch1)]);
         inputProvider.Confirm(Questions.ConfirmCreatePullRequests).Returns(true);
         inputProvider.Text(Questions.PullRequestTitle).Returns("PR Title");
-
-        var prForBranch1 = new GitHubPullRequest(1, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
-        gitHubClient
-            .CreatePullRequest(branch1, sourceBranch, "PR Title", Arg.Any<string>(), false)
-            .Returns(prForBranch1);
-
-        var prForBranch2 = new GitHubPullRequest(2, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
-        gitHubClient
-            .CreatePullRequest(branch2, branch1, "PR Title", Arg.Any<string>(), false)
-            .Returns(prForBranch2);
+        inputProvider.Text(Questions.PullRequestStackDescription, Arg.Any<string>()).Returns("A custom description");
 
         // Act
         await handler.Handle(new CreatePullRequestsCommandInputs("Stack1"));
 
-        // Assert        
-        gitHubClient.Received().CreatePullRequest(branch1, sourceBranch, "PR Title", Arg.Any<string>(), false);
-        gitHubClient.Received().CreatePullRequest(branch2, branch1, "PR Title", Arg.Any<string>(), false);
+        // Assert
+        var expectedPrBody = $@"{StackConstants.StackMarkerStart}
+A custom description
+
+{string.Join(Environment.NewLine, gitHubClient.PullRequests.Values.Select(pr => $"- {pr.Url}"))}
+{StackConstants.StackMarkerEnd}";
+
+        var expectedPullRequests = new Dictionary<string, GitHubPullRequest>
+        {
+            [branch1] = new GitHubPullRequest(1, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false),
+            [branch2] = new GitHubPullRequest(2, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false)
+        };
+
+        gitHubClient.PullRequests.Should().BeEquivalentTo(expectedPullRequests,
+            opt => opt.Excluding(member =>
+                member.DeclaringType == typeof(GitHubPullRequest) && member.Name.Equals(nameof(GitHubPullRequest.Url))
+        ));
     }
 
     [Fact]
@@ -286,11 +271,11 @@ A custom description
             .WithBranch(branch2, true)
             .Build();
 
-        var gitHubClient = Substitute.For<IGitHubClient>();
+        var gitHubClient = new TestGitHubRepositoryBuilder().Build();
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var fileOperations = Substitute.For<IFileOperations>();
+        var fileOperations = new FileOperations();
         var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, fileOperations, stackConfig);
 
@@ -309,23 +294,28 @@ A custom description
             .Returns([new PullRequestCreateAction(branch1, sourceBranch), new PullRequestCreateAction(branch2, branch1)]);
         inputProvider.Confirm(Questions.ConfirmCreatePullRequests).Returns(true);
         inputProvider.Text(Questions.PullRequestTitle).Returns("PR Title");
-
-        var prForBranch1 = new GitHubPullRequest(1, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
-        gitHubClient
-            .CreatePullRequest(branch1, sourceBranch, "PR Title", Arg.Any<string>(), false)
-            .Returns(prForBranch1);
-
-        var prForBranch2 = new GitHubPullRequest(2, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
-        gitHubClient
-            .CreatePullRequest(branch2, branch1, "PR Title", Arg.Any<string>(), false)
-            .Returns(prForBranch2);
+        inputProvider.Text(Questions.PullRequestStackDescription, Arg.Any<string>()).Returns("A custom description");
 
         // Act
         await handler.Handle(CreatePullRequestsCommandInputs.Empty);
 
-        // Assert        
-        gitHubClient.Received().CreatePullRequest(branch1, sourceBranch, "PR Title", Arg.Any<string>(), false);
-        gitHubClient.Received().CreatePullRequest(branch2, branch1, "PR Title", Arg.Any<string>(), false);
+        // Assert
+        var expectedPrBody = $@"{StackConstants.StackMarkerStart}
+A custom description
+
+{string.Join(Environment.NewLine, gitHubClient.PullRequests.Values.Select(pr => $"- {pr.Url}"))}
+{StackConstants.StackMarkerEnd}";
+
+        var expectedPullRequests = new Dictionary<string, GitHubPullRequest>
+        {
+            [branch1] = new GitHubPullRequest(1, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false),
+            [branch2] = new GitHubPullRequest(2, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false)
+        };
+
+        gitHubClient.PullRequests.Should().BeEquivalentTo(expectedPullRequests,
+            opt => opt.Excluding(member =>
+                member.DeclaringType == typeof(GitHubPullRequest) && member.Name.Equals(nameof(GitHubPullRequest.Url))
+        ));
     }
 
     [Fact]
@@ -341,11 +331,11 @@ A custom description
             .WithBranch(branch2, true)
             .Build();
 
-        var gitHubClient = Substitute.For<IGitHubClient>();
+        var gitHubClient = new TestGitHubRepositoryBuilder().Build();
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var fileOperations = Substitute.For<IFileOperations>();
+        var fileOperations = new FileOperations();
         var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, fileOperations, stackConfig);
 
@@ -381,11 +371,16 @@ A custom description
             .WithBranch(branch2, true)
             .Build();
 
-        var gitHubClient = Substitute.For<IGitHubClient>();
+        var gitHubClient = new TestGitHubRepositoryBuilder()
+            .WithPullRequest(branch1, pr => pr
+                .WithBody($"{StackConstants.StackMarkerStart} {StackConstants.StackMarkerEnd}")
+                .WithTitle("PR Title")
+                .Merged())
+            .Build();
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var fileOperations = Substitute.For<IFileOperations>();
+        var fileOperations = new FileOperations();
         var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, fileOperations, stackConfig);
 
@@ -411,37 +406,26 @@ A custom description
         inputProvider.Text(Questions.PullRequestTitle).Returns("PR Title");
         inputProvider.Text(Questions.PullRequestStackDescription, Arg.Any<string>()).Returns("A custom description");
 
-        var prForBranch1 = new GitHubPullRequest(1, "PR Title", string.Empty, GitHubPullRequestStates.Merged, Some.HttpsUri(), false);
-        gitHubClient.GetPullRequest(branch1).Returns(prForBranch1);
-
-        var prForBranch2 = new GitHubPullRequest(2, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
-        gitHubClient
-            .CreatePullRequest(branch2, sourceBranch, "PR Title", Arg.Any<string>(), false)
-            .Returns(prForBranch2);
-
-        gitHubClient
-            .When(g => g.EditPullRequest(1, Arg.Any<string>()))
-            .Do(ci => prForBranch1 = prForBranch1 with { Body = ci.ArgAt<string>(1) });
-
-        gitHubClient
-            .When(g => g.EditPullRequest(2, Arg.Any<string>()))
-            .Do(ci => prForBranch2 = prForBranch2 with { Body = ci.ArgAt<string>(1) });
-
         // Act
         await handler.Handle(CreatePullRequestsCommandInputs.Empty);
 
-        // Assert        
-        gitHubClient.DidNotReceive().CreatePullRequest(branch1, sourceBranch, "PR Title", Arg.Any<string>(), false);
-        gitHubClient.Received().CreatePullRequest(branch2, sourceBranch, "PR Title", Arg.Any<string>(), false);
-        var expectedStackDescription = $@"<!-- stack-pr-list -->
+        // Assert
+        var expectedPrBody = $@"{StackConstants.StackMarkerStart}
 A custom description
 
-- {prForBranch1.Url}
-- {prForBranch2.Url}
-<!-- /stack-pr-list -->";
+{string.Join(Environment.NewLine, gitHubClient.PullRequests.Values.Select(pr => $"- {pr.Url}"))}
+{StackConstants.StackMarkerEnd}";
 
-        prForBranch1.Body.Should().Be(expectedStackDescription);
-        prForBranch2.Body.Should().Be(expectedStackDescription);
+        var expectedPullRequests = new Dictionary<string, GitHubPullRequest>
+        {
+            [branch1] = new GitHubPullRequest(1, "PR Title", expectedPrBody, GitHubPullRequestStates.Merged, Some.HttpsUri(), false),
+            [branch2] = new GitHubPullRequest(2, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false)
+        };
+
+        gitHubClient.PullRequests.Should().BeEquivalentTo(expectedPullRequests,
+            opt => opt.Excluding(member =>
+                member.DeclaringType == typeof(GitHubPullRequest) && member.Name.Equals(nameof(GitHubPullRequest.Url))
+        ));
     }
 
     [Fact]
@@ -457,11 +441,11 @@ A custom description
             .WithBranch(branch2, true)
             .Build();
 
-        var gitHubClient = Substitute.For<IGitHubClient>();
+        var gitHubClient = new TestGitHubRepositoryBuilder().Build();
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var fileOperations = Substitute.For<IFileOperations>();
+        var fileOperations = new FileOperations();
         var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, fileOperations, stackConfig);
 
@@ -469,11 +453,12 @@ A custom description
             .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
             .Do(ci => ci.ArgAt<Action>(1)());
 
-        fileOperations.Exists(Arg.Any<string>()).Returns(true);
+        Directory.CreateDirectory(Path.Join(repo.LocalDirectoryPath, ".github"));
+        File.WriteAllText(Path.Join(repo.LocalDirectoryPath, ".github", "PULL_REQUEST_TEMPLATE.md"), "This is the PR template");
 
         var stacks = new List<Config.Stack>(
         [
-            new("Stack1", repo.RemoteUri, sourceBranch, [branch1]),
+            new("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]),
             new("Stack2", repo.RemoteUri, sourceBranch, [])
         ]);
         stackConfig.Load().Returns(stacks);
@@ -484,25 +469,36 @@ A custom description
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
         inputProvider
             .MultiSelect(Questions.SelectPullRequestsToCreate, Arg.Any<PullRequestCreateAction[]>(), Arg.Any<Func<PullRequestCreateAction, string>>())
-            .Returns([new PullRequestCreateAction(branch1, sourceBranch)]);
+            .Returns([new PullRequestCreateAction(branch1, sourceBranch), new PullRequestCreateAction(branch2, branch1)]);
         inputProvider.Confirm(Questions.ConfirmCreatePullRequests).Returns(true);
         inputProvider.Text(Questions.PullRequestTitle).Returns("PR Title");
-
-        var prForBranch1 = new GitHubPullRequest(1, "PR Title", "PR Template", GitHubPullRequestStates.Open, Some.HttpsUri(), false);
-        gitHubClient
-            .CreatePullRequest(branch1, sourceBranch, "PR Title", Arg.Any<string>(), false)
-            .Returns(prForBranch1);
+        inputProvider.Text(Questions.PullRequestStackDescription, Arg.Any<string>()).Returns("A custom description");
 
         // Act
         await handler.Handle(CreatePullRequestsCommandInputs.Empty);
 
-        // Assert        
-        gitHubClient.Received().CreatePullRequest(branch1, sourceBranch, "PR Title", Arg.Any<string>(), false);
-        fileOperations.Received().Copy(Arg.Any<string>(), Arg.Any<string>(), true);
+        // Assert
+        var expectedPrBody = $@"{StackConstants.StackMarkerStart}
+A custom description
+
+{string.Join(Environment.NewLine, gitHubClient.PullRequests.Values.Select(pr => $"- {pr.Url}"))}
+{StackConstants.StackMarkerEnd}
+This is the PR template";
+
+        var expectedPullRequests = new Dictionary<string, GitHubPullRequest>
+        {
+            [branch1] = new GitHubPullRequest(1, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false),
+            [branch2] = new GitHubPullRequest(2, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false)
+        };
+
+        gitHubClient.PullRequests.Should().BeEquivalentTo(expectedPullRequests,
+            opt => opt.Excluding(member =>
+                member.DeclaringType == typeof(GitHubPullRequest) && member.Name.Equals(nameof(GitHubPullRequest.Url))
+        ));
     }
 
     [Fact]
-    public async Task WhenAPullRequestTemplateDoesNotExistInTheRepo_AnEmptyBodyIsUsed()
+    public async Task WhenAPullRequestTemplateDoesNotExistInTheRepo_TheStackPrListMarkersArePutIntoTheBody()
     {
         // Arrange
         var sourceBranch = Some.BranchName();
@@ -514,19 +510,17 @@ A custom description
             .WithBranch(branch2, true)
             .Build();
 
-        var gitHubClient = Substitute.For<IGitHubClient>();
+        var gitHubClient = new TestGitHubRepositoryBuilder().Build();
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var fileOperations = Substitute.For<IFileOperations>();
+        var fileOperations = new FileOperations();
         var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, fileOperations, stackConfig);
 
         outputProvider
             .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
             .Do(ci => ci.ArgAt<Action>(1)());
-
-        fileOperations.Exists(Arg.Any<string>()).Returns(false);
 
         var stacks = new List<Config.Stack>(
         [
@@ -545,18 +539,25 @@ A custom description
         inputProvider.Confirm(Questions.ConfirmCreatePullRequests).Returns(true);
         inputProvider.Text(Questions.PullRequestTitle).Returns("PR Title");
 
-        var prForBranch1 = new GitHubPullRequest(1, "PR Title", "PR Template", GitHubPullRequestStates.Open, Some.HttpsUri(), false);
-        gitHubClient
-            .CreatePullRequest(branch1, sourceBranch, "PR Title", Arg.Any<string>(), false)
-            .Returns(prForBranch1);
-
         // Act
         await handler.Handle(CreatePullRequestsCommandInputs.Empty);
 
-        // Assert        
-        gitHubClient.Received().CreatePullRequest(branch1, sourceBranch, "PR Title", Arg.Any<string>(), false);
-        fileOperations.Received().Create(Arg.Any<string>());
-        fileOperations.DidNotReceive().Copy(Arg.Any<string>(), Arg.Any<string>(), true);
+        // Assert
+        var expectedPrBody = $@"{StackConstants.StackMarkerStart}
+            
+{StackConstants.StackMarkerDescription}
+
+{StackConstants.StackMarkerEnd}";
+
+        var expectedPullRequests = new Dictionary<string, GitHubPullRequest>
+        {
+            [branch1] = new GitHubPullRequest(1, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false)
+        };
+
+        gitHubClient.PullRequests.Should().BeEquivalentTo(expectedPullRequests,
+            opt => opt.Excluding(member =>
+                member.DeclaringType == typeof(GitHubPullRequest) && member.Name.Equals(nameof(GitHubPullRequest.Url))
+        ));
     }
 
     [Fact]
@@ -572,11 +573,11 @@ A custom description
             .WithBranch(branch2, true)
             .Build();
 
-        var gitHubClient = Substitute.For<IGitHubClient>();
+        var gitHubClient = new TestGitHubRepositoryBuilder().Build();
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var fileOperations = Substitute.For<IFileOperations>();
+        var fileOperations = new FileOperations();
         var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, fileOperations, stackConfig);
 
@@ -602,22 +603,11 @@ A custom description
         inputProvider.Confirm(Questions.CreatePullRequestAsDraft, false).Returns(true);
         inputProvider.Text(Questions.PullRequestTitle).Returns("PR Title");
 
-        var prForBranch1 = new GitHubPullRequest(1, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), true);
-        gitHubClient
-            .CreatePullRequest(branch1, sourceBranch, "PR Title", Arg.Any<string>(), true)
-            .Returns(prForBranch1);
-
-        var prForBranch2 = new GitHubPullRequest(2, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), true);
-        gitHubClient
-            .CreatePullRequest(branch2, branch1, "PR Title", Arg.Any<string>(), true)
-            .Returns(prForBranch2);
-
         // Act
         await handler.Handle(CreatePullRequestsCommandInputs.Empty);
 
-        // Assert        
-        gitHubClient.Received().CreatePullRequest(branch1, sourceBranch, "PR Title", Arg.Any<string>(), true);
-        gitHubClient.Received().CreatePullRequest(branch2, branch1, "PR Title", Arg.Any<string>(), true);
+        // Assert
+        gitHubClient.PullRequests.Should().AllSatisfy(pr => pr.Value.IsDraft.Should().BeTrue());
     }
 
     [Fact]
@@ -633,11 +623,11 @@ A custom description
             .WithBranch(branch2, true)
             .Build();
 
-        var gitHubClient = Substitute.For<IGitHubClient>();
+        var gitHubClient = new TestGitHubRepositoryBuilder().Build();
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
         var outputProvider = Substitute.For<IOutputProvider>();
-        var fileOperations = Substitute.For<IFileOperations>();
+        var fileOperations = new FileOperations();
         var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, fileOperations, stackConfig);
 
@@ -662,17 +652,25 @@ A custom description
         inputProvider.Confirm(Questions.ConfirmCreatePullRequests).Returns(true);
         inputProvider.Text(Questions.PullRequestTitle).Returns("PR Title");
 
-        var prForBranch1 = new GitHubPullRequest(1, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
-        gitHubClient
-            .CreatePullRequest(branch1, sourceBranch, "PR Title", Arg.Any<string>(), false)
-            .Returns(prForBranch1);
-
         // Act
         await handler.Handle(CreatePullRequestsCommandInputs.Empty);
 
-        // Assert        
-        gitHubClient.Received().CreatePullRequest(branch1, sourceBranch, "PR Title", Arg.Any<string>(), false);
-        gitHubClient.DidNotReceive().CreatePullRequest(branch2, branch1, Arg.Any<string>(), Arg.Any<string>(), false);
+        // Assert
+        var expectedPrBody = $@"{StackConstants.StackMarkerStart}
+            
+{StackConstants.StackMarkerDescription}
+
+{StackConstants.StackMarkerEnd}";
+
+        var expectedPullRequests = new Dictionary<string, GitHubPullRequest>
+        {
+            [branch1] = new GitHubPullRequest(1, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false)
+        };
+
+        gitHubClient.PullRequests.Should().BeEquivalentTo(expectedPullRequests,
+            opt => opt.Excluding(member =>
+                member.DeclaringType == typeof(GitHubPullRequest) && member.Name.Equals(nameof(GitHubPullRequest.Url))
+        ));
     }
 }
 

--- a/src/Stack.Tests/Commands/PullRequests/CreatePullRequestsCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/PullRequests/CreatePullRequestsCommandHandlerTests.cs
@@ -30,14 +30,10 @@ public class CreatePullRequestsCommandHandlerTests(ITestOutputHelper testOutputH
         var gitHubClient = new TestGitHubRepositoryBuilder().Build();
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
-        var outputProvider = Substitute.For<IOutputProvider>();
+        var outputProvider = new TestOutputProvider(testOutputHelper);
         var fileOperations = new FileOperations();
         var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, fileOperations, stackConfig);
-
-        outputProvider
-            .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
-            .Do(ci => ci.ArgAt<Action>(1)());
 
         var stacks = new List<Config.Stack>(
         [
@@ -99,14 +95,10 @@ A custom description
         var gitHubClient = new TestGitHubRepositoryBuilder().Build();
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
-        var outputProvider = Substitute.For<IOutputProvider>();
+        var outputProvider = new TestOutputProvider(testOutputHelper);
         var fileOperations = new FileOperations();
         var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, fileOperations, stackConfig);
-
-        outputProvider
-            .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
-            .Do(ci => ci.ArgAt<Action>(1)());
 
         var stacks = new List<Config.Stack>(
         [
@@ -211,14 +203,10 @@ A custom description
         var gitHubClient = new TestGitHubRepositoryBuilder().Build();
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
-        var outputProvider = Substitute.For<IOutputProvider>();
+        var outputProvider = new TestOutputProvider(testOutputHelper);
         var fileOperations = new FileOperations();
         var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, fileOperations, stackConfig);
-
-        outputProvider
-            .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
-            .Do(ci => ci.ArgAt<Action>(1)());
 
         var stacks = new List<Config.Stack>(
         [
@@ -273,14 +261,10 @@ A custom description
         var gitHubClient = new TestGitHubRepositoryBuilder().Build();
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
-        var outputProvider = Substitute.For<IOutputProvider>();
+        var outputProvider = new TestOutputProvider(testOutputHelper);
         var fileOperations = new FileOperations();
         var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, fileOperations, stackConfig);
-
-        outputProvider
-            .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
-            .Do(ci => ci.ArgAt<Action>(1)());
 
         var stacks = new List<Config.Stack>(
         [
@@ -330,14 +314,10 @@ A custom description
         var gitHubClient = new TestGitHubRepositoryBuilder().Build();
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
-        var outputProvider = Substitute.For<IOutputProvider>();
+        var outputProvider = new TestOutputProvider(testOutputHelper);
         var fileOperations = new FileOperations();
         var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, fileOperations, stackConfig);
-
-        outputProvider
-            .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
-            .Do(ci => ci.ArgAt<Action>(1)());
 
         var stacks = new List<Config.Stack>(
         [
@@ -375,14 +355,10 @@ A custom description
             .Build();
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
-        var outputProvider = Substitute.For<IOutputProvider>();
+        var outputProvider = new TestOutputProvider(testOutputHelper);
         var fileOperations = new FileOperations();
         var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, fileOperations, stackConfig);
-
-        outputProvider
-            .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
-            .Do(ci => ci.ArgAt<Action>(1)());
 
         var stacks = new List<Config.Stack>(
         [
@@ -437,14 +413,10 @@ A custom description
         var gitHubClient = new TestGitHubRepositoryBuilder().Build();
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
-        var outputProvider = Substitute.For<IOutputProvider>();
+        var outputProvider = new TestOutputProvider(testOutputHelper);
         var fileOperations = new FileOperations();
         var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, fileOperations, stackConfig);
-
-        outputProvider
-            .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
-            .Do(ci => ci.ArgAt<Action>(1)());
 
         Directory.CreateDirectory(Path.Join(repo.LocalDirectoryPath, ".github"));
         File.WriteAllText(Path.Join(repo.LocalDirectoryPath, ".github", "PULL_REQUEST_TEMPLATE.md"), "This is the PR template");
@@ -503,14 +475,10 @@ This is the PR template";
         var gitHubClient = new TestGitHubRepositoryBuilder().Build();
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
-        var outputProvider = Substitute.For<IOutputProvider>();
+        var outputProvider = new TestOutputProvider(testOutputHelper);
         var fileOperations = new FileOperations();
         var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, fileOperations, stackConfig);
-
-        outputProvider
-            .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
-            .Do(ci => ci.ArgAt<Action>(1)());
 
         var stacks = new List<Config.Stack>(
         [
@@ -563,14 +531,10 @@ This is the PR template";
         var gitHubClient = new TestGitHubRepositoryBuilder().Build();
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
-        var outputProvider = Substitute.For<IOutputProvider>();
+        var outputProvider = new TestOutputProvider(testOutputHelper);
         var fileOperations = new FileOperations();
         var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, fileOperations, stackConfig);
-
-        outputProvider
-            .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
-            .Do(ci => ci.ArgAt<Action>(1)());
 
         var stacks = new List<Config.Stack>(
         [
@@ -613,14 +577,10 @@ This is the PR template";
         var gitHubClient = new TestGitHubRepositoryBuilder().Build();
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
-        var outputProvider = Substitute.For<IOutputProvider>();
+        var outputProvider = new TestOutputProvider(testOutputHelper);
         var fileOperations = new FileOperations();
         var gitClient = new GitClient(outputProvider, repo.GitClientSettings);
         var handler = new CreatePullRequestsCommandHandler(inputProvider, outputProvider, gitClient, gitHubClient, fileOperations, stackConfig);
-
-        outputProvider
-            .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
-            .Do(ci => ci.ArgAt<Action>(1)());
 
         var stacks = new List<Config.Stack>(
         [
@@ -655,119 +615,5 @@ This is the PR template";
         };
 
         gitHubClient.PullRequests.Should().BeEquivalentTo(expectedPullRequests, ExcludeUnimportantPullRequestProperties);
-    }
-}
-
-public class TestGitHubPullRequestBuilder
-{
-    int _number = Some.Int();
-    string _title = Some.Name();
-    string _body = Some.Name();
-    string _state = GitHubPullRequestStates.Open;
-    Uri _url = Some.HttpsUri();
-    bool _draft = false;
-
-    public TestGitHubPullRequestBuilder WithNumber(int number)
-    {
-        _number = number;
-        return this;
-    }
-
-    public TestGitHubPullRequestBuilder WithTitle(string title)
-    {
-        _title = title;
-        return this;
-    }
-
-    public TestGitHubPullRequestBuilder WithBody(string body)
-    {
-        _body = body;
-        return this;
-    }
-
-    public TestGitHubPullRequestBuilder Merged()
-    {
-        _state = GitHubPullRequestStates.Merged;
-        return this;
-    }
-
-    public TestGitHubPullRequestBuilder Open()
-    {
-        _state = GitHubPullRequestStates.Open;
-        return this;
-    }
-
-    public TestGitHubPullRequestBuilder Closed()
-    {
-        _state = GitHubPullRequestStates.Closed;
-        return this;
-    }
-
-    public TestGitHubPullRequestBuilder WithUrl(Uri url)
-    {
-        _url = url;
-        return this;
-    }
-
-    public TestGitHubPullRequestBuilder AsDraft()
-    {
-        _draft = true;
-        return this;
-    }
-
-    public GitHubPullRequest Build()
-    {
-        return new GitHubPullRequest(_number, _title, _body, _state, _url, _draft);
-    }
-}
-
-public class TestGitHubRepositoryBuilder
-{
-    readonly Dictionary<string, GitHubPullRequest> _pullRequests = new();
-
-    public TestGitHubRepositoryBuilder WithPullRequest(string branch, Action<TestGitHubPullRequestBuilder> pullRequestBuilder)
-    {
-        var builder = new TestGitHubPullRequestBuilder();
-        pullRequestBuilder(builder);
-        _pullRequests.Add(branch, builder.Build());
-        return this;
-    }
-
-    public TestGitHubRepository Build()
-    {
-        return new TestGitHubRepository(_pullRequests);
-    }
-}
-
-public class TestGitHubRepository(Dictionary<string, GitHubPullRequest> PullRequests) : IGitHubClient
-{
-    public Dictionary<string, GitHubPullRequest> PullRequests { get; } = PullRequests;
-
-    public GitHubPullRequest CreatePullRequest(string headBranch, string baseBranch, string title, string bodyFilePath, bool draft)
-    {
-        var prBody = File.ReadAllText(bodyFilePath).Trim();
-        var pr = new GitHubPullRequest(Some.Int(), title, prBody, GitHubPullRequestStates.Open, Some.HttpsUri(), draft);
-        PullRequests.Add(headBranch, pr);
-        return pr;
-    }
-
-    public void EditPullRequest(int number, string body)
-    {
-        if (!PullRequests.Any(pr => pr.Value.Number == number))
-        {
-            throw new InvalidOperationException("Pull request not found.");
-        }
-
-        var pr = PullRequests.First(p => p.Value.Number == number);
-        PullRequests[pr.Key] = pr.Value with { Body = body };
-    }
-
-    public GitHubPullRequest? GetPullRequest(string branch)
-    {
-        return PullRequests.GetValueOrDefault(branch);
-    }
-
-    public void OpenPullRequest(GitHubPullRequest pullRequest)
-    {
     }
 }

--- a/src/Stack.Tests/Helpers/Some.cs
+++ b/src/Stack.Tests/Helpers/Some.cs
@@ -4,6 +4,8 @@ namespace Stack.Tests.Helpers;
 
 public static class Some
 {
+    static int next;
+    public static int Int() => Interlocked.Increment(ref next);
     public static string Name() => Guid.NewGuid().ToString("N");
     public static string ShortName() => Guid.NewGuid().ToString("N").Substring(0, 8);
     public static string BranchName() => $"branch-{ShortName()}";

--- a/src/Stack.Tests/Helpers/TestGitHubRepositoryBuilder.cs
+++ b/src/Stack.Tests/Helpers/TestGitHubRepositoryBuilder.cs
@@ -29,12 +29,6 @@ public class TestGitHubPullRequestBuilder
     Uri _url = Some.HttpsUri();
     bool _draft = false;
 
-    public TestGitHubPullRequestBuilder WithNumber(int number)
-    {
-        _number = number;
-        return this;
-    }
-
     public TestGitHubPullRequestBuilder WithTitle(string title)
     {
         _title = title;
@@ -50,30 +44,6 @@ public class TestGitHubPullRequestBuilder
     public TestGitHubPullRequestBuilder Merged()
     {
         _state = GitHubPullRequestStates.Merged;
-        return this;
-    }
-
-    public TestGitHubPullRequestBuilder Open()
-    {
-        _state = GitHubPullRequestStates.Open;
-        return this;
-    }
-
-    public TestGitHubPullRequestBuilder Closed()
-    {
-        _state = GitHubPullRequestStates.Closed;
-        return this;
-    }
-
-    public TestGitHubPullRequestBuilder WithUrl(Uri url)
-    {
-        _url = url;
-        return this;
-    }
-
-    public TestGitHubPullRequestBuilder AsDraft()
-    {
-        _draft = true;
         return this;
     }
 

--- a/src/Stack.Tests/Helpers/TestGitHubRepositoryBuilder.cs
+++ b/src/Stack.Tests/Helpers/TestGitHubRepositoryBuilder.cs
@@ -1,0 +1,117 @@
+using Stack.Git;
+
+namespace Stack.Tests.Helpers;
+
+public class TestGitHubRepositoryBuilder
+{
+    readonly Dictionary<string, GitHubPullRequest> _pullRequests = new();
+
+    public TestGitHubRepositoryBuilder WithPullRequest(string branch, Action<TestGitHubPullRequestBuilder> pullRequestBuilder)
+    {
+        var builder = new TestGitHubPullRequestBuilder();
+        pullRequestBuilder(builder);
+        _pullRequests.Add(branch, builder.Build());
+        return this;
+    }
+
+    public TestGitHubRepository Build()
+    {
+        return new TestGitHubRepository(_pullRequests);
+    }
+}
+
+public class TestGitHubPullRequestBuilder
+{
+    int _number = Some.Int();
+    string _title = Some.Name();
+    string _body = Some.Name();
+    string _state = GitHubPullRequestStates.Open;
+    Uri _url = Some.HttpsUri();
+    bool _draft = false;
+
+    public TestGitHubPullRequestBuilder WithNumber(int number)
+    {
+        _number = number;
+        return this;
+    }
+
+    public TestGitHubPullRequestBuilder WithTitle(string title)
+    {
+        _title = title;
+        return this;
+    }
+
+    public TestGitHubPullRequestBuilder WithBody(string body)
+    {
+        _body = body;
+        return this;
+    }
+
+    public TestGitHubPullRequestBuilder Merged()
+    {
+        _state = GitHubPullRequestStates.Merged;
+        return this;
+    }
+
+    public TestGitHubPullRequestBuilder Open()
+    {
+        _state = GitHubPullRequestStates.Open;
+        return this;
+    }
+
+    public TestGitHubPullRequestBuilder Closed()
+    {
+        _state = GitHubPullRequestStates.Closed;
+        return this;
+    }
+
+    public TestGitHubPullRequestBuilder WithUrl(Uri url)
+    {
+        _url = url;
+        return this;
+    }
+
+    public TestGitHubPullRequestBuilder AsDraft()
+    {
+        _draft = true;
+        return this;
+    }
+
+    public GitHubPullRequest Build()
+    {
+        return new GitHubPullRequest(_number, _title, _body, _state, _url, _draft);
+    }
+}
+
+public class TestGitHubRepository(Dictionary<string, GitHubPullRequest> PullRequests) : IGitHubClient
+{
+    public Dictionary<string, GitHubPullRequest> PullRequests { get; } = PullRequests;
+
+    public GitHubPullRequest CreatePullRequest(string headBranch, string baseBranch, string title, string bodyFilePath, bool draft)
+    {
+        var prBody = File.ReadAllText(bodyFilePath).Trim();
+        var pr = new GitHubPullRequest(Some.Int(), title, prBody, GitHubPullRequestStates.Open, Some.HttpsUri(), draft);
+        PullRequests.Add(headBranch, pr);
+        return pr;
+    }
+
+    public void EditPullRequest(int number, string body)
+    {
+        if (!PullRequests.Any(pr => pr.Value.Number == number))
+        {
+            throw new InvalidOperationException("Pull request not found.");
+        }
+
+        var pr = PullRequests.First(p => p.Value.Number == number);
+        PullRequests[pr.Key] = pr.Value with { Body = body };
+    }
+
+    public GitHubPullRequest? GetPullRequest(string branch)
+    {
+        return PullRequests.GetValueOrDefault(branch);
+    }
+
+    public void OpenPullRequest(GitHubPullRequest pullRequest)
+    {
+    }
+}

--- a/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
+++ b/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
@@ -292,7 +292,7 @@ public class CreatePullRequestsCommandHandler(
             // Add the stack pr list markers to the body
             fileOperations.InsertText(bodyFilePath, 0, $@"{StackConstants.StackMarkerStart}
             
-<!-- The contents of the section between the {StackConstants.StackMarkerText} markers will be replaced with the list of pull requests in the stack. Move this section around as you would like or delete it to not include the list of pull requests.  -->
+{StackConstants.StackMarkerDescription}
 
 {StackConstants.StackMarkerEnd}");
 

--- a/src/Stack/Config/StackConfig.cs
+++ b/src/Stack/Config/StackConfig.cs
@@ -9,6 +9,7 @@ public static class StackConstants
     public const string StackMarkerText = "stack-pr-list";
     public const string StackMarkerStart = $"<!-- {StackMarkerText} -->";
     public const string StackMarkerEnd = $"<!-- /{StackMarkerText} -->";
+    public const string StackMarkerDescription = $"<!-- The contents of the section between the {StackConstants.StackMarkerText} markers will be replaced with the list of pull requests in the stack. Move this section around as you would like or delete it to not include the list of pull requests.  -->";
 }
 
 public class Stack(string Name, string RemoteUri, string SourceBranch, List<string> Branches)

--- a/src/Stack/Config/StackConfig.cs
+++ b/src/Stack/Config/StackConfig.cs
@@ -4,6 +4,13 @@ using Humanizer;
 
 namespace Stack.Config;
 
+public static class StackConstants
+{
+    public const string StackMarkerText = "stack-pr-list";
+    public const string StackMarkerStart = $"<!-- {StackMarkerText} -->";
+    public const string StackMarkerEnd = $"<!-- /{StackMarkerText} -->";
+}
+
 public class Stack(string Name, string RemoteUri, string SourceBranch, List<string> Branches)
 {
     public string Name { get; private set; } = Name;

--- a/src/Stack/Config/StackConfig.cs
+++ b/src/Stack/Config/StackConfig.cs
@@ -9,7 +9,7 @@ public static class StackConstants
     public const string StackMarkerText = "stack-pr-list";
     public const string StackMarkerStart = $"<!-- {StackMarkerText} -->";
     public const string StackMarkerEnd = $"<!-- /{StackMarkerText} -->";
-    public const string StackMarkerDescription = $"<!-- The contents of the section between the {StackConstants.StackMarkerText} markers will be replaced with the description and list of pull requests in the stack. Move this section around as you would like or delete it to not include the list of pull requests.  -->";
+    public const string StackMarkerDescription = $"<!-- The contents of the section between the {StackConstants.StackMarkerText} markers will be replaced with the description and list of pull requests in the stack when there is more than one pull request. Move this section around as you would like or delete it to not include the list of pull requests.  -->";
 }
 
 public class Stack(string Name, string RemoteUri, string SourceBranch, List<string> Branches)

--- a/src/Stack/Config/StackConfig.cs
+++ b/src/Stack/Config/StackConfig.cs
@@ -9,7 +9,7 @@ public static class StackConstants
     public const string StackMarkerText = "stack-pr-list";
     public const string StackMarkerStart = $"<!-- {StackMarkerText} -->";
     public const string StackMarkerEnd = $"<!-- /{StackMarkerText} -->";
-    public const string StackMarkerDescription = $"<!-- The contents of the section between the {StackConstants.StackMarkerText} markers will be replaced with the list of pull requests in the stack. Move this section around as you would like or delete it to not include the list of pull requests.  -->";
+    public const string StackMarkerDescription = $"<!-- The contents of the section between the {StackConstants.StackMarkerText} markers will be replaced with the description and list of pull requests in the stack. Move this section around as you would like or delete it to not include the list of pull requests.  -->";
 }
 
 public class Stack(string Name, string RemoteUri, string SourceBranch, List<string> Branches)

--- a/src/Stack/Infrastructure/FileOperations.cs
+++ b/src/Stack/Infrastructure/FileOperations.cs
@@ -6,6 +6,7 @@ public interface IFileOperations
     void Copy(string sourceFileName, string destFileName, bool overwrite);
     bool Exists(string path);
     string GetTempPath();
+    void InsertText(string path, int index, string contents);
 }
 
 public class FileOperations : IFileOperations
@@ -28,5 +29,12 @@ public class FileOperations : IFileOperations
     public string GetTempPath()
     {
         return Path.GetTempPath();
+    }
+
+    public void InsertText(string path, int index, string contents)
+    {
+        var lines = File.ReadAllLines(path).ToList();
+        lines.Insert(index, contents);
+        File.WriteAllLines(path, lines);
     }
 }


### PR DESCRIPTION
## Background

<!-- stack-pr-list -->
This PR is part of a series that makes more improvements to pull request creation:

- https://github.com/geofflamrock/stack/pull/202
- https://github.com/geofflamrock/stack/pull/203
- https://github.com/geofflamrock/stack/pull/204
<!-- /stack-pr-list -->

## Changes

This PR changes creation of pull requests by inserting the stack PR list into the body straight away, rather than always putting it at the top after the PR is created. This means that it can be incorporated more easily into the right spot in templates, and can be removed if not desired.
