### PR TITLE
Add confirm option to `delete` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ OPTIONS:
         --verbose        Show verbose output
         --working-dir    The path to the directory containing the git repository. Defaults to the current directory
     -s, --stack          The name of the stack to delete
+        --yes            Confirm the deletion of the stack without prompting
 ```
 
 ### Branch commands <!-- omit from toc -->

--- a/src/Stack/Commands/Stack/DeleteStackCommand.cs
+++ b/src/Stack/Commands/Stack/DeleteStackCommand.cs
@@ -14,6 +14,10 @@ public class DeleteStackCommandSettings : CommandSettingsBase
     [Description("The name of the stack to delete.")]
     [CommandOption("-s|--stack")]
     public string? Stack { get; init; }
+
+    [Description("Confirm the deletion of the stack.")]
+    [CommandOption("--yes")]
+    public bool Confirm { get; init; }
 }
 
 public class DeleteStackCommand : Command<DeleteStackCommandSettings>
@@ -27,16 +31,13 @@ public class DeleteStackCommand : Command<DeleteStackCommandSettings>
             new GitHubClient(StdErrLogger, settings.GetGitHubClientSettings()),
             new StackConfig());
 
-        var response = await handler.Handle(new DeleteStackCommandInputs(settings.Stack));
-
-        if (response.DeletedStackName is not null)
-            StdErrLogger.Information($"Stack {response.DeletedStackName.Stack()} deleted");
+        await handler.Handle(new DeleteStackCommandInputs(settings.Stack, settings.Confirm));
     }
 }
 
-public record DeleteStackCommandInputs(string? Stack)
+public record DeleteStackCommandInputs(string? Stack, bool Confirm)
 {
-    public static DeleteStackCommandInputs Empty => new((string?)null);
+    public static DeleteStackCommandInputs Empty => new(null, false);
 }
 
 public record DeleteStackCommandResponse(string? DeletedStackName);
@@ -47,9 +48,9 @@ public class DeleteStackCommandHandler(
     IGitClient gitClient,
     IGitHubClient gitHubClient,
     IStackConfig stackConfig)
-    : CommandHandlerBase<DeleteStackCommandInputs, DeleteStackCommandResponse>
+    : CommandHandlerBase<DeleteStackCommandInputs>
 {
-    public override async Task<DeleteStackCommandResponse> Handle(DeleteStackCommandInputs inputs)
+    public override async Task Handle(DeleteStackCommandInputs inputs)
     {
         await Task.CompletedTask;
         var stacks = stackConfig.Load();
@@ -66,7 +67,7 @@ public class DeleteStackCommandHandler(
             throw new InvalidOperationException("Stack not found.");
         }
 
-        if (inputProvider.Confirm(Questions.ConfirmDeleteStack))
+        if (inputs.Confirm || inputProvider.Confirm(Questions.ConfirmDeleteStack))
         {
             var branchesNeedingCleanup = StackHelpers.GetBranchesNeedingCleanup(stack, logger, gitClient, gitHubClient);
 
@@ -83,9 +84,7 @@ public class DeleteStackCommandHandler(
             stacks.Remove(stack);
             stackConfig.Save(stacks);
 
-            return new DeleteStackCommandResponse(stack.Name);
+            logger.Information($"Stack {stack.Name.Stack()} deleted");
         }
-
-        return new DeleteStackCommandResponse(null);
     }
 }

--- a/src/Stack/Commands/Stack/DeleteStackCommand.cs
+++ b/src/Stack/Commands/Stack/DeleteStackCommand.cs
@@ -15,7 +15,7 @@ public class DeleteStackCommandSettings : CommandSettingsBase
     [CommandOption("-s|--stack")]
     public string? Stack { get; init; }
 
-    [Description("Confirm the deletion of the stack.")]
+    [Description("Confirm the deletion of the stack without prompting.")]
     [CommandOption("--yes")]
     public bool Confirm { get; init; }
 }


### PR DESCRIPTION
## Background

<!-- stack-pr-list -->
This PR is part of a series that improves the use of stack in non-interactive scenarios:

- https://github.com/geofflamrock/stack/pull/223
- https://github.com/geofflamrock/stack/pull/224
- https://github.com/geofflamrock/stack/pull/225
- https://github.com/geofflamrock/stack/pull/226
- https://github.com/geofflamrock/stack/pull/227
- https://github.com/geofflamrock/stack/pull/228
- https://github.com/geofflamrock/stack/pull/229
- https://github.com/geofflamrock/stack/pull/230
- https://github.com/geofflamrock/stack/pull/231
<!-- /stack-pr-list -->

## Changes

This PR adds a `--yes` option to the delete stack command to confirm without prompting.
