### PR TITLE
Removes confirmations from `stack new` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,8 @@ To create a stack:
 - Give your stack a name.
 - Select a branch to start your stack from.
 - Optionally either create a new branch from the source branch, or add an existing branch to the stack.
-- Optionally push a new branch to the remote repository.
-- If you chose to create or add a branch you can switch to that branch to start work.
 
-If a new branch was not pushed to the remote, you can use the `stack push` command to push the branch to the remote.
+If a new branch was not able to be pushed to the remote, you can use the `stack push` command to push the branch to the remote later.
 
 ### Working within a stack
 
@@ -83,11 +81,10 @@ Once you've done some work on the first branch within the stack, at some point y
 - Run `stack branch new`.
 - Select the stack to create the branch in.
 - Give the branch a name.
-- Optionally push a new branch to the remote repository.
 
-The new branch will be created from the branch at the bottom of the stack and you can then switch to the branch if you would like to in order to make more changes.
+The new branch will be created from the branch at the bottom of the stack and you will be switched to the branch if you would like to in order to make more changes.
 
-If a new branch was not pushed to the remote, you can use the `stack push` command to push the branch to the remote.
+If a new branch was not able to be pushed to the remote, you can use the `stack push` command to push the branch to the remote later.
 
 ### Incorporating changes from the remote repository
 

--- a/README.md
+++ b/README.md
@@ -81,10 +81,11 @@ Once you've done some work on the first branch within the stack, at some point y
 - Run `stack branch new`.
 - Select the stack to create the branch in.
 - Give the branch a name.
+- Optionally push a new branch to the remote repository.
 
-The new branch will be created from the branch at the bottom of the stack and you will be switched to the branch if you would like to in order to make more changes.
+The new branch will be created from the branch at the bottom of the stack and you can then switch to the branch if you would like to in order to make more changes.
 
-If a new branch was not able to be pushed to the remote, you can use the `stack push` command to push the branch to the remote later.
+If a new branch was not pushed to the remote, you can use the `stack push` command to push the branch to the remote.
 
 ### Incorporating changes from the remote repository
 

--- a/src/Stack/Commands/Helpers/Questions.cs
+++ b/src/Stack/Commands/Helpers/Questions.cs
@@ -14,7 +14,6 @@ public static class Questions
     public const string ConfirmDeleteStack = "Are you sure you want to delete this stack?";
     public const string ConfirmDeleteBranches = "Are you sure you want to delete these local branches?";
     public const string ConfirmRemoveBranch = "Are you sure you want to remove this branch from the stack?";
-    public const string ConfirmAddOrCreateBranch = "Do you want to add an existing branch or create a new branch and add it to the stack?";
     public const string AddOrCreateBranch = "Add or create a branch:";
     public const string ConfirmSwitchToBranch = "Do you want to switch to the new branch?";
     public const string ConfirmPushBranch = "Do you want to push the new branch to the remote repository?";


### PR DESCRIPTION
## Background

<!-- stack-pr-list -->
This PR is part of a series that improves the use of stack in non-interactive scenarios:

- https://github.com/geofflamrock/stack/pull/223
- https://github.com/geofflamrock/stack/pull/224
- https://github.com/geofflamrock/stack/pull/225
- https://github.com/geofflamrock/stack/pull/226
- https://github.com/geofflamrock/stack/pull/227
- https://github.com/geofflamrock/stack/pull/228
- https://github.com/geofflamrock/stack/pull/229
- https://github.com/geofflamrock/stack/pull/230
- https://github.com/geofflamrock/stack/pull/231
<!-- /stack-pr-list -->

## Changes

This PR removes the confirmation for "Create or add a new branch?", "Push branch to remote" and "Switch to branch" to streamline the creation of a new stack.
