### PR TITLE
Fix issue where worktree would cause status command to fail

### DIFF
--- a/src/Stack.Tests/Git/GitBranchStatusParserTests.cs
+++ b/src/Stack.Tests/Git/GitBranchStatusParserTests.cs
@@ -82,4 +82,95 @@ public class GitBranchStatusParserTests
         // Assert
         result.Should().Be(new GitBranchStatus("main", "origin/main", false, false, 0, 0, new Commit("1234567", "Some message")));
     }
+
+    [Fact]
+    public void WhenBranchHasWorktreePathWithoutStatus_ReturnsCorrectStatus()
+    {
+        // Arrange
+        var branchStatus = "+ main 1234567 (D:/path/to/worktree) [origin/main] Some message";
+
+        // Act
+        var result = GitBranchStatusParser.Parse(branchStatus);
+
+        // Assert
+        result.Should().Be(new GitBranchStatus("main", "origin/main", true, false, 0, 0, new Commit("1234567", "Some message")));
+    }
+
+    [Fact]
+    public void WhenBranchHasWorktreePathWithBehindStatus_ReturnsCorrectStatus()
+    {
+        // Arrange
+        var branchStatus = "+ main 1234567 (D:/path/to/worktree) [origin/main: behind 6] Some message";
+
+        // Act
+        var result = GitBranchStatusParser.Parse(branchStatus);
+
+        // Assert
+        result.Should().Be(new GitBranchStatus("main", "origin/main", true, false, 0, 6, new Commit("1234567", "Some message")));
+    }
+
+    [Fact]
+    public void WhenBranchHasWorktreePathWithAheadStatus_ReturnsCorrectStatus()
+    {
+        // Arrange
+        var branchStatus = "+ main 1234567 (D:/path/to/worktree) [origin/main: ahead 6] Some message";
+
+        // Act
+        var result = GitBranchStatusParser.Parse(branchStatus);
+
+        // Assert
+        result.Should().Be(new GitBranchStatus("main", "origin/main", true, false, 6, 0, new Commit("1234567", "Some message")));
+    }
+
+    [Fact]
+    public void WhenBranchHasWorktreePathWithAheadAndBehindStatus_ReturnsCorrectStatus()
+    {
+        // Arrange
+        var branchStatus = "+ main 1234567 (D:/path/to/worktree) [origin/main: ahead 6, behind 2] Some message";
+
+        // Act
+        var result = GitBranchStatusParser.Parse(branchStatus);
+
+        // Assert
+        result.Should().Be(new GitBranchStatus("main", "origin/main", true, false, 6, 2, new Commit("1234567", "Some message")));
+    }
+
+    [Fact]
+    public void WhenBranchHasWorktreePath_AndRemoteBranchIsGone_ReturnsCorrectStatus()
+    {
+        // Arrange
+        var branchStatus = "+ main 1234567 (D:/path/to/worktree) [origin/main: gone] Some message";
+
+        // Act
+        var result = GitBranchStatusParser.Parse(branchStatus);
+
+        // Assert
+        result.Should().Be(new GitBranchStatus("main", "origin/main", false, false, 0, 0, new Commit("1234567", "Some message")));
+    }
+
+    [Fact]
+    public void WhenBranchHasWorktreePath_AndBranchIsNotTracked_ReturnsCorrectStatus()
+    {
+        // Arrange
+        var branchStatus = "+ main 1234567 (D:/path/to/worktree) Some message";
+
+        // Act
+        var result = GitBranchStatusParser.Parse(branchStatus);
+
+        // Assert
+        result.Should().Be(new GitBranchStatus("main", null, false, false, 0, 0, new Commit("1234567", "Some message")));
+    }
+
+    [Fact]
+    public void WhenBranchHasWorktreePathWithParentheses_ReturnsCorrectStatus()
+    {
+        // Arrange
+        var branchStatus = "+ main 1234567 (D:/path/with (parentheses)/worktree) [origin/main: ahead 3, behind 1] Some message";
+
+        // Act
+        var result = GitBranchStatusParser.Parse(branchStatus);
+
+        // Assert
+        result.Should().Be(new GitBranchStatus("main", "origin/main", true, false, 3, 1, new Commit("1234567", "Some message")));
+    }
 }

--- a/src/Stack/Git/GitBranchStatusParser.cs
+++ b/src/Stack/Git/GitBranchStatusParser.cs
@@ -5,7 +5,7 @@ namespace Stack.Git;
 public static class GitBranchStatusParser
 {
     static Regex regex = new(
-        @"^(?<isCurrentBranch>\*)?\s*(?<branchName>\S+)\s+(?<sha>\S+)\s*(\[(?<remoteTrackingBranchName>[^:]+)?(?::\s*(?<status>(ahead\s+(?<ahead>\d+),\s*behind\s+(?<behind>\d+))|(ahead\s+(?<aheadOnly>\d+))|(behind\s+(?<behindOnly>\d+))|(gone)))?\])?\s+(?<message>.+)$",
+        @"^(?<branchMarker>[\*\+])?\s*(?<branchName>\S+)\s+(?<sha>\S+)(?:\s+\((?<worktreePath>.*?)\))?\s*(\[(?<remoteTrackingBranchName>[^:]+)?(?::\s*(?<status>(ahead\s+(?<ahead>\d+),\s*behind\s+(?<behind>\d+))|(ahead\s+(?<aheadOnly>\d+))|(behind\s+(?<behindOnly>\d+))|(gone)))?\])?\s+(?<message>.+)$",
         RegexOptions.Compiled);
 
     public static GitBranchStatus? Parse(string branchStatus)
@@ -15,7 +15,8 @@ public static class GitBranchStatusParser
         if (match.Success)
         {
             var branchName = match.Groups["branchName"].Value;
-            var isCurrentBranch = match.Groups["isCurrentBranch"].Success;
+            var branchMarker = match.Groups["branchMarker"].Success ? match.Groups["branchMarker"].Value : null;
+            var isCurrentBranch = branchMarker == "*";
             var remoteTrackingBranchName = string.IsNullOrEmpty(match.Groups["remoteTrackingBranchName"].Value) ? null : match.Groups["remoteTrackingBranchName"].Value;
             var ahead = match.Groups["ahead"].Success ? int.Parse(match.Groups["ahead"].Value) : (match.Groups["aheadOnly"].Success ? int.Parse(match.Groups["aheadOnly"].Value) : 0);
             var behind = match.Groups["behind"].Success ? int.Parse(match.Groups["behind"].Value) : (match.Groups["behindOnly"].Success ? int.Parse(match.Groups["behindOnly"].Value) : 0);


### PR DESCRIPTION
When we get the status of a stack we use `git branch -vv` to list branches in the repo along with their tracking information. When a repo has multiple worktrees there is some additional information in the output of the path to the worktree that we weren't catering for. This resulted in data being missing that wasn't expected if the branch in question is in the stack and the status command would fail.

Improves the parsing to include the worktree information, we don't do anything with it but it now shouldn't fail.