### PR TITLE
Add confirm option to `cleanup` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ OPTIONS:
         --verbose        Show verbose output
         --working-dir    The path to the directory containing the git repository. Defaults to the current directory
     -s, --stack          The name of the stack to cleanup
+        --yes            Confirm the cleanup operation without prompting
 ```
 
 #### `stack branch new` <!-- omit from toc -->


### PR DESCRIPTION
## Background

<!-- stack-pr-list -->
This PR is part of a series that improves the use of stack in non-interactive scenarios:

- https://github.com/geofflamrock/stack/pull/223
- https://github.com/geofflamrock/stack/pull/224
- https://github.com/geofflamrock/stack/pull/225
- https://github.com/geofflamrock/stack/pull/226
- https://github.com/geofflamrock/stack/pull/227
- https://github.com/geofflamrock/stack/pull/228
- https://github.com/geofflamrock/stack/pull/229
- https://github.com/geofflamrock/stack/pull/230
- https://github.com/geofflamrock/stack/pull/231
<!-- /stack-pr-list -->

## Changes

This PR adds a `--yes` option to the `cleanup` command to confirm without prompting.
