### PR TITLE
Remove applying labels on PR creation

### DIFF
--- a/src/Stack.Tests/Commands/PullRequests/CreatePullRequestsCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/PullRequests/CreatePullRequestsCommandHandlerTests.cs
@@ -65,8 +65,8 @@ A custom description
 
         var expectedPullRequests = new Dictionary<string, GitHubPullRequest>
         {
-            [branch1] = new GitHubPullRequest(1, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false, []),
-            [branch2] = new GitHubPullRequest(2, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false, [])
+            [branch1] = new GitHubPullRequest(1, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false),
+            [branch2] = new GitHubPullRequest(2, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false)
         };
 
         gitHubClient.PullRequests.Should().BeEquivalentTo(expectedPullRequests, ExcludeUnimportantPullRequestProperties);
@@ -238,8 +238,8 @@ A custom description
 
         var expectedPullRequests = new Dictionary<string, GitHubPullRequest>
         {
-            [branch1] = new GitHubPullRequest(1, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false, []),
-            [branch2] = new GitHubPullRequest(2, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false, [])
+            [branch1] = new GitHubPullRequest(1, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false),
+            [branch2] = new GitHubPullRequest(2, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false)
         };
 
         gitHubClient.PullRequests.Should().BeEquivalentTo(expectedPullRequests, ExcludeUnimportantPullRequestProperties);
@@ -291,8 +291,8 @@ A custom description
 
         var expectedPullRequests = new Dictionary<string, GitHubPullRequest>
         {
-            [branch1] = new GitHubPullRequest(1, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false, []),
-            [branch2] = new GitHubPullRequest(2, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false, [])
+            [branch1] = new GitHubPullRequest(1, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false),
+            [branch2] = new GitHubPullRequest(2, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false)
         };
 
         gitHubClient.PullRequests.Should().BeEquivalentTo(expectedPullRequests, ExcludeUnimportantPullRequestProperties);
@@ -391,8 +391,8 @@ A custom description
 
         var expectedPullRequests = new Dictionary<string, GitHubPullRequest>
         {
-            [branch1] = new GitHubPullRequest(1, "PR Title", expectedPrBody, GitHubPullRequestStates.Merged, Some.HttpsUri(), false, []),
-            [branch2] = new GitHubPullRequest(2, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false, [])
+            [branch1] = new GitHubPullRequest(1, "PR Title", expectedPrBody, GitHubPullRequestStates.Merged, Some.HttpsUri(), false),
+            [branch2] = new GitHubPullRequest(2, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false)
         };
 
         gitHubClient.PullRequests.Should().BeEquivalentTo(expectedPullRequests, ExcludeUnimportantPullRequestProperties);
@@ -453,8 +453,8 @@ This is the PR template";
 
         var expectedPullRequests = new Dictionary<string, GitHubPullRequest>
         {
-            [branch1] = new GitHubPullRequest(1, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false, []),
-            [branch2] = new GitHubPullRequest(2, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false, [])
+            [branch1] = new GitHubPullRequest(1, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false),
+            [branch2] = new GitHubPullRequest(2, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false)
         };
 
         gitHubClient.PullRequests.Should().BeEquivalentTo(expectedPullRequests, ExcludeUnimportantPullRequestProperties);
@@ -510,7 +510,7 @@ This is the PR template";
 
         var expectedPullRequests = new Dictionary<string, GitHubPullRequest>
         {
-            [branch1] = new GitHubPullRequest(1, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false, [])
+            [branch1] = new GitHubPullRequest(1, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false)
         };
 
         gitHubClient.PullRequests.Should().BeEquivalentTo(expectedPullRequests, ExcludeUnimportantPullRequestProperties);
@@ -612,7 +612,7 @@ This is the PR template";
 
         var expectedPullRequests = new Dictionary<string, GitHubPullRequest>
         {
-            [branch1] = new GitHubPullRequest(1, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false, [])
+            [branch1] = new GitHubPullRequest(1, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false)
         };
 
         gitHubClient.PullRequests.Should().BeEquivalentTo(expectedPullRequests, ExcludeUnimportantPullRequestProperties);
