### PR TITLE
Improve rebase after squash merge

### DIFF
--- a/src/Stack.Tests/Commands/Helpers/StackHelpersTests.cs
+++ b/src/Stack.Tests/Commands/Helpers/StackHelpersTests.cs
@@ -118,4 +118,62 @@ public class StackHelpersTests(ITestOutputHelper testOutputHelper)
         gitClient.DidNotReceive().ChangeBranch(branch2);
         gitClient.DidNotReceive().MergeFromLocalSourceBranch(branch1);
     }
+
+    [Fact]
+    public void UpdateStackUsingRebase_WhenARemoteBranchIsDeleted_RebasesOntoTheParentBranchToAvoidConflicts()
+    {
+        // Arrange
+        var sourceBranch = Some.BranchName();
+        var branch1 = Some.BranchName();
+        var branch2 = Some.BranchName();
+        var changedFilePath = Some.Name();
+        var commit1ChangedFileContents = "These are the changes in the first commit";
+        var commit2ChangedFileContents = "These are the changes in the first commit, with some additional changes in the second commit";
+
+        // We have three branches in this scenario:
+        //
+        // sourceBranch: A commit containing the changes that were made in branch1 but with a different hash e.g. a squash merge
+        // branch1: A commit containing the original changes to the file
+        // branch2: A second commit that changes the file again, building on the one from branch1
+        var repo = new TestGitRepositoryBuilder()
+            .WithBranch(b => b
+                .WithName(sourceBranch)
+                .PushToRemote())
+            .WithBranch(b => b
+                .WithName(branch1)
+                .FromSourceBranch(sourceBranch)
+                .WithCommit(c => c.WithChanges(changedFilePath, commit1ChangedFileContents))
+                .PushToRemote())
+            .WithBranch(b => b
+                .WithName(branch2)
+                .FromSourceBranch(branch1)
+                .WithCommit(c => c.WithChanges(changedFilePath, commit2ChangedFileContents))
+                .PushToRemote())
+            .Build();
+
+        var inputProvider = Substitute.For<IInputProvider>();
+        var gitClient = new GitClient(new TestLogger(testOutputHelper), repo.GitClientSettings);
+        var logger = new TestLogger(testOutputHelper);
+        var gitHubClient = Substitute.For<IGitHubClient>();
+
+        gitClient.ChangeBranch(sourceBranch);
+        File.WriteAllText(Path.Join(repo.LocalDirectoryPath, changedFilePath), commit1ChangedFileContents);
+        repo.Stage(changedFilePath);
+        repo.Commit();
+        repo.Push(sourceBranch);
+
+        // Delete the remote branch for branch1 to simulate a PR being merged
+        repo.DeleteRemoteTrackingBranch(branch1);
+
+        var stack = new Config.Stack("Stack1", Some.HttpsUri().ToString(), sourceBranch, [branch1, branch2]);
+        var stackStatus = StackHelpers.GetStackStatus(stack, branch1, logger, gitClient, gitHubClient, false);
+
+        // Act
+        StackHelpers.UpdateStackUsingRebase(stack, stackStatus, gitClient, inputProvider, logger);
+
+        // Assert
+        gitClient.ChangeBranch(branch2);
+        var fileContents = File.ReadAllText(Path.Join(repo.LocalDirectoryPath, changedFilePath));
+        fileContents.Should().Be(commit2ChangedFileContents);
+    }
 }

--- a/src/Stack/Commands/Helpers/StackHelpers.cs
+++ b/src/Stack/Commands/Helpers/StackHelpers.cs
@@ -564,14 +564,32 @@ public static class StackHelpers
         // When rebasing the stack, we'll use `git rebase --update-refs` from the
         // lowest branch in the stack to pick up changes throughout all branches in the stack.
         // Because there could be changes in any branch in the stack that aren't in the ones
-        // below it, we'll repeat this all the way from the bottom to the top of the stack.        
+        // below it, we'll repeat this all the way from the bottom to the top of the stack to
+        // ensure that all changes are applied in the correct order.
         //
         // For example if we have a stack like this:
         // main -> feature1 -> feature2 -> feature3
         // 
         // We'll rebase feature3 onto feature2, then feature3 onto feature1, and finally feature3 onto main.
         //
+        // In addition to this, if the stack is in a state where one of the branches has been squash merged
+        // into the source branch, we'll want to rebase onto that branch directly using
+        // `git rebase --onto {sourceBranch} {oldParentBranch}` to ensure that the changes are 
+        // applied correctly and to try and avoid merge conflicts during the rebase.
+        // 
+        // For example if we have a stack like this:
+        // main
+        //   -> feature1 (deleted in remote): Squash merged into main
+        //   -> feature2
+        //   -> feature3
+        //  
+        // We'll rebase feature3 onto feature2 using a normal `git rebase feature2 --update-refs`, 
+        // then feature3 onto main using `git rebase --onto main feature1 --update-refs` to replay
+        // all commits from feature3 (and therefore from feature2) on top of the latest commits of main
+        // which will include the squashed commit. 
+        //
         string? branchToRebaseFrom = null;
