### PR TITLE
Refactor stack status

### DIFF
--- a/src/Stack.Tests/Commands/Helpers/StackHelpersTests.cs
+++ b/src/Stack.Tests/Commands/Helpers/StackHelpersTests.cs
@@ -145,7 +145,7 @@ public class StackHelpersTests(ITestOutputHelper testOutputHelper)
         repo.DeleteRemoteTrackingBranch(branch1);
 
         var stack = new Config.Stack("Stack1", Some.HttpsUri().ToString(), sourceBranch, [branch1, branch2]);
-        var stackStatus = StackHelpers.GetStackStatusNew(stack, branch1, logger, gitClient, gitHubClient, false);
+        var stackStatus = StackHelpers.GetStackStatus(stack, branch1, logger, gitClient, gitHubClient, false);
 
         // Act
         StackHelpers.UpdateStackUsingRebase(stack, stackStatus, gitClient, inputProvider, logger);
@@ -216,7 +216,7 @@ public class StackHelpersTests(ITestOutputHelper testOutputHelper)
         repo.Push(sourceBranch);
 
         var stack = new Config.Stack("Stack1", Some.HttpsUri().ToString(), sourceBranch, [branch1, branch2]);
-        var stackStatus = StackHelpers.GetStackStatusNew(stack, branch1, logger, gitClient, gitHubClient, false);
+        var stackStatus = StackHelpers.GetStackStatus(stack, branch1, logger, gitClient, gitHubClient, false);
 
         // Act: Even though the parent branch (branch1) has been deleted on the remote,
         // we should not explicitly re-parent the target branch (branch2) onto the source branch
@@ -265,7 +265,7 @@ public class StackHelpersTests(ITestOutputHelper testOutputHelper)
         repo.Commit();
 
         var stack = new Config.Stack("Stack1", Some.HttpsUri().ToString(), sourceBranch, [branch1, branch2]);
-        var stackStatus = StackHelpers.GetStackStatusNew(stack, branch1, logger, gitClient, gitHubClient, false);
+        var stackStatus = StackHelpers.GetStackStatus(stack, branch1, logger, gitClient, gitHubClient, false);
 
         gitClient.Fetch(true);
 

--- a/src/Stack.Tests/Commands/Helpers/StackHelpersTests.cs
+++ b/src/Stack.Tests/Commands/Helpers/StackHelpersTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using NSubstitute;
+using Stack.Commands;
 using Stack.Commands.Helpers;
 using Stack.Git;
 using Stack.Infrastructure;
@@ -22,20 +23,9 @@ public class StackHelpersTests(ITestOutputHelper testOutputHelper)
         var inputProvider = Substitute.For<IInputProvider>();
 
         var stack = new Config.Stack("Stack1", Some.HttpsUri().ToString(), sourceBranch, [branch1, branch2]);
-        var branchDetail1 = new BranchDetail
-        {
-            Status = new BranchStatus(true, true, true, false, 0, 0, 0, 0, null)
-        };
-        var branchDetail2 = new BranchDetail
-        {
-            Status = new BranchStatus(true, true, true, false, 0, 0, 0, 0, null)
-        };
-
-        var stackStatus = new StackStatus(new Dictionary<string, BranchDetail>
-        {
-            { branch1, branchDetail1 },
-            { branch2, branchDetail2 },
-        });
+        var branchDetail1 = new BranchDetail(branch1, true, new Commit(Some.Sha(), Some.Name()), new RemoteTrackingBranchStatus($"origin/{branch1}", true, 0, 0), null, null);
+        var branchDetail2 = new BranchDetail(branch2, true, new Commit(Some.Sha(), Some.Name()), new RemoteTrackingBranchStatus($"origin/{branch2}", true, 0, 0), null, null);
+        var stackStatus = new StackStatus("Stack1", new Branch(sourceBranch, true, null, null), [branchDetail1, branchDetail2]);
 
         inputProvider
             .Select(
@@ -76,20 +66,9 @@ public class StackHelpersTests(ITestOutputHelper testOutputHelper)
         var logger = new TestLogger(testOutputHelper);
 
         var stack = new Config.Stack("Stack1", Some.HttpsUri().ToString(), sourceBranch, [branch1, branch2]);
-        var branchDetail1 = new BranchDetail
-        {
-            Status = new BranchStatus(true, true, true, false, 0, 0, 0, 0, null)
-        };
-        var branchDetail2 = new BranchDetail
-        {
-            Status = new BranchStatus(true, true, true, false, 0, 0, 0, 0, null)
-        };
-
-        var stackStatus = new StackStatus(new Dictionary<string, BranchDetail>
-        {
-            { branch1, branchDetail1 },
-            { branch2, branchDetail2 },
-        });
+        var branchDetail1 = new BranchDetail(branch1, true, new Commit(Some.Sha(), Some.Name()), new RemoteTrackingBranchStatus($"origin/{branch1}", true, 0, 0), null, null);
+        var branchDetail2 = new BranchDetail(branch2, true, new Commit(Some.Sha(), Some.Name()), new RemoteTrackingBranchStatus($"origin/{branch2}", true, 0, 0), null, null);
+        var stackStatus = new StackStatus("Stack1", new Branch(sourceBranch, true, null, null), [branchDetail1, branchDetail2]);
 
         gitClient
             .When(g => g.MergeFromLocalSourceBranch(sourceBranch))
@@ -166,7 +145,7 @@ public class StackHelpersTests(ITestOutputHelper testOutputHelper)
         repo.DeleteRemoteTrackingBranch(branch1);
 
         var stack = new Config.Stack("Stack1", Some.HttpsUri().ToString(), sourceBranch, [branch1, branch2]);
-        var stackStatus = StackHelpers.GetStackStatus(stack, branch1, logger, gitClient, gitHubClient, false);
+        var stackStatus = StackHelpers.GetStackStatusNew(stack, branch1, logger, gitClient, gitHubClient, false);
 
         // Act
         StackHelpers.UpdateStackUsingRebase(stack, stackStatus, gitClient, inputProvider, logger);
@@ -237,7 +216,7 @@ public class StackHelpersTests(ITestOutputHelper testOutputHelper)
         repo.Push(sourceBranch);
 
         var stack = new Config.Stack("Stack1", Some.HttpsUri().ToString(), sourceBranch, [branch1, branch2]);
-        var stackStatus = StackHelpers.GetStackStatus(stack, branch1, logger, gitClient, gitHubClient, false);
+        var stackStatus = StackHelpers.GetStackStatusNew(stack, branch1, logger, gitClient, gitHubClient, false);
 
         // Act: Even though the parent branch (branch1) has been deleted on the remote,
         // we should not explicitly re-parent the target branch (branch2) onto the source branch
@@ -286,7 +265,7 @@ public class StackHelpersTests(ITestOutputHelper testOutputHelper)
         repo.Commit();
 
         var stack = new Config.Stack("Stack1", Some.HttpsUri().ToString(), sourceBranch, [branch1, branch2]);
-        var stackStatus = StackHelpers.GetStackStatus(stack, branch1, logger, gitClient, gitHubClient, false);
+        var stackStatus = StackHelpers.GetStackStatusNew(stack, branch1, logger, gitClient, gitHubClient, false);
 
         gitClient.Fetch(true);
 

--- a/src/Stack.Tests/Commands/Stack/CleanupStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/CleanupStackCommandHandlerTests.cs
@@ -39,6 +39,7 @@ public class CleanupStackCommandHandlerTests
 
         var remoteUri = Some.HttpsUri().ToString();
         stackConfig.Load().Returns(stacks);
+        logger.WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>())).Do(ci => ci.ArgAt<Action>(1)());
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
         inputProvider.Confirm(Questions.ConfirmDeleteBranches).Returns(true);