@@ -671,140 +671,11 @@ A custom description
 
         var expectedPullRequests = new Dictionary<string, GitHubPullRequest>
         {
-            [branch1] = new GitHubPullRequest(1, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false, []),
-            [branch2] = new GitHubPullRequest(2, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false, [])
+            [branch1] = new GitHubPullRequest(1, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false),
+            [branch2] = new GitHubPullRequest(2, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false)
         };
 
         gitHubClient.PullRequests.Should().BeEquivalentTo(expectedPullRequests, ExcludeUnimportantPullRequestProperties);
         inputProvider.DidNotReceive().Text(Questions.PullRequestStackDescription, Arg.Any<string>());
-    }
-
-    [Fact]
-    public async Task WhenNoLabelsExistInTheRepo_DoesNotAskForLabels_AndNoLabelsAreAppliedToCreatedPullRequests()
-    {
-        // Arrange
-        var sourceBranch = Some.BranchName();
-        var branch1 = Some.BranchName();
-        var branch2 = Some.BranchName();
-        using var repo = new TestGitRepositoryBuilder()
-            .WithBranch(sourceBranch, true)
-            .WithBranch(branch1, true)
-            .WithBranch(branch2, true)
-            .Build();
-
-        var gitHubClient = new TestGitHubRepositoryBuilder().Build();
-        var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<IInputProvider>();
-        var logger = new TestLogger(testOutputHelper);
-        var fileOperations = new FileOperations();
-        var gitClient = new GitClient(logger, repo.GitClientSettings);
-        var handler = new CreatePullRequestsCommandHandler(inputProvider, logger, gitClient, gitHubClient, fileOperations, stackConfig);
-
-        var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
-
-        var stacks = new List<Config.Stack>(
-        [
-            stack1,
-            new("Stack2", repo.RemoteUri, sourceBranch, [])
-        ]);
-        stackConfig.Load().Returns(stacks);
-        stackConfig
-            .WhenForAnyArgs(s => s.Save(Arg.Any<List<Config.Stack>>()))
-            .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
-
-        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
-        inputProvider
-            .MultiSelect(Questions.SelectPullRequestsToCreate, Arg.Any<PullRequestCreateAction[]>(), true, Arg.Any<Func<PullRequestCreateAction, string>>())
-            .Returns([new PullRequestCreateAction(branch1, sourceBranch), new PullRequestCreateAction(branch2, branch1)]);
-        inputProvider.Confirm(Questions.ConfirmCreatePullRequests).Returns(true);
-        inputProvider.Text(Questions.PullRequestTitle).Returns("PR Title");
-        inputProvider.Text(Questions.PullRequestStackDescription, Arg.Any<string>()).Returns("A custom description");
-
-        // Act
-        await handler.Handle(CreatePullRequestsCommandInputs.Empty);
-
-        // Assert
-        var expectedPrBody = $@"{StackConstants.StackMarkerStart}
-A custom description
-
-{string.Join(Environment.NewLine, gitHubClient.PullRequests.Values.Select(pr => $"- {pr.Url}"))}
-{StackConstants.StackMarkerEnd}";
-
-        var expectedLabels = new List<string>(["label1", "label2"]).Select(l => new GitHubLabel(l)).ToArray();
-
-        var expectedPullRequests = new Dictionary<string, GitHubPullRequest>
-        {
-            [branch1] = new GitHubPullRequest(1, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false, []),
-            [branch2] = new GitHubPullRequest(2, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false, [])
-        };
-
-        gitHubClient.PullRequests.Should().BeEquivalentTo(expectedPullRequests, ExcludeUnimportantPullRequestProperties);
-        inputProvider.DidNotReceive().MultiSelect(Questions.PullRequestLabels, Arg.Any<string[]>(), Arg.Any<bool>(), Arg.Any<Func<string, string>>());
-    }
-
-    [Fact]
-    public async Task WhenLabelsExistInTheRepo_AsksForLabels_AndAppliesToCreatedPullRequests()
-    {
-        // Arrange
-        var sourceBranch = Some.BranchName();
-        var branch1 = Some.BranchName();
-        var branch2 = Some.BranchName();
-        using var repo = new TestGitRepositoryBuilder()
-            .WithBranch(sourceBranch, true)
-            .WithBranch(branch1, true)
-            .WithBranch(branch2, true)
-            .Build();
-
-        var gitHubClient = new TestGitHubRepositoryBuilder()
-            .WithLabel("label1")
-            .WithLabel("label2")
-            .Build();
-        var stackConfig = Substitute.For<IStackConfig>();
-        var inputProvider = Substitute.For<IInputProvider>();
-        var logger = new TestLogger(testOutputHelper);
-        var fileOperations = new FileOperations();
-        var gitClient = new GitClient(logger, repo.GitClientSettings);
-        var handler = new CreatePullRequestsCommandHandler(inputProvider, logger, gitClient, gitHubClient, fileOperations, stackConfig);
-
-        var stack1 = new Config.Stack("Stack1", repo.RemoteUri, sourceBranch, [branch1, branch2]);
-
-        var stacks = new List<Config.Stack>(
-        [
-            stack1,
-            new("Stack2", repo.RemoteUri, sourceBranch, [])
-        ]);
-        stackConfig.Load().Returns(stacks);
-        stackConfig
-            .WhenForAnyArgs(s => s.Save(Arg.Any<List<Config.Stack>>()))
-            .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
-
-        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
-        inputProvider
-            .MultiSelect(Questions.SelectPullRequestsToCreate, Arg.Any<PullRequestCreateAction[]>(), true, Arg.Any<Func<PullRequestCreateAction, string>>())
-            .Returns([new PullRequestCreateAction(branch1, sourceBranch), new PullRequestCreateAction(branch2, branch1)]);
-        inputProvider.Confirm(Questions.ConfirmCreatePullRequests).Returns(true);
-        inputProvider.Text(Questions.PullRequestTitle).Returns("PR Title");
-        inputProvider.Text(Questions.PullRequestStackDescription, Arg.Any<string>()).Returns("A custom description");
-        inputProvider.MultiSelect(Questions.PullRequestLabels, Arg.Any<string[]>(), Arg.Any<bool>(), Arg.Any<Func<string, string>>()).Returns(new List<string>(["label1", "label2"]).ToArray());
-
-        // Act
-        await handler.Handle(CreatePullRequestsCommandInputs.Empty);
-
-        // Assert
-        var expectedPrBody = $@"{StackConstants.StackMarkerStart}
-A custom description
-
-{string.Join(Environment.NewLine, gitHubClient.PullRequests.Values.Select(pr => $"- {pr.Url}"))}
-{StackConstants.StackMarkerEnd}";
-
-        var expectedLabels = new List<string>(["label1", "label2"]).Select(l => new GitHubLabel(l)).ToArray();
-
-        var expectedPullRequests = new Dictionary<string, GitHubPullRequest>
-        {
-            [branch1] = new GitHubPullRequest(1, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false, expectedLabels),
-            [branch2] = new GitHubPullRequest(2, "PR Title", expectedPrBody, GitHubPullRequestStates.Open, Some.HttpsUri(), false, expectedLabels)
-        };
-
-        gitHubClient.PullRequests.Should().BeEquivalentTo(expectedPullRequests, ExcludeUnimportantPullRequestProperties);
     }
 }

