### PR TITLE
Remove `Humanizer`

### DIFF
--- a/src/Stack/Commands/Branch/RemoveBranchCommand.cs
+++ b/src/Stack/Commands/Branch/RemoveBranchCommand.cs
@@ -1,6 +1,5 @@
 using System.CommandLine;
 using System.ComponentModel;
-using Humanizer;
 using Stack.Commands.Helpers;
 using Stack.Config;
 using Stack.Git;

--- a/src/Stack/Commands/Helpers/HumanizeEnumExtensionMethods.cs
+++ b/src/Stack/Commands/Helpers/HumanizeEnumExtensionMethods.cs
@@ -1,0 +1,27 @@
+namespace Stack.Commands;
+
+public static class HumanizeEnumExtensionMethods
+{
+    public static string Humanize(this BranchAction action)
+    {
+        return action switch
+        {
+            BranchAction.Add => "Add an existing branch",
+            BranchAction.Create => "Create a new branch",
+            BranchAction.None => "Do not add or create a branch",
+            _ => throw new ArgumentOutOfRangeException(nameof(action))
+        };
+    }
+
+    public static string Humanize(this RemoveBranchChildAction action)
+    {
+        return action switch
+        {
+            RemoveBranchChildAction.RemoveChildren => "Remove children branches",
+            RemoveBranchChildAction.MoveChildrenToParent => "Move children branches to parent branch",
+            _ => throw new ArgumentOutOfRangeException(nameof(action)),
+        };
+    }
+}
+
+

--- a/src/Stack/Commands/Helpers/Questions.cs
+++ b/src/Stack/Commands/Helpers/Questions.cs
@@ -1,6 +1,3 @@
-using Humanizer;
-using Stack.Infrastructure;
-
 namespace Stack.Commands.Helpers;
 
 public static class Questions

--- a/src/Stack/Commands/Stack/ListStacksCommand.cs
+++ b/src/Stack/Commands/Stack/ListStacksCommand.cs
@@ -1,7 +1,6 @@
 using System.CommandLine;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Humanizer;
 using Spectre.Console;
 using Stack.Config;
 using Stack.Git;
@@ -41,7 +40,7 @@ public class ListStacksCommand : CommandWithOutput<ListStacksCommandResponse>
 
         foreach (var stack in response.Stacks)
         {
-            StdOutLogger.Information($"{stack.Name.Stack()} {$"({stack.SourceBranch})".Muted()} {"branch".ToQuantity(stack.BranchCount)}");
+            StdOutLogger.Information($"{stack.Name.Stack()} {$"({stack.SourceBranch})".Muted()} {stack.BranchCount} {(stack.BranchCount == 1 ? "branch" : "branches")}");
         }
     }
 

--- a/src/Stack/Commands/Stack/NewStackCommand.cs
+++ b/src/Stack/Commands/Stack/NewStackCommand.cs
@@ -2,7 +2,6 @@
 
 using System.CommandLine;
 using System.ComponentModel;
-using Humanizer;
 using Spectre.Console;
 using Stack.Commands.Helpers;
 using Stack.Config;

--- a/src/Stack/Config/Stack.cs
+++ b/src/Stack/Config/Stack.cs
@@ -1,5 +1,5 @@
-using Humanizer;
 using Stack.Commands;
+using System.Text.RegularExpressions;
 
 namespace Stack.Config;
 
@@ -44,7 +44,28 @@ public record Stack(string Name, string RemoteUri, string SourceBranch, List<Bra
     public string GetDefaultBranchName()
     {
         var fullBranchNames = Branches.SelectMany(b => b.AllBranchNames).Distinct().ToList();
-        return $"{Name.Kebaberize()}-{fullBranchNames.Count + 1}";
+        return $"{SanitizeBranchName(Name)}-{fullBranchNames.Count + 1}";
+    }
+
+    static string SanitizeBranchName(string name)
+    {
+        // Replace invalid characters (including spaces and special chars) with '-'
+        var sanitized = Regex.Replace(name, "[\\s~^:?*\\[\\\\@{{}}]+|[" + Regex.Escape(new string(Path.GetInvalidFileNameChars())) + "]", "-");
+
+        // Remove consecutive dashes
+        sanitized = Regex.Replace(sanitized, "-+", "-");
+
+        // Trim leading/trailing dashes and dots
+        sanitized = sanitized.Trim('-', '.');
+
+        // Git branch names cannot start with a slash, dot, or end with a dot or slash
+        sanitized = sanitized.TrimStart('/', '.').TrimEnd('/', '.');
+
+        // Avoid reserved names
+        if (sanitized.Equals("HEAD", StringComparison.OrdinalIgnoreCase))
+            sanitized = "branch-" + sanitized;
+
+        return sanitized.ToLower();
     }
 
     public void RemoveBranch(string branchName, RemoveBranchChildAction action)

--- a/src/Stack/Stack.csproj
+++ b/src/Stack/Stack.csproj
@@ -13,7 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Humanizer.Core" Version="3.0.0-beta.96" />
     <PackageReference Include="morelinq" Version="4.4.0" />
     <PackageReference Include="Spectre.Console" Version="0.50.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta5.25306.1" />


### PR DESCRIPTION
<!-- stack-pr-list -->
This PR is part of a series that allow enabling AOT:

- https://github.com/geofflamrock/stack/pull/276
- https://github.com/geofflamrock/stack/pull/285
- https://github.com/geofflamrock/stack/pull/280
- https://github.com/geofflamrock/stack/pull/284
- https://github.com/geofflamrock/stack/pull/286
- https://github.com/geofflamrock/stack/pull/287
- https://github.com/geofflamrock/stack/pull/288
- https://github.com/geofflamrock/stack/pull/290
<!-- /stack-pr-list -->

This PR removes `Humanizer`, it's a really useful library but the `.Humanize()` extension methods don't work with AOT, so have replaced them and other usages with direct code. Most of the other usages are pretty simple, the only one is the default branch name which I got GitHub Copilot to write me a reasonable replacement to sanitize branch names. It's also likely to go away in the future.

Fixes #281 