### PR TITLE
Fixes confirmation when deleting stack in non-interactive console

### DIFF
--- a/src/Stack/Commands/Stack/DeleteStackCommand.cs
+++ b/src/Stack/Commands/Stack/DeleteStackCommand.cs
@@ -75,7 +75,7 @@ public class DeleteStackCommandHandler(
             {
                 StackHelpers.OutputBranchesNeedingCleanup(logger, branchesNeedingCleanup);
 
-                if (inputProvider.Confirm(Questions.ConfirmDeleteBranches))
+                if (inputs.Confirm || inputProvider.Confirm(Questions.ConfirmDeleteBranches))
                 {
                     StackHelpers.CleanupBranches(gitClient, logger, branchesNeedingCleanup);
                 }


### PR DESCRIPTION
Fixes issue where supplying `--yes` in non-interactive console would still ask for confirmation