### PR TITLE
Remove editing PR body as part of creation

### DIFF
--- a/src/Stack/Commands/Helpers/Questions.cs
+++ b/src/Stack/Commands/Helpers/Questions.cs
@@ -20,7 +20,6 @@ public static class Questions
     public const string PullRequestStackDescription = "Stack description for pull request:";
     public const string OpenPullRequests = "Open new pull requests in a browser?";
     public const string CreatePullRequestAsDraft = "Create pull request as draft?";
-    public const string EditPullRequestBody = "Edit pull request body? This will open a file in your default editor.";
     public const string ContinueOrAbortMerge = "Conflict(s) detected during merge. Please either resolve the conflicts, commit the result and select Continue to continue merging, or Abort.";
     public const string ContinueOrAbortRebase = "Conflict(s) detected during rebase. Please either resolve the conflicts and select Continue to continue rebasing, or Abort.";
     public const string ConfirmMigrateConfig = "Are you sure you want to migrate the configuration file to the latest version? This will create a backup of the current configuration file.";

--- a/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
+++ b/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
@@ -123,7 +123,6 @@ public class CreatePullRequestsCommandHandler(
                 inputProvider,
                 logger,
                 gitClient,
-                gitHubClient,
                 fileOperations,
                 selectedPullRequestActions);
 
@@ -235,7 +234,6 @@ public class CreatePullRequestsCommandHandler(
         IInputProvider inputProvider,
         ILogger logger,
         IGitClient gitClient,
-        IGitHubClient gitHubClient,
         IFileOperations fileOperations,
         List<PullRequestCreateAction> pullRequestCreateActions)
     {
@@ -271,11 +269,6 @@ public class CreatePullRequestsCommandHandler(
 {StackConstants.StackMarkerDescription}
 
 {StackConstants.StackMarkerEnd}");
-
-            if (inputProvider.Confirm(Questions.EditPullRequestBody))
-            {
-                gitClient.OpenFileInEditorAndWaitForClose(bodyFilePath);
-            }
 
             var draft = inputProvider.Confirm(Questions.CreatePullRequestAsDraft, false);
 

--- a/src/Stack/Git/GitClient.cs
+++ b/src/Stack/Git/GitClient.cs
@@ -46,7 +46,6 @@ public interface IGitClient
     string GetRemoteUri();
     string[] GetLocalBranchesOrderedByMostRecentCommitterDate();
     string GetRootOfRepository();
-    void OpenFileInEditorAndWaitForClose(string path);
     string? GetConfigValue(string key);
     bool IsAncestor(string ancestor, string descendant);
 }
@@ -293,38 +292,6 @@ public class GitClient(ILogger logger, GitClientSettings settings) : IGitClient
         });
 
         return isAncestor;
-    }
-
-    public void OpenFileInEditorAndWaitForClose(string path)
-    {
-        var editor = GetConfiguredEditor();
-        if (string.IsNullOrWhiteSpace(editor))
-        {
-            logger.Error("No editor is configured in git. Please configure an editor using 'git config --global core.editor <editor>'.");
-            return;
-        }
-
-        var editorSplit = editor.Split(' ');
-        var editorFileName = editorSplit[0];
-        var editorArguments = editorSplit.Length > 1 ? string.Join(' ', editorSplit.Skip(1)) : string.Empty;
-
-        var processStartInfo = new ProcessStartInfo
-        {
-            FileName = editorFileName,
-            Arguments = $"\"{path}\" {editorArguments}",
-            UseShellExecute = true,
-            CreateNoWindow = true
-        };
-
-        var process = Process.Start(processStartInfo);
-
-        if (process == null)
-        {
-            logger.Error("Failed to start editor process.");
-            return;
-        }
-
-        process.WaitForExit();
     }
 
     private string ExecuteGitCommandAndReturnOutput(


### PR DESCRIPTION
Currently we support editing the body of a new PR in the default editor as part of creation. I've found that I don't use this at all and it just gets in the way, so am removing it. PRs will now just put the list at the top of the body (and include any template) and then create, making the workflow much simpler.