@@ -80,6 +81,7 @@ public class CleanupStackCommandHandlerTests
 
         var remoteUri = Some.HttpsUri().ToString();
         stackConfig.Load().Returns(stacks);
+        logger.WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>())).Do(ci => ci.ArgAt<Action>(1)());
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
         inputProvider.Confirm(Questions.ConfirmDeleteBranches).Returns(true);
@@ -117,6 +119,7 @@ public class CleanupStackCommandHandlerTests
             new("Stack2", repo.RemoteUri, sourceBranch, [])
         ]);
         stackConfig.Load().Returns(stacks);
+        logger.WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>())).Do(ci => ci.ArgAt<Action>(1)());
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
         inputProvider.Confirm(Questions.ConfirmDeleteBranches).Returns(true);
@@ -154,6 +157,7 @@ public class CleanupStackCommandHandlerTests
             new("Stack2", repo.RemoteUri, sourceBranch, [])
         ]);
         stackConfig.Load().Returns(stacks);
+        logger.WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>())).Do(ci => ci.ArgAt<Action>(1)());
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
         inputProvider.Confirm(Questions.ConfirmDeleteBranches).Returns(false);
@@ -191,6 +195,7 @@ public class CleanupStackCommandHandlerTests
             new("Stack2", repo.RemoteUri, sourceBranch, [])
         ]);
         stackConfig.Load().Returns(stacks);
+        logger.WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>())).Do(ci => ci.ArgAt<Action>(1)());
 
         inputProvider.Confirm(Questions.ConfirmDeleteBranches).Returns(true);
 
@@ -263,6 +268,7 @@ public class CleanupStackCommandHandlerTests
             new("Stack1", repo.RemoteUri, sourceBranch, [branchToCleanup, branchToKeep]),
         ]);
         stackConfig.Load().Returns(stacks);
+        logger.WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>())).Do(ci => ci.ArgAt<Action>(1)());
 
         inputProvider.Confirm(Questions.ConfirmDeleteBranches).Returns(true);
 
@@ -303,6 +309,7 @@ public class CleanupStackCommandHandlerTests
 
         var remoteUri = Some.HttpsUri().ToString();
         stackConfig.Load().Returns(stacks);
+        logger.WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>())).Do(ci => ci.ArgAt<Action>(1)());
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
 

--- a/src/Stack.Tests/Commands/Stack/DeleteStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/DeleteStackCommandHandlerTests.cs
@@ -34,6 +34,7 @@ public class DeleteStackCommandHandlerTests
         stackConfig
             .WhenForAnyArgs(s => s.Save(Arg.Any<List<Config.Stack>>()))
             .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
+        logger.WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>())).Do(ci => ci.ArgAt<Action>(1)());
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
         inputProvider.Confirm(Questions.ConfirmDeleteStack).Returns(true);
@@ -71,6 +72,7 @@ public class DeleteStackCommandHandlerTests
         stackConfig
             .WhenForAnyArgs(s => s.Save(Arg.Any<List<Config.Stack>>()))
             .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
+        logger.WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>())).Do(ci => ci.ArgAt<Action>(1)());
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
         inputProvider.Confirm(Questions.ConfirmDeleteStack).Returns(false);
@@ -109,6 +111,7 @@ public class DeleteStackCommandHandlerTests
         stackConfig
             .WhenForAnyArgs(s => s.Save(Arg.Any<List<Config.Stack>>()))
             .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
+        logger.WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>())).Do(ci => ci.ArgAt<Action>(1)());
 
         inputProvider.Confirm(Questions.ConfirmDeleteStack).Returns(true);
 
@@ -189,6 +192,7 @@ public class DeleteStackCommandHandlerTests
         stackConfig
             .WhenForAnyArgs(s => s.Save(Arg.Any<List<Config.Stack>>()))
             .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
+        logger.WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>())).Do(ci => ci.ArgAt<Action>(1)());
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
         inputProvider.Confirm(Questions.ConfirmDeleteStack).Returns(true);
@@ -227,6 +231,7 @@ public class DeleteStackCommandHandlerTests
         stackConfig
             .WhenForAnyArgs(s => s.Save(Arg.Any<List<Config.Stack>>()))
             .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
+        logger.WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>())).Do(ci => ci.ArgAt<Action>(1)());
 
         inputProvider.Confirm(Questions.ConfirmDeleteStack).Returns(true);
 
@@ -262,6 +267,7 @@ public class DeleteStackCommandHandlerTests
         stackConfig
             .WhenForAnyArgs(s => s.Save(Arg.Any<List<Config.Stack>>()))
             .Do(ci => stacks = ci.ArgAt<List<Config.Stack>>(0));
+        logger.WhenForAnyArgs(o => o.Status(Arg.Any<string>(), Arg.Any<Action>())).Do(ci => ci.ArgAt<Action>(1)());
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
 