--- a/src/Stack.Tests/Commands/PullRequests/OpenPullRequestsCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/PullRequests/OpenPullRequestsCommandHandlerTests.cs
@@ -44,12 +44,12 @@ public class OpenPullRequestsCommandHandlerTests
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
 
-        var prForBranch1 = new GitHubPullRequest(1, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false, []);
+        var prForBranch1 = new GitHubPullRequest(1, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubClient
             .GetPullRequest(branch1)
             .Returns(prForBranch1);
 
-        var prForBranch2 = new GitHubPullRequest(2, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false, []);
+        var prForBranch2 = new GitHubPullRequest(2, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubClient
             .GetPullRequest(branch2)
             .Returns(prForBranch2);
@@ -95,12 +95,12 @@ public class OpenPullRequestsCommandHandlerTests
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
 
-        var prForBranch1 = new GitHubPullRequest(1, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false, []);
+        var prForBranch1 = new GitHubPullRequest(1, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubClient
             .GetPullRequest(branch1)
             .Returns(prForBranch1);
 
-        var prForBranch2 = new GitHubPullRequest(2, "PR Title", string.Empty, GitHubPullRequestStates.Closed, Some.HttpsUri(), false, []);
+        var prForBranch2 = new GitHubPullRequest(2, "PR Title", string.Empty, GitHubPullRequestStates.Closed, Some.HttpsUri(), false);
 
         // Act
         await handler.Handle(OpenPullRequestsCommandInputs.Empty);
@@ -138,12 +138,12 @@ public class OpenPullRequestsCommandHandlerTests
         ]);
         stackConfig.Load().Returns(stacks);
 
-        var prForBranch1 = new GitHubPullRequest(1, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false, []);
+        var prForBranch1 = new GitHubPullRequest(1, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubClient
             .GetPullRequest(branch1)
             .Returns(prForBranch1);
 
-        var prForBranch2 = new GitHubPullRequest(2, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false, []);
+        var prForBranch2 = new GitHubPullRequest(2, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubClient
             .GetPullRequest(branch2)
             .Returns(prForBranch2);
@@ -183,12 +183,12 @@ public class OpenPullRequestsCommandHandlerTests
         ]);
         stackConfig.Load().Returns(stacks);
 
-        var prForBranch1 = new GitHubPullRequest(1, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false, []);
+        var prForBranch1 = new GitHubPullRequest(1, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubClient
             .GetPullRequest(branch1)
             .Returns(prForBranch1);
 
-        var prForBranch2 = new GitHubPullRequest(2, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false, []);
+        var prForBranch2 = new GitHubPullRequest(2, "PR Title", string.Empty, GitHubPullRequestStates.Open, Some.HttpsUri(), false);
         gitHubClient
             .GetPullRequest(branch2)
             .Returns(prForBranch2);

--- a/src/Stack.Tests/Commands/Stack/StackStatusCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/StackStatusCommandHandlerTests.cs
@@ -46,7 +46,7 @@ public class StackStatusCommandHandlerTests
             .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
             .Do(ci => ci.ArgAt<Action>(1)());
 
-        var pr = new GitHubPullRequest(1, "PR title", "PR body", GitHubPullRequestStates.Open, Some.HttpsUri(), false, []);
+        var pr = new GitHubPullRequest(1, "PR title", "PR body", GitHubPullRequestStates.Open, Some.HttpsUri(), false);
 
         gitHubClient
             .GetPullRequest(branch1)
@@ -106,7 +106,7 @@ public class StackStatusCommandHandlerTests
             .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
             .Do(ci => ci.ArgAt<Action>(1)());
 
-        var pr = new GitHubPullRequest(1, "PR title", "PR body", GitHubPullRequestStates.Open, Some.HttpsUri(), false, []);
+        var pr = new GitHubPullRequest(1, "PR title", "PR body", GitHubPullRequestStates.Open, Some.HttpsUri(), false);
 
         gitHubClient
             .GetPullRequest(branch1)
@@ -169,7 +169,7 @@ public class StackStatusCommandHandlerTests
             .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
             .Do(ci => ci.ArgAt<Action>(1)());
 
-        var pr = new GitHubPullRequest(1, "PR title", "PR body", GitHubPullRequestStates.Open, Some.HttpsUri(), false, []);
+        var pr = new GitHubPullRequest(1, "PR title", "PR body", GitHubPullRequestStates.Open, Some.HttpsUri(), false);
 
         gitHubClient
             .GetPullRequest(branch1)
@@ -239,7 +239,7 @@ public class StackStatusCommandHandlerTests
             .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
             .Do(ci => ci.ArgAt<Action>(1)());
 
-        var pr = new GitHubPullRequest(1, "PR title", "PR body", GitHubPullRequestStates.Open, Some.HttpsUri(), false, []);
+        var pr = new GitHubPullRequest(1, "PR title", "PR body", GitHubPullRequestStates.Open, Some.HttpsUri(), false);
 
         gitHubClient
             .GetPullRequest(branch1)
@@ -342,7 +342,7 @@ public class StackStatusCommandHandlerTests
             .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
             .Do(ci => ci.ArgAt<Action>(1)());
 
-        var pr = new GitHubPullRequest(1, "PR title", "PR body", GitHubPullRequestStates.Open, Some.HttpsUri(), false, []);
+        var pr = new GitHubPullRequest(1, "PR title", "PR body", GitHubPullRequestStates.Open, Some.HttpsUri(), false);
 
         gitHubClient
             .GetPullRequest(branch2)
@@ -399,7 +399,7 @@ public class StackStatusCommandHandlerTests
             .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
             .Do(ci => ci.ArgAt<Action>(1)());
 
-        var pr = new GitHubPullRequest(1, "PR title", "PR body", GitHubPullRequestStates.Open, Some.HttpsUri(), false, []);
+        var pr = new GitHubPullRequest(1, "PR title", "PR body", GitHubPullRequestStates.Open, Some.HttpsUri(), false);
 
         gitHubClient
             .GetPullRequest(branch2)
@@ -456,7 +456,7 @@ public class StackStatusCommandHandlerTests
             .WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>()))
             .Do(ci => ci.ArgAt<Action>(1)());
 