+        string? lowestInactiveBranchToReParentFrom = null;
 
         foreach (var branch in stack.Branches)
         {
@@ -600,7 +618,18 @@ public static class StackHelpers
 
             if (branchDetail.IsActive)
             {
-                RebaseFromSourceBranch(branchToRebaseFrom, branchToRebaseOnto, gitClient, inputProvider, logger);
+                if (lowestInactiveBranchToReParentFrom is not null)
+                {
+                    RebaseOntoNewParent(branchToRebaseFrom, branchToRebaseOnto, lowestInactiveBranchToReParentFrom, gitClient, inputProvider, logger);
+                }
+                else
+                {
+                    RebaseFromSourceBranch(branchToRebaseFrom, branchToRebaseOnto, gitClient, inputProvider, logger);
+                }
+            }
+            else if (lowestInactiveBranchToReParentFrom is null)
+            {
+                lowestInactiveBranchToReParentFrom = branchToRebaseOnto;
             }
         }
     }
@@ -610,43 +639,64 @@ public static class StackHelpers
         logger.Information($"Rebasing {branch.Branch()} onto {sourceBranchName.Branch()}");
         gitClient.ChangeBranch(branch);
 
-        void HandleConflicts()
-        {
-            var action = inputProvider.Select(
-                Questions.ContinueOrAbortRebase,
-                [MergeConflictAction.Continue, MergeConflictAction.Abort],
-                a => a switch
-                {
-                    MergeConflictAction.Continue => "Continue",
-                    MergeConflictAction.Abort => "Abort",
-                    _ => throw new InvalidOperationException("Invalid rebase conflict action.")
-                });
-
-            if (action == MergeConflictAction.Abort)
-            {
-                gitClient.AbortRebase();
-                throw new Exception("Rebase aborted due to conflicts.");
-            }
-            else if (action == MergeConflictAction.Continue)
-            {
-                try
-                {
-                    gitClient.ContinueRebase();
-                }
-                catch (ConflictException)
-                {
-                    HandleConflicts();
-                }
-            }
-        }
-
         try
         {
             gitClient.RebaseFromLocalSourceBranch(sourceBranchName);
         }
         catch (ConflictException)
         {
-            HandleConflicts();
+            HandleConflictsDuringRebase(gitClient, inputProvider);
+        }
+    }
+
+    static void RebaseOntoNewParent(
+        string branch,
+        string newParentBranchName,
+        string oldParentBranchName,
+        IGitClient gitClient,
+        IInputProvider inputProvider,
+        ILogger logger)
+    {
+        logger.Information($"Rebasing {branch.Branch()} onto new parent {newParentBranchName.Branch()}");
+        gitClient.ChangeBranch(branch);
+
+        try
+        {
+            gitClient.RebaseOntoNewParent(newParentBranchName, oldParentBranchName);
+        }
+        catch (ConflictException)
+        {
+            HandleConflictsDuringRebase(gitClient, inputProvider);
+        }
+    }
+
+    static void HandleConflictsDuringRebase(IGitClient gitClient, IInputProvider inputProvider)
+    {
+        var action = inputProvider.Select(
+            Questions.ContinueOrAbortRebase,
+            [MergeConflictAction.Continue, MergeConflictAction.Abort],
+            a => a switch
+            {
+                MergeConflictAction.Continue => "Continue",
+                MergeConflictAction.Abort => "Abort",
+                _ => throw new InvalidOperationException("Invalid rebase conflict action.")
+            });
+
+        if (action == MergeConflictAction.Abort)
+        {
+            gitClient.AbortRebase();
+            throw new Exception("Rebase aborted due to conflicts.");
+        }
+        else if (action == MergeConflictAction.Continue)
+        {
+            try
+            {
+                gitClient.ContinueRebase();
+            }
+            catch (ConflictException)
+            {
+                HandleConflictsDuringRebase(gitClient, inputProvider);
+            }
         }
     }
 }

--- a/src/Stack/Commands/Helpers/StackHelpers.cs
+++ b/src/Stack/Commands/Helpers/StackHelpers.cs
@@ -553,7 +553,7 @@ public static class StackHelpers
         }
     }
 
-    static void UpdateStackUsingRebase(
+    public static void UpdateStackUsingRebase(
         Config.Stack stack,
         StackStatus status,
         IGitClient gitClient,

--- a/src/Stack/Git/GitClient.cs
+++ b/src/Stack/Git/GitClient.cs
@@ -31,6 +31,7 @@ public interface IGitClient
     void DeleteLocalBranch(string branchName);
     void MergeFromLocalSourceBranch(string sourceBranchName);
     void RebaseFromLocalSourceBranch(string sourceBranchName);
+    void RebaseOntoNewParent(string newParentBranchName, string oldParentBranchName);
     void AbortMerge();
     void AbortRebase();
     void ContinueRebase();
@@ -132,6 +133,19 @@ public class GitClient(ILogger logger, GitClientSettings settings) : IGitClient
     public void RebaseFromLocalSourceBranch(string sourceBranchName)
     {
         ExecuteGitCommand($"rebase {sourceBranchName} --update-refs", false, exitCode =>
+        {
+            if (exitCode > 0)
+            {
+                return new ConflictException();
+            }
+
+            return null;
+        });
+    }
+
+    public void RebaseOntoNewParent(string newParentBranchName, string oldParentBranchName)
+    {
+        ExecuteGitCommand($"rebase --onto {newParentBranchName} {oldParentBranchName} --update-refs", false, exitCode =>
         {
             if (exitCode > 0)
             {


### PR DESCRIPTION
Improves rebasing after a squash merge by using `git rebase --onto <newparent> <oldparent>` when a parent branch has been deleted in the remote.

Fixes #234.