--- a/src/Stack.Tests/Commands/Stack/DeleteStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/DeleteStackCommandHandlerTests.cs
@@ -16,7 +16,7 @@ public class DeleteStackCommandHandlerTests
     {
         // Arrange
         var sourceBranch = Some.BranchName();
-        using var repo = new TestGitRepositoryBuilder().Build();
+        using var repo = new TestGitRepositoryBuilder().WithBranch(sourceBranch).Build();
 
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
@@ -91,7 +91,7 @@ public class DeleteStackCommandHandlerTests
     {
         // Arrange
         var sourceBranch = Some.BranchName();
-        using var repo = new TestGitRepositoryBuilder().Build();
+        using var repo = new TestGitRepositoryBuilder().WithBranch(sourceBranch).Build();
 
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
@@ -210,7 +210,7 @@ public class DeleteStackCommandHandlerTests
     {
         // Arrange
         var sourceBranch = Some.BranchName();
-        using var repo = new TestGitRepositoryBuilder().Build();
+        using var repo = new TestGitRepositoryBuilder().WithBranch(sourceBranch).Build();
 
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();
@@ -244,7 +244,7 @@ public class DeleteStackCommandHandlerTests
     {
         // Arrange
         var sourceBranch = Some.BranchName();
-        using var repo = new TestGitRepositoryBuilder().Build();
+        using var repo = new TestGitRepositoryBuilder().WithBranch(sourceBranch).Build();
 
         var stackConfig = Substitute.For<IStackConfig>();
         var inputProvider = Substitute.For<IInputProvider>();

--- a/src/Stack.Tests/Commands/Stack/UpdateStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/UpdateStackCommandHandlerTests.cs
@@ -45,7 +45,7 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
 
         // Act
-        await handler.Handle(new UpdateStackCommandInputs(null, false, false));
+        await handler.Handle(new UpdateStackCommandInputs(null, false, true));
 
         // Assert
         repo.GetCommitsReachableFromBranch(branch1).Should().Contain(tipOfSourceBranch);
@@ -160,7 +160,7 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         stackConfig.Load().Returns(stacks);
 
         // Act
-        await handler.Handle(new UpdateStackCommandInputs("Stack1", false, false));
+        await handler.Handle(new UpdateStackCommandInputs("Stack1", false, true));
 
         // Assert
         repo.GetCommitsReachableFromBranch(branch1).Should().Contain(tipOfSourceBranch);
@@ -242,7 +242,7 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
 
         // Act
-        await handler.Handle(new UpdateStackCommandInputs(null, false, false));
+        await handler.Handle(new UpdateStackCommandInputs(null, false, true));
 
         // Assert
         repo.GetCommitsReachableFromBranch(branch1).Should().Contain(tipOfSourceBranch);
@@ -281,7 +281,7 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         stackConfig.Load().Returns(stacks);
 
         // Act
-        await handler.Handle(new UpdateStackCommandInputs(null, false, false));
+        await handler.Handle(new UpdateStackCommandInputs(null, false, true));
 
         // Assert
         repo.GetCommitsReachableFromBranch(branch1).Should().Contain(tipOfSourceBranch);

--- a/src/Stack.Tests/Helpers/Some.cs
+++ b/src/Stack.Tests/Helpers/Some.cs
@@ -11,4 +11,5 @@ public static class Some
     public static string BranchName() => $"branch-{ShortName()}";
     public static Uri HttpsUri() => new($"https://{ShortName()}.com");
     public static string Email() => $"{ShortName()}@{ShortName()}.com";
+    public static string Sha() => Guid.NewGuid().ToString("N").Substring(0, 7);
 }

--- a/src/Stack/Commands/Helpers/StackHelpers.cs
+++ b/src/Stack/Commands/Helpers/StackHelpers.cs
@@ -37,7 +37,7 @@ public record ParentBranchStatus(Branch Branch, int Ahead, int Behind);
 
 public static class StackHelpers
 {
-    public static List<StackStatus> GetStackStatusNew(
+    public static List<StackStatus> GetStackStatus(
         List<Config.Stack> stacks,
         string currentBranch,
         ILogger logger,
@@ -127,7 +127,7 @@ public static class StackHelpers
         return stacksToReturnStatusFor;
     }
 
-    public static StackStatus GetStackStatusNew(
+    public static StackStatus GetStackStatus(
         Config.Stack stack,
         string currentBranch,
         ILogger logger,
@@ -135,7 +135,7 @@ public static class StackHelpers
         IGitHubClient gitHubClient,
         bool includePullRequestStatus = true)
     {
-        var statuses = GetStackStatusNew(
+        var statuses = GetStackStatus(
             [stack],
             currentBranch,
             logger,
@@ -470,7 +470,7 @@ public static class StackHelpers
     public static string[] GetBranchesNeedingCleanup(Config.Stack stack, ILogger logger, IGitClient gitClient, IGitHubClient gitHubClient)
     {
         var currentBranch = gitClient.GetCurrentBranch();
-        var stackStatus = GetStackStatusNew(stack, currentBranch, logger, gitClient, gitHubClient, true);
+        var stackStatus = GetStackStatus(stack, currentBranch, logger, gitClient, gitHubClient, true);
 
         return [.. stackStatus.Branches.Where(b => b.CouldBeCleanedUp).Select(b => b.Name)];
     }

--- a/src/Stack/Commands/Helpers/StackHelpers.cs
+++ b/src/Stack/Commands/Helpers/StackHelpers.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Text.Json.Serialization;
 using Spectre.Console;
 using Stack.Config;
 using Stack.Git;
@@ -12,8 +13,13 @@ public record RemoteTrackingBranchStatus(string Name, bool Exists, int Ahead, in
 
 public record Branch(string Name, bool Exists, Commit? Tip, RemoteTrackingBranchStatus? RemoteTrackingBranch)
 {
+    [JsonIgnore]
     public virtual bool IsActive => Exists && RemoteTrackingBranch?.Exists == true;
+
+    [JsonIgnore]
     public int AheadOfRemote => RemoteTrackingBranch?.Ahead ?? 0;
+
+    [JsonIgnore]
     public int BehindRemote => RemoteTrackingBranch?.Behind ?? 0;
 }
 
@@ -25,11 +31,22 @@ public record BranchDetail(
     GitHubPullRequest? PullRequest,
     ParentBranchStatus? Parent) : Branch(Name, Exists, Tip, RemoteTrackingBranch)
 {
+    [JsonIgnore]
     public override bool IsActive => base.IsActive && (PullRequest is null || PullRequest.State != GitHubPullRequestStates.Merged);
+
+    [JsonIgnore]
     public bool CouldBeCleanedUp => Exists && ((RemoteTrackingBranch is not null && !RemoteTrackingBranch.Exists) || (PullRequest is not null && PullRequest.State == GitHubPullRequestStates.Merged));
+
+    [JsonIgnore]
     public bool HasPullRequest => PullRequest is not null && PullRequest.State != GitHubPullRequestStates.Closed;
+
+    [JsonIgnore]
     public int AheadOfParent => Parent?.Ahead ?? 0;
+
+    [JsonIgnore]
     public int BehindParent => Parent?.Behind ?? 0;
+
+    [JsonIgnore]
     public string ParentBranchName => Parent?.Branch.Name ?? string.Empty;
 }
 

--- a/src/Stack/Commands/Helpers/StackHelpers.cs
+++ b/src/Stack/Commands/Helpers/StackHelpers.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using System.Text.Json.Serialization;
 using Spectre.Console;
 using Stack.Config;
 using Stack.Git;
@@ -13,13 +12,8 @@ public record RemoteTrackingBranchStatus(string Name, bool Exists, int Ahead, in
 
 public record Branch(string Name, bool Exists, Commit? Tip, RemoteTrackingBranchStatus? RemoteTrackingBranch)
 {
-    [JsonIgnore]
     public virtual bool IsActive => Exists && RemoteTrackingBranch?.Exists == true;
-
-    [JsonIgnore]
     public int AheadOfRemote => RemoteTrackingBranch?.Ahead ?? 0;
-
-    [JsonIgnore]
     public int BehindRemote => RemoteTrackingBranch?.Behind ?? 0;
 }
 
@@ -31,22 +25,11 @@ public record BranchDetail(
     GitHubPullRequest? PullRequest,
     ParentBranchStatus? Parent) : Branch(Name, Exists, Tip, RemoteTrackingBranch)
 {
-    [JsonIgnore]
     public override bool IsActive => base.IsActive && (PullRequest is null || PullRequest.State != GitHubPullRequestStates.Merged);
-
-    [JsonIgnore]
     public bool CouldBeCleanedUp => Exists && ((RemoteTrackingBranch is not null && !RemoteTrackingBranch.Exists) || (PullRequest is not null && PullRequest.State == GitHubPullRequestStates.Merged));
-
-    [JsonIgnore]
     public bool HasPullRequest => PullRequest is not null && PullRequest.State != GitHubPullRequestStates.Closed;
-
-    [JsonIgnore]
     public int AheadOfParent => Parent?.Ahead ?? 0;
-
-    [JsonIgnore]
     public int BehindParent => Parent?.Behind ?? 0;
-
-    [JsonIgnore]
     public string ParentBranchName => Parent?.Branch.Name ?? string.Empty;
 }
 

--- a/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
+++ b/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
@@ -69,7 +69,7 @@ public class CreatePullRequestsCommandHandler(
             throw new InvalidOperationException($"Stack '{inputs.Stack}' not found.");
         }
 
-        var status = StackHelpers.GetStackStatusNew(
+        var status = StackHelpers.GetStackStatus(
             stack,
             currentBranch,
             logger,
@@ -133,7 +133,7 @@ public class CreatePullRequestsCommandHandler(
                 var newPullRequests = CreatePullRequests(logger, gitHubClient, status, pullRequestInformation);
 
                 // Re-get the status to pick up PRs
-                status = StackHelpers.GetStackStatusNew(
+                status = StackHelpers.GetStackStatus(
                     stack,
                     currentBranch,
                     logger,

--- a/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
+++ b/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
@@ -69,7 +69,7 @@ public class CreatePullRequestsCommandHandler(
             throw new InvalidOperationException($"Stack '{inputs.Stack}' not found.");
         }
 
-        var status = StackHelpers.GetStackStatus(
+        var status = StackHelpers.GetStackStatusNew(
             stack,
             currentBranch,
             logger,
@@ -79,22 +79,20 @@ public class CreatePullRequestsCommandHandler(
         var sourceBranch = stack.SourceBranch;
         var pullRequestCreateActions = new List<PullRequestCreateAction>();
 
-        foreach (var branch in stack.Branches)
+        foreach (var branch in status.Branches)
         {
-            var branchDetail = status.Branches[branch];
-
-            if (branchDetail.IsActive)
+            if (branch.IsActive)
             {
-                if (!branchDetail.HasPullRequest)
+                if (!branch.HasPullRequest)
                 {
-                    pullRequestCreateActions.Add(new PullRequestCreateAction(branch, sourceBranch));
+                    pullRequestCreateActions.Add(new PullRequestCreateAction(branch.Name, sourceBranch));
                 }
 
-                sourceBranch = branch;
+                sourceBranch = branch.Name;
             }
         }
 
-        StackHelpers.OutputStackStatus(stack, status, logger);
+        StackHelpers.OutputStackStatus(status, logger);
 
         logger.NewLine();
 
@@ -134,7 +132,7 @@ public class CreatePullRequestsCommandHandler(
             {
                 var newPullRequests = CreatePullRequests(logger, gitHubClient, status, pullRequestInformation);
 
-                var pullRequestsInStack = status.Branches.Values
+                var pullRequestsInStack = status.Branches
                     .Where(branch => branch.HasPullRequest)
                     .Select(branch => branch.PullRequest!)
                     .ToList();
@@ -178,7 +176,7 @@ public class CreatePullRequestsCommandHandler(
         var pullRequests = new List<GitHubPullRequest>();
         foreach (var action in pullRequestCreateActions)
         {
-            var branchDetail = status.Branches[action.HeadBranch];
+            var branchDetail = status.Branches.First(b => b.Name == action.HeadBranch);
             logger.Information($"Creating pull request for branch {action.HeadBranch.Branch()} to {action.BaseBranch.Branch()}");
             var pullRequest = gitHubClient.CreatePullRequest(
                 action.HeadBranch,
@@ -191,7 +189,7 @@ public class CreatePullRequestsCommandHandler(
             {
                 logger.Information($"Pull request {pullRequest.GetPullRequestDisplay()} created for branch {action.HeadBranch.Branch()} to {action.BaseBranch.Branch()}");
                 pullRequests.Add(pullRequest);
-                branchDetail.PullRequest = pullRequest;
+                branchDetail = branchDetail with { PullRequest = pullRequest };
             }
         }
 
@@ -201,28 +199,25 @@ public class CreatePullRequestsCommandHandler(
     private static void OutputUpdatedStackStatus(ILogger logger, Config.Stack stack, StackStatus status, List<PullRequestInformation> pullRequestCreateActions)
     {
         var branchDisplayItems = new List<string>();
-        var parentBranch = stack.SourceBranch;
 
-        foreach (var branch in stack.Branches)
+        foreach (var branch in status.Branches)
         {
-            var branchDetail = status.Branches[branch];
-            if (branchDetail.PullRequest is not null && branchDetail.PullRequest.State != GitHubPullRequestStates.Closed)
+            if (branch.PullRequest is not null && branch.PullRequest.State != GitHubPullRequestStates.Closed)
             {
-                branchDisplayItems.Add(StackHelpers.GetBranchAndPullRequestStatusOutput(branch, parentBranch, branchDetail));
+                branchDisplayItems.Add(StackHelpers.GetBranchAndPullRequestStatusOutput(branch));
             }
             else
             {
-                var action = pullRequestCreateActions.FirstOrDefault(a => a.HeadBranch == branch);
+                var action = pullRequestCreateActions.FirstOrDefault(a => a.HeadBranch == branch.Name);
                 if (action is not null)
                 {
-                    branchDisplayItems.Add($"{StackHelpers.GetBranchStatusOutput(branch, parentBranch, branchDetail)} {$"*NEW* {action.Title}".Highlighted()}{(action.Draft == true ? " (draft)".Muted() : string.Empty)}");
+                    branchDisplayItems.Add($"{StackHelpers.GetBranchStatusOutput(branch)} {$"*NEW* {action.Title}".Highlighted()}{(action.Draft == true ? " (draft)".Muted() : string.Empty)}");
                 }
                 else
                 {
-                    branchDisplayItems.Add(StackHelpers.GetBranchStatusOutput(branch, parentBranch, branchDetail));
+                    branchDisplayItems.Add(StackHelpers.GetBranchStatusOutput(branch));
                 }
             }
-            parentBranch = branch;
         }
 
         logger.Tree(

--- a/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
+++ b/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
@@ -132,6 +132,14 @@ public class CreatePullRequestsCommandHandler(
             {
                 var newPullRequests = CreatePullRequests(logger, gitHubClient, status, pullRequestInformation);
 
+                // Re-get the status to pick up PRs
+                status = StackHelpers.GetStackStatusNew(
+                    stack,
+                    currentBranch,
+                    logger,
+                    gitClient,
+                    gitHubClient);
+
                 var pullRequestsInStack = status.Branches
                     .Where(branch => branch.HasPullRequest)
                     .Select(branch => branch.PullRequest!)
@@ -189,7 +197,6 @@ public class CreatePullRequestsCommandHandler(
             {
                 logger.Information($"Pull request {pullRequest.GetPullRequestDisplay()} created for branch {action.HeadBranch.Branch()} to {action.BaseBranch.Branch()}");
                 pullRequests.Add(pullRequest);
-                branchDetail = branchDetail with { PullRequest = pullRequest };
             }
         }
 

--- a/src/Stack/Commands/PullRequests/SetPullRequestDescriptionCommand.cs
+++ b/src/Stack/Commands/PullRequests/SetPullRequestDescriptionCommand.cs
@@ -66,7 +66,7 @@ public class SetPullRequestDescriptionCommandHandler(
             throw new InvalidOperationException($"Stack '{inputs.Stack}' not found.");
         }
 
-        var status = StackHelpers.GetStackStatusNew(
+        var status = StackHelpers.GetStackStatus(
             stack,
             currentBranch,
             logger,

--- a/src/Stack/Commands/PullRequests/SetPullRequestDescriptionCommand.cs
+++ b/src/Stack/Commands/PullRequests/SetPullRequestDescriptionCommand.cs
@@ -66,7 +66,7 @@ public class SetPullRequestDescriptionCommandHandler(
             throw new InvalidOperationException($"Stack '{inputs.Stack}' not found.");
         }
 
-        var status = StackHelpers.GetStackStatus(
+        var status = StackHelpers.GetStackStatusNew(
             stack,
             currentBranch,
             logger,
@@ -76,12 +76,11 @@ public class SetPullRequestDescriptionCommandHandler(
 
         var pullRequestsInStack = new List<GitHubPullRequest>();
 
-        foreach (var branch in stack.Branches)
+        foreach (var branch in status.Branches)
         {
-            var branchDetail = status.Branches[branch];
-            if (branchDetail.PullRequest is not null)
+            if (branch.PullRequest is not null)
             {
-                pullRequestsInStack.Add(branchDetail.PullRequest);
+                pullRequestsInStack.Add(branch.PullRequest);
             }
         }
 

--- a/src/Stack/Commands/Remote/SyncStackCommand.cs
+++ b/src/Stack/Commands/Remote/SyncStackCommand.cs
@@ -97,7 +97,7 @@ public class SyncStackCommandHandler(
 
         FetchChanges();
 
-        var status = StackHelpers.GetStackStatus(
+        var status = StackHelpers.GetStackStatusNew(
             stack,
             currentBranch,
             logger,
@@ -105,7 +105,7 @@ public class SyncStackCommandHandler(
             gitHubClient,
             true);
 
-        StackHelpers.OutputStackStatus(stack, status, logger);
+        StackHelpers.OutputStackStatus(status, logger);
 
         logger.NewLine();
 

--- a/src/Stack/Commands/Remote/SyncStackCommand.cs
+++ b/src/Stack/Commands/Remote/SyncStackCommand.cs
@@ -97,7 +97,7 @@ public class SyncStackCommandHandler(
 
         FetchChanges();
 
-        var status = StackHelpers.GetStackStatusNew(
+        var status = StackHelpers.GetStackStatus(
             stack,
             currentBranch,
             logger,

--- a/src/Stack/Commands/Stack/StackStatusCommand.cs
+++ b/src/Stack/Commands/Stack/StackStatusCommand.cs
@@ -7,209 +7,208 @@ using Stack.Config;
 using Stack.Git;
 using Stack.Infrastructure;
 
-namespace Stack.Commands
+namespace Stack.Commands;
+
+public class StackStatusCommandSettings : CommandWithOutputSettingsBase
 {
-    public class StackStatusCommandSettings : CommandWithOutputSettingsBase
+    [Description("The name of the stack to show the status of.")]
+    [CommandOption("-s|--stack")]
+    public string? Stack { get; init; }
+
+    [Description("Show status of all stacks.")]
+    [CommandOption("--all")]
+    public bool All { get; init; }
+
+    [Description("Show full status including pull requests.")]
+    [CommandOption("--full")]
+    public bool Full { get; init; }
+}
+
+public record StackStatusCommandJsonOutput
+(
+    string Name,
+    StackStatusCommandJsonOutputBranch SourceBranch,
+    List<StackStatusCommandJsonOutputBranchDetail> Branches
+);
+
+public record StackStatusCommandJsonOutputBranch
+(
+    string Name,
+    bool Exists,
+    StackStatusCommandJsonOutputCommit? Tip,
+    StackStatusCommandJsonOutputRemoteTrackingBranchStatus? RemoteTrackingBranch
+);
+
+public record StackStatusCommandJsonOutputBranchDetail
+(
+    string Name,
+    bool Exists,
+    StackStatusCommandJsonOutputCommit? Tip,
+    StackStatusCommandJsonOutputRemoteTrackingBranchStatus? RemoteTrackingBranch,
+    StackStatusCommandJsonOutputGitHubPullRequest? PullRequest,
+    StackStatusCommandJsonOutputParentBranchStatus? Parent
+) : StackStatusCommandJsonOutputBranch(Name, Exists, Tip, RemoteTrackingBranch);
+
+public record StackStatusCommandJsonOutputRemoteTrackingBranchStatus
+(
+    string Name,
+    bool Exists,
+    int Ahead,
+    int Behind
+);
+
+public record StackStatusCommandJsonOutputCommit
+(
+    string Sha,
+    string Message
+);
+
+public record StackStatusCommandJsonOutputGitHubPullRequest
+(
+    int Number,
+    string Title,
+    string State,
+    Uri Url,
+    bool IsDraft
+);
+
+public record StackStatusCommandJsonOutputParentBranchStatus
+(
+    StackStatusCommandJsonOutputBranch Branch,
+    int Ahead,
+    int Behind
+);
+
+public class StackStatusCommand : CommandWithOutput<StackStatusCommandSettings, StackStatusCommandResponse>
+{
+    protected override async Task<StackStatusCommandResponse> Execute(StackStatusCommandSettings settings)
     {
-        [Description("The name of the stack to show the status of.")]
-        [CommandOption("-s|--stack")]
-        public string? Stack { get; init; }
+        var handler = new StackStatusCommandHandler(
+            InputProvider,
+            StdErrLogger,
+            new GitClient(StdErrLogger, settings.GetGitClientSettings()),
+            new GitHubClient(StdErrLogger, settings.GetGitHubClientSettings()),
+            new StackConfig());
 
-        [Description("Show status of all stacks.")]
-        [CommandOption("--all")]
-        public bool All { get; init; }
-
-        [Description("Show full status including pull requests.")]
-        [CommandOption("--full")]
-        public bool Full { get; init; }
+        return await handler.Handle(new StackStatusCommandInputs(settings.Stack, settings.All, settings.Full));
     }
 
-    public record StackStatusCommandJsonOutput
-    (
-        string Name,
-        StackStatusCommandJsonOutputBranch SourceBranch,
-        List<StackStatusCommandJsonOutputBranchDetail> Branches
-    );
-
-    public record StackStatusCommandJsonOutputBranch
-    (
-        string Name,
-        bool Exists,
-        StackStatusCommandJsonOutputCommit? Tip,
-        StackStatusCommandJsonOutputRemoteTrackingBranchStatus? RemoteTrackingBranch
-    );
-
-    public record StackStatusCommandJsonOutputBranchDetail
-    (
-        string Name,
-        bool Exists,
-        StackStatusCommandJsonOutputCommit? Tip,
-        StackStatusCommandJsonOutputRemoteTrackingBranchStatus? RemoteTrackingBranch,
-        StackStatusCommandJsonOutputGitHubPullRequest? PullRequest,
-        StackStatusCommandJsonOutputParentBranchStatus? Parent
-    ) : StackStatusCommandJsonOutputBranch(Name, Exists, Tip, RemoteTrackingBranch);
-
-    public record StackStatusCommandJsonOutputRemoteTrackingBranchStatus
-    (
-        string Name,
-        bool Exists,
-        int Ahead,
-        int Behind
-    );
-
-    public record StackStatusCommandJsonOutputCommit
-    (
-        string Sha,
-        string Message
-    );
-
-    public record StackStatusCommandJsonOutputGitHubPullRequest
-    (
-        int Number,
-        string Title,
-        string State,
-        Uri Url,
-        bool IsDraft
-    );
-
-    public record StackStatusCommandJsonOutputParentBranchStatus
-    (
-        StackStatusCommandJsonOutputBranch Branch,
-        int Ahead,
-        int Behind
-    );
-
-    public class StackStatusCommand : CommandWithOutput<StackStatusCommandSettings, StackStatusCommandResponse>
+    protected override void WriteDefaultOutput(StackStatusCommandResponse response)
     {
-        protected override async Task<StackStatusCommandResponse> Execute(StackStatusCommandSettings settings)
+        StackHelpers.OutputStackStatus(response.Stacks, StdOutLogger);
+
+        if (response.Stacks.Count == 1)
         {
-            var handler = new StackStatusCommandHandler(
-                InputProvider,
-                StdErrLogger,
-                new GitClient(StdErrLogger, settings.GetGitClientSettings()),
-                new GitHubClient(StdErrLogger, settings.GetGitHubClientSettings()),
-                new StackConfig());
-
-            return await handler.Handle(new StackStatusCommandInputs(settings.Stack, settings.All, settings.Full));
-        }
-
-        protected override void WriteDefaultOutput(StackStatusCommandResponse response)
-        {
-            StackHelpers.OutputStackStatus(response.Stacks, StdOutLogger);
-
-            if (response.Stacks.Count == 1)
-            {
-                var stack = response.Stacks.First();
-                StackHelpers.OutputBranchAndStackActions(stack, StdOutLogger);
-            }
-        }
-
-        protected override void WriteJsonOutput(StackStatusCommandResponse response, JsonSerializerOptions options)
-        {
-            var output = response.Stacks.Select(MapToJsonOutput).ToList();
-            var json = JsonSerializer.Serialize(output, options);
-            StdOut.WriteLine(json);
-        }
-
-        private static StackStatusCommandJsonOutput MapToJsonOutput(StackStatus stack)
-        {
-            return new StackStatusCommandJsonOutput(
-                stack.Name,
-                MapBranch(stack.SourceBranch),
-                stack.Branches.Select(MapBranchDetail).ToList()
-            );
-        }
-
-        private static StackStatusCommandJsonOutputBranch MapBranch(Branch branch)
-        {
-            return new StackStatusCommandJsonOutputBranch(
-                branch.Name,
-                branch.Exists,
-                branch.Tip is null ? null : new StackStatusCommandJsonOutputCommit(branch.Tip.Sha, branch.Tip.Message),
-                branch.RemoteTrackingBranch is null ? null : new StackStatusCommandJsonOutputRemoteTrackingBranchStatus(
-                    branch.RemoteTrackingBranch.Name,
-                    branch.RemoteTrackingBranch.Exists,
-                    branch.RemoteTrackingBranch.Ahead,
-                    branch.RemoteTrackingBranch.Behind
-                )
-            );
-        }
-
-        private static StackStatusCommandJsonOutputBranchDetail MapBranchDetail(BranchDetail branch)
-        {
-            return new StackStatusCommandJsonOutputBranchDetail(
-                branch.Name,
-                branch.Exists,
-                branch.Tip is null ? null : new StackStatusCommandJsonOutputCommit(branch.Tip.Sha, branch.Tip.Message),
-                branch.RemoteTrackingBranch is null ? null : new StackStatusCommandJsonOutputRemoteTrackingBranchStatus(
-                    branch.RemoteTrackingBranch.Name,
-                    branch.RemoteTrackingBranch.Exists,
-                    branch.RemoteTrackingBranch.Ahead,
-                    branch.RemoteTrackingBranch.Behind
-                ),
-                branch.PullRequest is null ? null : new StackStatusCommandJsonOutputGitHubPullRequest(
-                    branch.PullRequest.Number,
-                    branch.PullRequest.Title,
-                    branch.PullRequest.State,
-                    branch.PullRequest.Url,
-                    branch.PullRequest.IsDraft
-                ),
-                branch.Parent is null ? null : new StackStatusCommandJsonOutputParentBranchStatus(
-                    MapBranch(branch.Parent.Branch),
-                    branch.Parent.Ahead,
-                    branch.Parent.Behind
-                )
-            );
+            var stack = response.Stacks.First();
+            StackHelpers.OutputBranchAndStackActions(stack, StdOutLogger);
         }
     }
 
-    public record StackStatusCommandInputs(string? Stack, bool All, bool Full);
-    public record StackStatusCommandResponse(List<StackStatus> Stacks);
-
-    public class StackStatusCommandHandler(
-        IInputProvider inputProvider,
-        ILogger logger,
-        IGitClient gitClient,
-        IGitHubClient gitHubClient,
-        IStackConfig stackConfig)
-        : CommandHandlerBase<StackStatusCommandInputs, StackStatusCommandResponse>
+    protected override void WriteJsonOutput(StackStatusCommandResponse response, JsonSerializerOptions options)
     {
-        public override async Task<StackStatusCommandResponse> Handle(StackStatusCommandInputs inputs)
+        var output = response.Stacks.Select(MapToJsonOutput).ToList();
+        var json = JsonSerializer.Serialize(output, options);
+        StdOut.WriteLine(json);
+    }
+
+    private static StackStatusCommandJsonOutput MapToJsonOutput(StackStatus stack)
+    {
+        return new StackStatusCommandJsonOutput(
+            stack.Name,
+            MapBranch(stack.SourceBranch),
+            stack.Branches.Select(MapBranchDetail).ToList()
+        );
+    }
+
+    private static StackStatusCommandJsonOutputBranch MapBranch(Branch branch)
+    {
+        return new StackStatusCommandJsonOutputBranch(
+            branch.Name,
+            branch.Exists,
+            branch.Tip is null ? null : new StackStatusCommandJsonOutputCommit(branch.Tip.Sha, branch.Tip.Message),
+            branch.RemoteTrackingBranch is null ? null : new StackStatusCommandJsonOutputRemoteTrackingBranchStatus(
+                branch.RemoteTrackingBranch.Name,
+                branch.RemoteTrackingBranch.Exists,
+                branch.RemoteTrackingBranch.Ahead,
+                branch.RemoteTrackingBranch.Behind
+            )
+        );
+    }
+
+    private static StackStatusCommandJsonOutputBranchDetail MapBranchDetail(BranchDetail branch)
+    {
+        return new StackStatusCommandJsonOutputBranchDetail(
+            branch.Name,
+            branch.Exists,
+            branch.Tip is null ? null : new StackStatusCommandJsonOutputCommit(branch.Tip.Sha, branch.Tip.Message),
+            branch.RemoteTrackingBranch is null ? null : new StackStatusCommandJsonOutputRemoteTrackingBranchStatus(
+                branch.RemoteTrackingBranch.Name,
+                branch.RemoteTrackingBranch.Exists,
+                branch.RemoteTrackingBranch.Ahead,
+                branch.RemoteTrackingBranch.Behind
+            ),
+            branch.PullRequest is null ? null : new StackStatusCommandJsonOutputGitHubPullRequest(
+                branch.PullRequest.Number,
+                branch.PullRequest.Title,
+                branch.PullRequest.State,
+                branch.PullRequest.Url,
+                branch.PullRequest.IsDraft
+            ),
+            branch.Parent is null ? null : new StackStatusCommandJsonOutputParentBranchStatus(
+                MapBranch(branch.Parent.Branch),
+                branch.Parent.Ahead,
+                branch.Parent.Behind
+            )
+        );
+    }
+}
+
+public record StackStatusCommandInputs(string? Stack, bool All, bool Full);
+public record StackStatusCommandResponse(List<StackStatus> Stacks);
+
+public class StackStatusCommandHandler(
+    IInputProvider inputProvider,
+    ILogger logger,
+    IGitClient gitClient,
+    IGitHubClient gitHubClient,
+    IStackConfig stackConfig)
+    : CommandHandlerBase<StackStatusCommandInputs, StackStatusCommandResponse>
+{
+    public override async Task<StackStatusCommandResponse> Handle(StackStatusCommandInputs inputs)
+    {
+        await Task.CompletedTask;
+        var stacks = stackConfig.Load();
+
+        var remoteUri = gitClient.GetRemoteUri();
+        var stacksForRemote = stacks.Where(s => s.RemoteUri.Equals(remoteUri, StringComparison.OrdinalIgnoreCase)).ToList();
+        var currentBranch = gitClient.GetCurrentBranch();
+
+        var stacksToCheckStatusFor = new List<Config.Stack>();
+
+        if (inputs.All)
         {
-            await Task.CompletedTask;
-            var stacks = stackConfig.Load();
-
-            var remoteUri = gitClient.GetRemoteUri();
-            var stacksForRemote = stacks.Where(s => s.RemoteUri.Equals(remoteUri, StringComparison.OrdinalIgnoreCase)).ToList();
-            var currentBranch = gitClient.GetCurrentBranch();
-
-            var stacksToCheckStatusFor = new List<Config.Stack>();
-
-            if (inputs.All)
-            {
-                stacksToCheckStatusFor.AddRange(stacksForRemote);
-            }
-            else
-            {
-                var stack = inputProvider.SelectStack(logger, inputs.Stack, stacksForRemote, currentBranch);
-
-                if (stack is null)
-                {
-                    throw new InvalidOperationException($"Stack '{inputs.Stack}' not found.");
-                }
-
-                stacksToCheckStatusFor.Add(stack);
-            }
-
-            var stackStatusResults = StackHelpers.GetStackStatus(
-                stacksToCheckStatusFor,
-                currentBranch,
-                logger,
-                gitClient,
-                gitHubClient,
-                inputs.Full);
-
-            return new StackStatusCommandResponse(stackStatusResults);
+            stacksToCheckStatusFor.AddRange(stacksForRemote);
         }
+        else
+        {
+            var stack = inputProvider.SelectStack(logger, inputs.Stack, stacksForRemote, currentBranch);
+
+            if (stack is null)
+            {
+                throw new InvalidOperationException($"Stack '{inputs.Stack}' not found.");
+            }
+
+            stacksToCheckStatusFor.Add(stack);
+        }
+
+        var stackStatusResults = StackHelpers.GetStackStatus(
+            stacksToCheckStatusFor,
+            currentBranch,
+            logger,
+            gitClient,
+            gitHubClient,
+            inputs.Full);
+
+        return new StackStatusCommandResponse(stackStatusResults);
     }
 }

--- a/src/Stack/Commands/Stack/StackStatusCommand.cs
+++ b/src/Stack/Commands/Stack/StackStatusCommand.cs
@@ -2,107 +2,214 @@ using System.ComponentModel;
 using System.Text.Json;
 using Spectre.Console;
 using Spectre.Console.Cli;
-using Stack.Commands;
 using Stack.Commands.Helpers;
 using Stack.Config;
 using Stack.Git;
 using Stack.Infrastructure;
 
-namespace Stack.Commands;
-
-public class StackStatusCommandSettings : CommandWithOutputSettingsBase
+namespace Stack.Commands
 {
-    [Description("The name of the stack to show the status of.")]
-    [CommandOption("-s|--stack")]
-    public string? Stack { get; init; }
-
-    [Description("Show status of all stacks.")]
-    [CommandOption("--all")]
-    public bool All { get; init; }
-
-    [Description("Show full status including pull requests.")]
-    [CommandOption("--full")]
-    public bool Full { get; init; }
-}
-
-public class StackStatusCommand : CommandWithOutput<StackStatusCommandSettings, StackStatusCommandResponse>
-{
-    protected override async Task<StackStatusCommandResponse> Execute(StackStatusCommandSettings settings)
+    public class StackStatusCommandSettings : CommandWithOutputSettingsBase
     {
-        var handler = new StackStatusCommandHandler(
-            InputProvider,
-            StdErrLogger,
-            new GitClient(StdErrLogger, settings.GetGitClientSettings()),
-            new GitHubClient(StdErrLogger, settings.GetGitHubClientSettings()),
-            new StackConfig());
+        [Description("The name of the stack to show the status of.")]
+        [CommandOption("-s|--stack")]
+        public string? Stack { get; init; }
 
-        return await handler.Handle(new StackStatusCommandInputs(settings.Stack, settings.All, settings.Full));
+        [Description("Show status of all stacks.")]
+        [CommandOption("--all")]
+        public bool All { get; init; }
+
+        [Description("Show full status including pull requests.")]
+        [CommandOption("--full")]
+        public bool Full { get; init; }
     }
 
-    protected override void WriteDefaultOutput(StackStatusCommandResponse response)
-    {
-        StackHelpers.OutputStackStatus(response.Stacks, StdOutLogger);
+    public record StackStatusCommandJsonOutput
+    (
+        string Name,
+        StackStatusCommandJsonOutputBranch SourceBranch,
+        List<StackStatusCommandJsonOutputBranchDetail> Branches
+    );
 
-        if (response.Stacks.Count == 1)
+    public record StackStatusCommandJsonOutputBranch
+    (
+        string Name,
+        bool Exists,
+        StackStatusCommandJsonOutputCommit? Tip,
+        StackStatusCommandJsonOutputRemoteTrackingBranchStatus? RemoteTrackingBranch
+    );
+
+    public record StackStatusCommandJsonOutputBranchDetail
+    (
+        string Name,
+        bool Exists,
+        StackStatusCommandJsonOutputCommit? Tip,
+        StackStatusCommandJsonOutputRemoteTrackingBranchStatus? RemoteTrackingBranch,
+        StackStatusCommandJsonOutputGitHubPullRequest? PullRequest,
+        StackStatusCommandJsonOutputParentBranchStatus? Parent
+    ) : StackStatusCommandJsonOutputBranch(Name, Exists, Tip, RemoteTrackingBranch);
+
+    public record StackStatusCommandJsonOutputRemoteTrackingBranchStatus
+    (
+        string Name,
+        bool Exists,
+        int Ahead,
+        int Behind
+    );
+
+    public record StackStatusCommandJsonOutputCommit
+    (
+        string Sha,
+        string Message
+    );
+
+    public record StackStatusCommandJsonOutputGitHubPullRequest
+    (
+        int Number,
+        string Title,
+        string State,
+        Uri Url,
+        bool IsDraft
+    );
+
+    public record StackStatusCommandJsonOutputParentBranchStatus
+    (
+        StackStatusCommandJsonOutputBranch Branch,
+        int Ahead,
+        int Behind
+    );
+
+    public class StackStatusCommand : CommandWithOutput<StackStatusCommandSettings, StackStatusCommandResponse>
+    {
+        protected override async Task<StackStatusCommandResponse> Execute(StackStatusCommandSettings settings)
         {
-            var stack = response.Stacks.First();
-            StackHelpers.OutputBranchAndStackActions(stack, StdOutLogger);
+            var handler = new StackStatusCommandHandler(
+                InputProvider,
+                StdErrLogger,
+                new GitClient(StdErrLogger, settings.GetGitClientSettings()),
+                new GitHubClient(StdErrLogger, settings.GetGitHubClientSettings()),
+                new StackConfig());
+
+            return await handler.Handle(new StackStatusCommandInputs(settings.Stack, settings.All, settings.Full));
         }
-    }
 
-    protected override void WriteJsonOutput(StackStatusCommandResponse response, JsonSerializerOptions options)
-    {
-        var json = JsonSerializer.Serialize(response.Stacks, options);
-        StdOut.WriteLine(json);
-    }
-}
-
-public record StackStatusCommandInputs(string? Stack, bool All, bool Full);
-public record StackStatusCommandResponse(List<StackStatus> Stacks);
-
-public class StackStatusCommandHandler(
-    IInputProvider inputProvider,
-    ILogger logger,
-    IGitClient gitClient,
-    IGitHubClient gitHubClient,
-    IStackConfig stackConfig)
-    : CommandHandlerBase<StackStatusCommandInputs, StackStatusCommandResponse>
-{
-    public override async Task<StackStatusCommandResponse> Handle(StackStatusCommandInputs inputs)
-    {
-        await Task.CompletedTask;
-        var stacks = stackConfig.Load();
-
-        var remoteUri = gitClient.GetRemoteUri();
-        var stacksForRemote = stacks.Where(s => s.RemoteUri.Equals(remoteUri, StringComparison.OrdinalIgnoreCase)).ToList();
-        var currentBranch = gitClient.GetCurrentBranch();
-
-        var stacksToCheckStatusFor = new List<Config.Stack>();
-
-        if (inputs.All)
+        protected override void WriteDefaultOutput(StackStatusCommandResponse response)
         {
-            stacksToCheckStatusFor.AddRange(stacksForRemote);
-        }
-        else
-        {
-            var stack = inputProvider.SelectStack(logger, inputs.Stack, stacksForRemote, currentBranch);
+            StackHelpers.OutputStackStatus(response.Stacks, StdOutLogger);
 
-            if (stack is null)
+            if (response.Stacks.Count == 1)
             {
-                throw new InvalidOperationException($"Stack '{inputs.Stack}' not found.");
+                var stack = response.Stacks.First();
+                StackHelpers.OutputBranchAndStackActions(stack, StdOutLogger);
+            }
+        }
+
+        protected override void WriteJsonOutput(StackStatusCommandResponse response, JsonSerializerOptions options)
+        {
+            var output = response.Stacks.Select(MapToJsonOutput).ToList();
+            var json = JsonSerializer.Serialize(output, options);
+            StdOut.WriteLine(json);
+        }
+
+        private static StackStatusCommandJsonOutput MapToJsonOutput(StackStatus stack)
+        {
+            return new StackStatusCommandJsonOutput(
+                stack.Name,
+                MapBranch(stack.SourceBranch),
+                stack.Branches.Select(MapBranchDetail).ToList()
+            );
+        }
+
+        private static StackStatusCommandJsonOutputBranch MapBranch(Branch branch)
+        {
+            return new StackStatusCommandJsonOutputBranch(
+                branch.Name,
+                branch.Exists,
+                branch.Tip is null ? null : new StackStatusCommandJsonOutputCommit(branch.Tip.Sha, branch.Tip.Message),
+                branch.RemoteTrackingBranch is null ? null : new StackStatusCommandJsonOutputRemoteTrackingBranchStatus(
+                    branch.RemoteTrackingBranch.Name,
+                    branch.RemoteTrackingBranch.Exists,
+                    branch.RemoteTrackingBranch.Ahead,
+                    branch.RemoteTrackingBranch.Behind
+                )
+            );
+        }
+
+        private static StackStatusCommandJsonOutputBranchDetail MapBranchDetail(BranchDetail branch)
+        {
+            return new StackStatusCommandJsonOutputBranchDetail(
+                branch.Name,
+                branch.Exists,
+                branch.Tip is null ? null : new StackStatusCommandJsonOutputCommit(branch.Tip.Sha, branch.Tip.Message),
+                branch.RemoteTrackingBranch is null ? null : new StackStatusCommandJsonOutputRemoteTrackingBranchStatus(
+                    branch.RemoteTrackingBranch.Name,
+                    branch.RemoteTrackingBranch.Exists,
+                    branch.RemoteTrackingBranch.Ahead,
+                    branch.RemoteTrackingBranch.Behind
+                ),
+                branch.PullRequest is null ? null : new StackStatusCommandJsonOutputGitHubPullRequest(
+                    branch.PullRequest.Number,
+                    branch.PullRequest.Title,
+                    branch.PullRequest.State,
+                    branch.PullRequest.Url,
+                    branch.PullRequest.IsDraft
+                ),
+                branch.Parent is null ? null : new StackStatusCommandJsonOutputParentBranchStatus(
+                    MapBranch(branch.Parent.Branch),
+                    branch.Parent.Ahead,
+                    branch.Parent.Behind
+                )
+            );
+        }
+    }
+
+    public record StackStatusCommandInputs(string? Stack, bool All, bool Full);
+    public record StackStatusCommandResponse(List<StackStatus> Stacks);
+
+    public class StackStatusCommandHandler(
+        IInputProvider inputProvider,
+        ILogger logger,
+        IGitClient gitClient,
+        IGitHubClient gitHubClient,
+        IStackConfig stackConfig)
+        : CommandHandlerBase<StackStatusCommandInputs, StackStatusCommandResponse>
+    {
+        public override async Task<StackStatusCommandResponse> Handle(StackStatusCommandInputs inputs)
+        {
+            await Task.CompletedTask;
+            var stacks = stackConfig.Load();
+
+            var remoteUri = gitClient.GetRemoteUri();
+            var stacksForRemote = stacks.Where(s => s.RemoteUri.Equals(remoteUri, StringComparison.OrdinalIgnoreCase)).ToList();
+            var currentBranch = gitClient.GetCurrentBranch();
+
+            var stacksToCheckStatusFor = new List<Config.Stack>();
+
+            if (inputs.All)
+            {
+                stacksToCheckStatusFor.AddRange(stacksForRemote);
+            }
+            else
+            {
+                var stack = inputProvider.SelectStack(logger, inputs.Stack, stacksForRemote, currentBranch);
+
+                if (stack is null)
+                {
+                    throw new InvalidOperationException($"Stack '{inputs.Stack}' not found.");
+                }
+
+                stacksToCheckStatusFor.Add(stack);
             }
 
-            stacksToCheckStatusFor.Add(stack);
+            var stackStatusResults = StackHelpers.GetStackStatus(
+                stacksToCheckStatusFor,
+                currentBranch,
+                logger,
+                gitClient,
+                gitHubClient,
+                inputs.Full);
+
+            return new StackStatusCommandResponse(stackStatusResults);
         }
-
-        var stackStatusResults = StackHelpers.GetStackStatus(
-            stacksToCheckStatusFor,
-            currentBranch,
-            logger,
-            gitClient,
-            gitHubClient,
-            inputs.Full);
-
-        return new StackStatusCommandResponse(stackStatusResults);
     }
 }

--- a/src/Stack/Commands/Stack/StackStatusCommand.cs
+++ b/src/Stack/Commands/Stack/StackStatusCommand.cs
@@ -95,7 +95,7 @@ public class StackStatusCommandHandler(
             stacksToCheckStatusFor.Add(stack);
         }
 
-        var stackStatusResults = StackHelpers.GetStackStatusNew(
+        var stackStatusResults = StackHelpers.GetStackStatus(
             stacksToCheckStatusFor,
             currentBranch,
             logger,

--- a/src/Stack/Commands/Stack/UpdateStackCommand.cs
+++ b/src/Stack/Commands/Stack/UpdateStackCommand.cs
@@ -78,7 +78,7 @@ public class UpdateStackCommandHandler(
         if (stack is null)
             throw new InvalidOperationException($"Stack '{inputs.Stack}' not found.");
 
-        var status = StackHelpers.GetStackStatus(
+        var status = StackHelpers.GetStackStatusNew(
             stack,
             currentBranch,
             logger,

--- a/src/Stack/Commands/Stack/UpdateStackCommand.cs
+++ b/src/Stack/Commands/Stack/UpdateStackCommand.cs
@@ -78,7 +78,7 @@ public class UpdateStackCommandHandler(
         if (stack is null)
             throw new InvalidOperationException($"Stack '{inputs.Stack}' not found.");
 
-        var status = StackHelpers.GetStackStatusNew(
+        var status = StackHelpers.GetStackStatus(
             stack,
             currentBranch,
             logger,


### PR DESCRIPTION
Refactors the types in getting the status of a stack to better match the ones used in the status command as these are a bit clearer and start to pave the way for having a proper tree structure.

Small change to the json output for the status command too, don't return the body now as that feels unnecessary.