-        var pr = new GitHubPullRequest(1, "PR title", "PR body", GitHubPullRequestStates.Open, Some.HttpsUri(), false, []);
+        var pr = new GitHubPullRequest(1, "PR title", "PR body", GitHubPullRequestStates.Open, Some.HttpsUri(), false);
 
         gitHubClient
             .GetPullRequest(branch1)

--- a/src/Stack.Tests/Commands/Stack/UpdateStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/UpdateStackCommandHandlerTests.cs
@@ -120,7 +120,7 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
 
-        gitHubClient.GetPullRequest(branch1).Returns(new GitHubPullRequest(1, Some.Name(), Some.Name(), GitHubPullRequestStates.Merged, Some.HttpsUri(), false, []));
+        gitHubClient.GetPullRequest(branch1).Returns(new GitHubPullRequest(1, Some.Name(), Some.Name(), GitHubPullRequestStates.Merged, Some.HttpsUri(), false));
 
         // Act
         await handler.Handle(new UpdateStackCommandInputs(null, false, false));

--- a/src/Stack.Tests/Helpers/TestGitHubRepositoryBuilder.cs
+++ b/src/Stack.Tests/Helpers/TestGitHubRepositoryBuilder.cs
@@ -5,7 +5,6 @@ namespace Stack.Tests.Helpers;
 public class TestGitHubRepositoryBuilder
 {
     readonly Dictionary<string, GitHubPullRequest> pullRequests = new();
-    readonly List<string> labels = [];
 
     public TestGitHubRepositoryBuilder WithPullRequest(string branch, Action<TestGitHubPullRequestBuilder>? pullRequestBuilder = null)
     {
@@ -15,15 +14,9 @@ public class TestGitHubRepositoryBuilder
         return this;
     }
 
-    public TestGitHubRepositoryBuilder WithLabel(string label)
-    {
-        labels.Add(label);
-        return this;
-    }
-
     public TestGitHubRepository Build()
     {
-        return new TestGitHubRepository(pullRequests, [.. labels]);
+        return new TestGitHubRepository(pullRequests);
     }
 }
 
