### PR TITLE
Remove `--working-directory` alias

### DIFF
--- a/src/Stack/Infrastructure/CommonOptions.cs
+++ b/src/Stack/Infrastructure/CommonOptions.cs
@@ -2,7 +2,7 @@ using System.CommandLine;
 
 public static class CommonOptions
 {
-    public static Option<string?> WorkingDirectory { get; } = new Option<string?>("--working-directory", "--working-dir")
+    public static Option<string?> WorkingDirectory { get; } = new Option<string?>("--working-dir")
     {
         Description = "The path to the directory containing the git repository. Defaults to the current directory.",
         Required = false


### PR DESCRIPTION
Part of a series of PRs that are adding support for AOT:

<!-- stack-pr-list -->
- https://github.com/geofflamrock/stack/pull/276
- https://github.com/geofflamrock/stack/pull/285
- https://github.com/geofflamrock/stack/pull/280
- https://github.com/geofflamrock/stack/pull/284
- https://github.com/geofflamrock/stack/pull/286
- https://github.com/geofflamrock/stack/pull/287
- https://github.com/geofflamrock/stack/pull/288
- https://github.com/geofflamrock/stack/pull/290
- https://github.com/geofflamrock/stack/pull/297
- https://github.com/geofflamrock/stack/pull/298
<!-- /stack-pr-list -->
