### PR TITLE
Add confirm option to `branch remove` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ OPTIONS:
         --working-dir    The path to the directory containing the git repository. Defaults to the current directory
     -s, --stack          The name of the stack to create the branch in
     -n, --name           The name of the branch to add
+        --yes            Confirm the removal of the branch without prompting
 ```
 
 ### Remote commands <!-- omit from toc -->

--- a/src/Stack.Tests/Commands/Branch/RemoveBranchCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Branch/RemoveBranchCommandHandlerTests.cs
@@ -43,7 +43,7 @@ public class RemoveBranchCommandHandlerTests
         inputProvider.Confirm(Questions.ConfirmRemoveBranch).Returns(true);
 
         // Act
-        await handler.Handle(new RemoveBranchCommandInputs(null, null));
+        await handler.Handle(RemoveBranchCommandInputs.Empty);
 
         // Assert
         stacks.Should().BeEquivalentTo(new List<Config.Stack>
@@ -84,7 +84,7 @@ public class RemoveBranchCommandHandlerTests
         inputProvider.Confirm(Questions.ConfirmRemoveBranch).Returns(true);
 
         // Act
-        await handler.Handle(new RemoveBranchCommandInputs("Stack1", null));
+        await handler.Handle(new RemoveBranchCommandInputs("Stack1", null, false));
 
         // Assert
         inputProvider.DidNotReceive().Select(Questions.SelectStack, Arg.Any<string[]>());
@@ -121,7 +121,7 @@ public class RemoveBranchCommandHandlerTests
 
         // Act and assert
         var invalidStackName = Some.Name();
-        await handler.Invoking(async h => await h.Handle(new RemoveBranchCommandInputs(invalidStackName, null)))
+        await handler.Invoking(async h => await h.Handle(new RemoveBranchCommandInputs(invalidStackName, null, false)))
             .Should()
             .ThrowAsync<InvalidOperationException>()
             .WithMessage($"Stack '{invalidStackName}' not found.");
@@ -158,7 +158,7 @@ public class RemoveBranchCommandHandlerTests
         inputProvider.Confirm(Questions.ConfirmRemoveBranch).Returns(true);
 
         // Act
-        await handler.Handle(new RemoveBranchCommandInputs(null, branchToRemove));
+        await handler.Handle(new RemoveBranchCommandInputs(null, branchToRemove, false));
 
         // Assert
         stacks.Should().BeEquivalentTo(new List<Config.Stack>
@@ -197,7 +197,7 @@ public class RemoveBranchCommandHandlerTests
 
         // Act and assert
         var invalidBranchName = Some.Name();
-        await handler.Invoking(async h => await h.Handle(new RemoveBranchCommandInputs(null, invalidBranchName)))
+        await handler.Invoking(async h => await h.Handle(new RemoveBranchCommandInputs(null, invalidBranchName, false)))
             .Should()
             .ThrowAsync<InvalidOperationException>()
             .WithMessage($"Branch '{invalidBranchName}' not found in stack 'Stack1'.");
@@ -233,7 +233,7 @@ public class RemoveBranchCommandHandlerTests
         inputProvider.Confirm(Questions.ConfirmRemoveBranch).Returns(true);
 
         // Act
-        await handler.Handle(new RemoveBranchCommandInputs(null, null));
+        await handler.Handle(RemoveBranchCommandInputs.Empty);
 
         // Assert
         stacks.Should().BeEquivalentTo(new List<Config.Stack>
@@ -242,5 +242,47 @@ public class RemoveBranchCommandHandlerTests
         });
 
         inputProvider.DidNotReceive().Select(Questions.SelectStack, Arg.Any<string[]>());
+    }
+
+    [Fact]
+    public async Task WhenConfirmProvided_DoesNotAskForConfirmation_RemovesBranchFromStack()
+    {
+        // Arrange
+        var sourceBranch = Some.BranchName();
+        var branchToRemove = Some.BranchName();
+        using var repo = new TestGitRepositoryBuilder()
+            .WithBranch(sourceBranch)
+            .WithBranch(branchToRemove)
+            .Build();
+
+        var stackConfig = Substitute.For<IStackConfig>();
+        var inputProvider = Substitute.For<IInputProvider>();
+        var logger = Substitute.For<ILogger>();
+        var gitClient = new GitClient(logger, repo.GitClientSettings);
+        var handler = new RemoveBranchCommandHandler(inputProvider, logger, gitClient, stackConfig);
+
+        var stacks = new List<Config.Stack>(
+        [
+            new("Stack1", repo.RemoteUri, sourceBranch, [branchToRemove]),
+            new("Stack2", repo.RemoteUri, sourceBranch, [])
+        ]);
+        stackConfig.Load().Returns(stacks);
+        stackConfig
+            .WhenForAnyArgs(s => s.Save(Arg.Any<List<Config.Stack>>()))
+            .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
+
+        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
+        inputProvider.Select(Questions.SelectBranch, Arg.Any<string[]>()).Returns(branchToRemove);
+
+        // Act
+        await handler.Handle(new RemoveBranchCommandInputs(null, null, true));
+
+        // Assert
+        stacks.Should().BeEquivalentTo(new List<Config.Stack>
+        {
+            new("Stack1", repo.RemoteUri, sourceBranch, []),
+            new("Stack2", repo.RemoteUri, sourceBranch, [])
+        });
+        inputProvider.DidNotReceive().Confirm(Questions.ConfirmRemoveBranch);
     }
 }

--- a/src/Stack/Commands/Branch/RemoveBranchCommand.cs
+++ b/src/Stack/Commands/Branch/RemoveBranchCommand.cs
@@ -17,7 +17,7 @@ public class RemoveBranchCommandSettings : CommandSettingsBase
     [CommandOption("-n|--name")]
     public string? Name { get; init; }
 
-    [Description("Confirm the removal of the branch.")]
+    [Description("Confirm the removal of the branch without prompting.")]
     [CommandOption("--yes")]
     public bool Confirm { get; init; }
 }

--- a/src/Stack/Commands/Branch/RemoveBranchCommand.cs
+++ b/src/Stack/Commands/Branch/RemoveBranchCommand.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using Spectre.Console;
 using Spectre.Console.Cli;
 using Stack.Commands.Helpers;
 using Stack.Config;
@@ -17,6 +16,10 @@ public class RemoveBranchCommandSettings : CommandSettingsBase
     [Description("The name of the branch to add.")]
     [CommandOption("-n|--name")]
     public string? Name { get; init; }
+
+    [Description("Confirm the removal of the branch.")]
+    [CommandOption("--yes")]
+    public bool Confirm { get; init; }
 }
 
 public class RemoveBranchCommand : Command<RemoveBranchCommandSettings>
@@ -29,13 +32,13 @@ public class RemoveBranchCommand : Command<RemoveBranchCommandSettings>
             new GitClient(StdErrLogger, settings.GetGitClientSettings()),
             new StackConfig());
 
-        await handler.Handle(new RemoveBranchCommandInputs(settings.Stack, settings.Name));
+        await handler.Handle(new RemoveBranchCommandInputs(settings.Stack, settings.Name, settings.Confirm));
     }
 }
 
-public record RemoveBranchCommandInputs(string? StackName, string? BranchName)
+public record RemoveBranchCommandInputs(string? StackName, string? BranchName, bool Confirm)
 {
-    public static RemoveBranchCommandInputs Empty => new(null, null);
+    public static RemoveBranchCommandInputs Empty => new(null, null, false);
 }
 
 public class RemoveBranchCommandHandler(
@@ -68,7 +71,7 @@ public class RemoveBranchCommandHandler(
             throw new InvalidOperationException($"Branch '{branchName}' not found in stack '{stack.Name}'.");
         }
 
-        if (inputProvider.Confirm(Questions.ConfirmRemoveBranch))
+        if (inputs.Confirm || inputProvider.Confirm(Questions.ConfirmRemoveBranch))
         {
             stack.Branches.Remove(branchName);
             stackConfig.Save(stacks);


### PR DESCRIPTION
## Background

<!-- stack-pr-list -->
This PR is part of a series that improves the use of stack in non-interactive scenarios:

- https://github.com/geofflamrock/stack/pull/223
- https://github.com/geofflamrock/stack/pull/224
- https://github.com/geofflamrock/stack/pull/225
- https://github.com/geofflamrock/stack/pull/226
- https://github.com/geofflamrock/stack/pull/227
- https://github.com/geofflamrock/stack/pull/228
- https://github.com/geofflamrock/stack/pull/229
- https://github.com/geofflamrock/stack/pull/230
- https://github.com/geofflamrock/stack/pull/231
<!-- /stack-pr-list -->

## Changes

This PR adds a new `--yes` option to the `branch remove` command to confirm without prompting.
