### PR TITLE
Only push changes to branches that are ahead of the remote

### DIFF
--- a/src/Stack.Tests/Commands/Helpers/StackHelpersTests.cs
+++ b/src/Stack.Tests/Commands/Helpers/StackHelpersTests.cs
@@ -434,4 +434,42 @@ public class StackHelpersTests(ITestOutputHelper testOutputHelper)
         var branch3FileContents = File.ReadAllText(Path.Join(repo.LocalDirectoryPath, changedFilePath));
         branch3FileContents.Should().Be(commit1ChangedFileContents);
     }
+
+    [Fact]
+    public void PushChanges_WhenSomeLocalBranchesAreAhead_OnlyPushesChangesForBranchesThatAreAhead()
+    {
+        // Arrange
+        var sourceBranch = Some.BranchName();
+        var branchAheadOfRemote = Some.BranchName();
+        var branchNotAheadOfRemote = Some.BranchName();
+
+        var gitClient = Substitute.For<IGitClient>();
+
+        var branchStatus = new Dictionary<string, GitBranchStatus>
+        {
+            { sourceBranch, new GitBranchStatus(sourceBranch, $"origin/{sourceBranch}", true, false, 0, 0, new Commit(Some.Sha(), Some.Name())) },
+            { branchAheadOfRemote, new GitBranchStatus(branchAheadOfRemote, $"origin/{branchAheadOfRemote}", true, false, 3, 0, new Commit(Some.Sha(), Some.Name())) },
+            { branchNotAheadOfRemote, new GitBranchStatus(branchNotAheadOfRemote, $"origin/{branchNotAheadOfRemote}", true, false, 0, 0, new Commit(Some.Sha(), Some.Name())) }
+        };
+
+        gitClient.GetBranchStatuses(Arg.Any<string[]>()).Returns(branchStatus);
+
+        var branchesPushedToRemote = new List<string>();
+
+        gitClient
+            .WhenForAnyArgs(g => g.PushBranches(Arg.Any<string[]>(), Arg.Any<bool>()))
+            .Do((c) => branchesPushedToRemote.AddRange(c.Arg<string[]>()));
+
+        var stack = new TestStackBuilder()
+            .WithSourceBranch(sourceBranch)
+            .WithBranch(b => b.WithName(branchAheadOfRemote))
+            .WithBranch(b => b.WithName(branchNotAheadOfRemote))
+            .Build();
+
+        // Act
+        StackHelpers.PushChanges(stack, 5, false, gitClient, new TestLogger(testOutputHelper));
+
+        // Assert
+        branchesPushedToRemote.ToArray().Should().BeEquivalentTo([branchAheadOfRemote]);
+    }
 }

--- a/src/Stack/Commands/Helpers/StackHelpers.cs
+++ b/src/Stack/Commands/Helpers/StackHelpers.cs
@@ -591,7 +591,10 @@ public static class StackHelpers
     {
         var branchStatus = gitClient.GetBranchStatuses([.. stack.AllBranchNames]);
 
-        var branchesThatHaveNotBeenPushedToRemote = branchStatus.Where(b => b.Value.RemoteTrackingBranchName is null).Select(b => b.Value.BranchName).ToList();
+        var branchesThatHaveNotBeenPushedToRemote = branchStatus
+            .Where(b => b.Value.RemoteTrackingBranchName is null)
+            .Select(b => b.Value.BranchName)
+            .ToList();
 
         foreach (var branch in branchesThatHaveNotBeenPushedToRemote)
         {
@@ -599,9 +602,12 @@ public static class StackHelpers
             gitClient.PushNewBranch(branch);
         }
 
-        var branchesInStackWithRemote = branchStatus.Where(b => b.Value.RemoteBranchExists).Select(b => b.Value.BranchName).ToList();
+        var branchesThatAreAheadOfTheRemote = branchStatus
+            .Where(b => b.Value.RemoteBranchExists && b.Value.Ahead > 0)
+            .Select(b => b.Value.BranchName)
+            .ToList();
 
-        var branchGroupsToPush = branchesInStackWithRemote
+        var branchGroupsToPush = branchesThatAreAheadOfTheRemote
             .Select((b, i) => new { Index = i, Value = b })
             .GroupBy(b => b.Index / maxBatchSize)
             .Select(g => g.Select(b => b.Value).ToList())


### PR DESCRIPTION
Currently when syncing or pushing changes from the remote, we push every branch, irrespective of if it is ahead of the remote branch or not. This adds extra wasted time to these actions.

This PR changes to only push branches that are ahead the remote.