### PR TITLE
Ignore major version updates to FluentAssertions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,6 +4,9 @@ updates:
     directory: "/src" # Need to specify the sub-directory to make sure projects are picked up
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: FluentAssertions
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
FluentAssertions recently changed their licensing to make version 8 paid. This PR updates the dependabot configuration to ignore major version updates to FluentAssertions to make sure we stay on v7.