@@ -35,7 +28,6 @@ public class TestGitHubPullRequestBuilder
     string state = GitHubPullRequestStates.Open;
     Uri url = Some.HttpsUri();
     bool draft = false;
-    string[] labels = [];
 
     public TestGitHubPullRequestBuilder WithTitle(string title)
     {
@@ -57,25 +49,23 @@ public class TestGitHubPullRequestBuilder
 
     public GitHubPullRequest Build()
     {
-        return new GitHubPullRequest(number, title, body, state, url, draft, [.. labels.Select(l => new GitHubLabel(l))]);
+        return new GitHubPullRequest(number, title, body, state, url, draft);
     }
 }
 
-public class TestGitHubRepository(Dictionary<string, GitHubPullRequest> PullRequests, string[] Labels) : IGitHubClient
+public class TestGitHubRepository(Dictionary<string, GitHubPullRequest> PullRequests) : IGitHubClient
 {
     public Dictionary<string, GitHubPullRequest> PullRequests { get; } = PullRequests;
-    public string[] Labels { get; } = Labels;
 
     public GitHubPullRequest CreatePullRequest(
         string headBranch,
         string baseBranch,
         string title,
         string bodyFilePath,
-        string[] labels,
         bool draft)
     {
         var prBody = File.ReadAllText(bodyFilePath).Trim();
-        var pr = new GitHubPullRequest(Some.Int(), title, prBody, GitHubPullRequestStates.Open, Some.HttpsUri(), draft, [.. labels.Select(l => new GitHubLabel(l))]);
+        var pr = new GitHubPullRequest(Some.Int(), title, prBody, GitHubPullRequestStates.Open, Some.HttpsUri(), draft);
         PullRequests.Add(headBranch, pr);
         return pr;
     }
@@ -98,10 +88,5 @@ public class TestGitHubRepository(Dictionary<string, GitHubPullRequest> PullRequ
 
     public void OpenPullRequest(GitHubPullRequest pullRequest)
     {
-    }
-
-    public string[] GetLabels()
-    {
-        return Labels;
     }
 }

--- a/src/Stack/Commands/Helpers/Questions.cs
+++ b/src/Stack/Commands/Helpers/Questions.cs
@@ -19,7 +19,6 @@ public static class Questions
     public const string ConfirmCreatePullRequests = "Are you sure you want to create pull requests for branches in this stack?";
     public const string PullRequestTitle = "Title:";
     public const string PullRequestStackDescription = "Stack description for pull request:";
-    public const string PullRequestLabels = "Labels to apply to pull request (optional):";
     public const string OpenPullRequests = "Open new pull requests in a browser?";
     public const string CreatePullRequestAsDraft = "Create pull request as draft?";
     public const string EditPullRequestBody = "Edit pull request body? This will open a file in your default editor.";

--- a/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
+++ b/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
@@ -185,7 +185,6 @@ public class CreatePullRequestsCommandHandler(
                 action.BaseBranch,
                 action.Title!,
                 action.BodyFilePath!,
-                action.Labels,
                 action.Draft);
 
             if (pullRequest is not null)
@@ -216,7 +215,7 @@ public class CreatePullRequestsCommandHandler(
                 var action = pullRequestCreateActions.FirstOrDefault(a => a.HeadBranch == branch);
                 if (action is not null)
                 {
-                    branchDisplayItems.Add($"{StackHelpers.GetBranchStatusOutput(branch, parentBranch, branchDetail)} {$"*NEW* {action.Title}".Highlighted()}{(action.Draft == true ? " (draft)".Muted() : string.Empty)}{(action.Labels.Length > 0 ? Markup.Escape($" [{string.Join(", ", action.Labels)}]").Muted() : string.Empty)}");
+                    branchDisplayItems.Add($"{StackHelpers.GetBranchStatusOutput(branch, parentBranch, branchDetail)} {$"*NEW* {action.Title}".Highlighted()}{(action.Draft == true ? " (draft)".Muted() : string.Empty)}");
                 }
                 else
                 {
@@ -251,8 +250,6 @@ public class CreatePullRequestsCommandHandler(
             logger.Information($"Found pull request template in repository, this will be used as the default body for each pull request.");
         }
 
-        var gitHubLabels = gitHubClient.GetLabels();
-
         foreach (var action in pullRequestCreateActions)
         {
             logger.NewLine();
@@ -279,17 +276,6 @@ public class CreatePullRequestsCommandHandler(
                 gitClient.OpenFileInEditorAndWaitForClose(bodyFilePath);
             }
 
-            string[] labels = [];
-
-            if (gitHubLabels.Length > 0)
-            {
-                labels = inputProvider.MultiSelect(
-                    logger,
-                    Questions.PullRequestLabels,
-                    gitHubLabels,
-                    false);
-            }
-
             var draft = inputProvider.Confirm(Questions.CreatePullRequestAsDraft, false);
 
             pullRequestActions.Add(new PullRequestInformation(
@@ -297,7 +283,6 @@ public class CreatePullRequestsCommandHandler(
                 action.BaseBranch,
                 title,
                 bodyFilePath,
-                [.. labels],
                 draft));
         }
 
@@ -309,7 +294,6 @@ public class CreatePullRequestsCommandHandler(
         string BaseBranch,
         string Title,
         string BodyFilePath,
-        string[] Labels,
         bool Draft);
 
     public record PullRequestCreateAction(string Branch, string BaseBranch);


### PR DESCRIPTION
After using the support for applying labels when creating PRs for a while, it doesn't feel like it's adding that much value and gets in the way a bit. Mostly this is because you can't search in the list properly due to some restrictions in `Spectre.Console`, but also because we already ask lots of questions in the PR creation flow, so it felt like too much.