### PR TITLE
Write stdout using `Console.Out` instead `AnsiConsole`

### DIFF
--- a/src/Stack/Commands/Stack/ListStacksCommand.cs
+++ b/src/Stack/Commands/Stack/ListStacksCommand.cs
@@ -24,7 +24,7 @@ public class ListStacksCommand : CommandWithOutput<ListStacksCommandSettings, Li
     {
         if (response.Stacks.Count == 0)
         {
-            StdOut.WriteLine("No stacks found for current repository.");
+            StdErr.WriteLine("No stacks found for current repository.");
             return;
         }
 

--- a/src/Stack/Commands/Stack/ListStacksCommand.cs
+++ b/src/Stack/Commands/Stack/ListStacksCommand.cs
@@ -24,13 +24,13 @@ public class ListStacksCommand : CommandWithOutput<ListStacksCommandSettings, Li
     {
         if (response.Stacks.Count == 0)
         {
-            StdErr.WriteLine("No stacks found for current repository.");
+            StdOut.WriteLine("No stacks found for current repository.");
             return;
         }
 
         foreach (var stack in response.Stacks)
         {
-            StdErr.MarkupLine($"{stack.Name.Stack()} {$"({stack.SourceBranch})".Muted()} {"branch".ToQuantity(stack.BranchCount)}");
+            StdOutLogger.Information($"{stack.Name.Stack()} {$"({stack.SourceBranch})".Muted()} {"branch".ToQuantity(stack.BranchCount)}");
         }
     }
 }

--- a/src/Stack/Infrastructure/Commands/Command.cs
+++ b/src/Stack/Infrastructure/Commands/Command.cs
@@ -6,30 +6,31 @@ namespace Stack.Commands;
 
 public abstract class Command<T> : AsyncCommand<T> where T : CommandSettingsBase
 {
-    protected IAnsiConsole StdOut;
-    protected IAnsiConsole StdErr;
     protected ILogger StdOutLogger;
     protected ILogger StdErrLogger;
     protected IInputProvider InputProvider;
 
     public Command()
     {
-        StdOut = AnsiConsole.Create(new AnsiConsoleSettings
+        var stdOutAnsiConsole = AnsiConsole.Create(new AnsiConsoleSettings
         {
             Ansi = AnsiSupport.Detect,
             ColorSystem = ColorSystemSupport.Detect,
             Out = new AnsiConsoleOutput(Console.Out),
         });
-        StdErr = AnsiConsole.Create(new AnsiConsoleSettings
+        var stdErrAnsiConsole = AnsiConsole.Create(new AnsiConsoleSettings
         {
             Ansi = AnsiSupport.Detect,
             ColorSystem = ColorSystemSupport.Detect,
             Out = new AnsiConsoleOutput(Console.Error),
         });
-        StdOutLogger = new ConsoleLogger(StdOut);
-        StdErrLogger = new ConsoleLogger(StdErr);
-        InputProvider = new ConsoleInputProvider(StdErr);
+        StdOutLogger = new ConsoleLogger(stdOutAnsiConsole);
+        StdErrLogger = new ConsoleLogger(stdErrAnsiConsole);
+        InputProvider = new ConsoleInputProvider(stdErrAnsiConsole);
     }
+
+    protected TextWriter StdOut => Console.Out;
+    protected TextWriter StdErr => Console.Error;
 
     public override async Task<int> ExecuteAsync(CommandContext context, T settings)
     {


### PR DESCRIPTION
Write `stdout` to `Console.Out` instead of `AnsiConsole` so that it doesn't wrap.

Fixes #241
