### PR TITLE
Only pull changes when local branch is behind remote

### DIFF
--- a/src/Stack/Commands/Helpers/StackHelpers.cs
+++ b/src/Stack/Commands/Helpers/StackHelpers.cs
@@ -574,7 +574,11 @@ public static class StackHelpers
         List<string> allBranchesInStacks = [stack.SourceBranch, .. stack.AllBranchNames];
         var branchStatus = gitClient.GetBranchStatuses([.. allBranchesInStacks]);
 
-        foreach (var branch in allBranchesInStacks.Where(b => branchStatus.ContainsKey(b) && branchStatus[b].RemoteBranchExists))
+        foreach (var branch in allBranchesInStacks
+            .Where(b =>
+                branchStatus.ContainsKey(b) &&
+                branchStatus[b].RemoteBranchExists &&
+                branchStatus[b].Behind > 0))
         {
             logger.Information($"Pulling changes for {branch.Branch()} from remote");
             gitClient.ChangeBranch(branch);


### PR DESCRIPTION
Currently when syncing or pulling changes from the remote, we pull every branch, irrespective of if it is behind the remote branch or not. This adds extra wasted time to these actions. 

This PR changes to only pull branches that are behind the remote.

Fixes #273 