### PR TITLE
Pull changes without changing branch

### DIFF
--- a/src/Stack.Tests/Commands/Helpers/StackActionsTests.cs
+++ b/src/Stack.Tests/Commands/Helpers/StackActionsTests.cs
@@ -471,9 +471,8 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         stackActions.PullChanges(stack);
 
         // Assert
-        gitClient.DidNotReceive().PullBranch(sourceBranch);
-        gitClient.Received().PullBranch(branchWithRemoteChanges);
-        gitClient.DidNotReceive().PullBranch(branchWithoutRemoteChanges);
+        gitClient.Received().FetchBranchRefSpecs(Arg.Is<string[]>(a => a.Length == 1 && a[0] == branchWithRemoteChanges));
+        gitClient.DidNotReceive().FetchBranchRefSpecs(Arg.Is<string[]>(a => a.Contains(branchWithoutRemoteChanges) || a.Contains(sourceBranch)));
     }
 
     [Fact]
@@ -509,9 +508,8 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         stackActions.PullChanges(stack);
 
         // Assert
-        gitClient.DidNotReceive().PullBranch(sourceBranch);
-        gitClient.Received().PullBranch(branchThatExistsInRemote);
-        gitClient.DidNotReceive().PullBranch(branchThatDoesNotExistInRemote);
+        gitClient.Received().FetchBranchRefSpecs(Arg.Is<string[]>(a => a.Length == 1 && a[0] == branchThatExistsInRemote));
+        gitClient.DidNotReceive().FetchBranchRefSpecs(Arg.Is<string[]>(a => a.Contains(branchThatDoesNotExistInRemote) || a.Contains(sourceBranch)));
     }
 
     [Fact]

--- a/src/Stack.Tests/Git/GitBranchStatusParserTests.cs
+++ b/src/Stack.Tests/Git/GitBranchStatusParserTests.cs
@@ -15,7 +15,7 @@ public class GitBranchStatusParserTests
         var result = GitBranchStatusParser.Parse(branchStatus);
 
         // Assert
-        result.Should().Be(new GitBranchStatus("main", "origin/main", true, true, 0, 0, new Commit("1234567", "Some message")));
+        result.Should().Be(new GitBranchStatus("main", "origin/main", true, true, 0, 0, new Commit("1234567", "Some message"), null));
     }
 
     [Fact]
@@ -28,7 +28,7 @@ public class GitBranchStatusParserTests
         var result = GitBranchStatusParser.Parse(branchStatus);
 
         // Assert
-        result.Should().Be(new GitBranchStatus("main", "origin/main", true, false, 1, 2, new Commit("1234567", "Some message")));
+        result.Should().Be(new GitBranchStatus("main", "origin/main", true, false, 1, 2, new Commit("1234567", "Some message"), null));
     }
 
     [Fact]
@@ -41,7 +41,7 @@ public class GitBranchStatusParserTests
         var result = GitBranchStatusParser.Parse(branchStatus);
 
         // Assert
-        result.Should().Be(new GitBranchStatus("main", "origin/main", true, false, 1, 0, new Commit("1234567", "Some message")));
+        result.Should().Be(new GitBranchStatus("main", "origin/main", true, false, 1, 0, new Commit("1234567", "Some message"), null));
     }
 
     [Fact]
@@ -54,7 +54,7 @@ public class GitBranchStatusParserTests
         var result = GitBranchStatusParser.Parse(branchStatus);
 
         // Assert
-        result.Should().Be(new GitBranchStatus("main", "origin/main", true, false, 0, 2, new Commit("1234567", "Some message")));
+        result.Should().Be(new GitBranchStatus("main", "origin/main", true, false, 0, 2, new Commit("1234567", "Some message"), null));
     }
 
     [Fact]
@@ -67,7 +67,7 @@ public class GitBranchStatusParserTests
         var result = GitBranchStatusParser.Parse(branchStatus);
 
         // Assert
-        result.Should().Be(new GitBranchStatus("main", null, false, false, 0, 0, new Commit("1234567", "Some message")));
+        result.Should().Be(new GitBranchStatus("main", null, false, false, 0, 0, new Commit("1234567", "Some message"), null));
     }
 
     [Fact]
@@ -80,7 +80,7 @@ public class GitBranchStatusParserTests
         var result = GitBranchStatusParser.Parse(branchStatus);
 
         // Assert
-        result.Should().Be(new GitBranchStatus("main", "origin/main", false, false, 0, 0, new Commit("1234567", "Some message")));
+        result.Should().Be(new GitBranchStatus("main", "origin/main", false, false, 0, 0, new Commit("1234567", "Some message"), null));
     }
 
     [Fact]
@@ -93,7 +93,7 @@ public class GitBranchStatusParserTests
         var result = GitBranchStatusParser.Parse(branchStatus);
 
         // Assert
-        result.Should().Be(new GitBranchStatus("main", "origin/main", true, false, 0, 0, new Commit("1234567", "Some message")));
+        result.Should().Be(new GitBranchStatus("main", "origin/main", true, false, 0, 0, new Commit("1234567", "Some message"), "D:/path/to/worktree"));
     }
 
     [Fact]
@@ -106,7 +106,7 @@ public class GitBranchStatusParserTests
         var result = GitBranchStatusParser.Parse(branchStatus);
 
         // Assert
-        result.Should().Be(new GitBranchStatus("main", "origin/main", true, false, 0, 6, new Commit("1234567", "Some message")));
+        result.Should().Be(new GitBranchStatus("main", "origin/main", true, false, 0, 6, new Commit("1234567", "Some message"), "D:/path/to/worktree"));
     }
 
     [Fact]
@@ -119,7 +119,7 @@ public class GitBranchStatusParserTests
         var result = GitBranchStatusParser.Parse(branchStatus);
 
         // Assert
-        result.Should().Be(new GitBranchStatus("main", "origin/main", true, false, 6, 0, new Commit("1234567", "Some message")));
+        result.Should().Be(new GitBranchStatus("main", "origin/main", true, false, 6, 0, new Commit("1234567", "Some message"), "D:/path/to/worktree"));
     }
 
     [Fact]
@@ -132,7 +132,7 @@ public class GitBranchStatusParserTests
         var result = GitBranchStatusParser.Parse(branchStatus);
 
         // Assert
-        result.Should().Be(new GitBranchStatus("main", "origin/main", true, false, 6, 2, new Commit("1234567", "Some message")));
+        result.Should().Be(new GitBranchStatus("main", "origin/main", true, false, 6, 2, new Commit("1234567", "Some message"), "D:/path/to/worktree"));
     }
 
     [Fact]
@@ -145,7 +145,7 @@ public class GitBranchStatusParserTests
         var result = GitBranchStatusParser.Parse(branchStatus);
 
         // Assert
-        result.Should().Be(new GitBranchStatus("main", "origin/main", false, false, 0, 0, new Commit("1234567", "Some message")));
+        result.Should().Be(new GitBranchStatus("main", "origin/main", false, false, 0, 0, new Commit("1234567", "Some message"), "D:/path/to/worktree"));
     }
 
     [Fact]
@@ -158,7 +158,7 @@ public class GitBranchStatusParserTests
         var result = GitBranchStatusParser.Parse(branchStatus);
 
         // Assert
-        result.Should().Be(new GitBranchStatus("main", null, false, false, 0, 0, new Commit("1234567", "Some message")));
+        result.Should().Be(new GitBranchStatus("main", null, false, false, 0, 0, new Commit("1234567", "Some message"), "D:/path/to/worktree"));
     }
 
     [Fact]
@@ -171,6 +171,6 @@ public class GitBranchStatusParserTests
         var result = GitBranchStatusParser.Parse(branchStatus);
 
         // Assert
-        result.Should().Be(new GitBranchStatus("main", "origin/main", true, false, 3, 1, new Commit("1234567", "Some message")));
+        result.Should().Be(new GitBranchStatus("main", "origin/main", true, false, 3, 1, new Commit("1234567", "Some message"), "D:/path/with (parentheses)/worktree"));
     }
 }

--- a/src/Stack.Tests/Helpers/TemporaryDirectory.cs
+++ b/src/Stack.Tests/Helpers/TemporaryDirectory.cs
@@ -20,8 +20,13 @@ public class TemporaryDirectory(string DirectoryPath) : IDisposable
 
     public static TemporaryDirectory Create()
     {
-        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var path = CreatePath();
         Directory.CreateDirectory(path);
         return new TemporaryDirectory(path);
+    }
+
+    public static string CreatePath()
+    {
+        return Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
     }
 }

--- a/src/Stack/Git/GitBranchStatusParser.cs
+++ b/src/Stack/Git/GitBranchStatusParser.cs
@@ -23,8 +23,9 @@ public static class GitBranchStatusParser
             var remoteBranchExists = remoteTrackingBranchName is not null && !match.Groups["status"].Value.Contains("gone");
             var sha = match.Groups["sha"].Value;
             var message = match.Groups["message"].Value;
+            var worktreePath = match.Groups["worktreePath"].Success ? match.Groups["worktreePath"].Value : null;
 
-            return new GitBranchStatus(branchName, remoteTrackingBranchName, remoteBranchExists, isCurrentBranch, ahead, behind, new Commit(sha, message));
+            return new GitBranchStatus(branchName, remoteTrackingBranchName, remoteBranchExists, isCurrentBranch, ahead, behind, new Commit(sha, message), worktreePath);
         }
 
         return null;

--- a/src/Stack/Git/GitClient.cs
+++ b/src/Stack/Git/GitClient.cs
@@ -11,7 +11,15 @@ public record GitClientSettings(bool Verbose, string? WorkingDirectory)
 
 public record Commit(string Sha, string Message);
 
-public record GitBranchStatus(string BranchName, string? RemoteTrackingBranchName, bool RemoteBranchExists, bool IsCurrentBranch, int Ahead, int Behind, Commit Tip);
+public record GitBranchStatus(
+    string BranchName,
+    string? RemoteTrackingBranchName,
+    bool RemoteBranchExists,
+    bool IsCurrentBranch,
+    int Ahead,
+    int Behind,
+    Commit Tip,
+    string? WorktreePath = null);
 
 public class ConflictException : Exception;
 
@@ -35,6 +43,7 @@ public interface IGitClient
     void PushNewBranch(string branchName);
     void PullBranch(string branchName);
     void FetchBranchRefSpecs(string[] branchNames);
+    void PullBranchForWorktree(string branchName, string worktreePath);
     void PushBranches(string[] branches, bool forceWithLease);
     void DeleteLocalBranch(string branchName);
 
@@ -168,6 +177,12 @@ public class GitClient(ILogger logger, GitClientSettings settings) : IGitClient
 
         var refSpecs = string.Join(" ", branchNames.Select(b => $"{b}:{b}"));
         ExecuteGitCommand($"fetch origin {refSpecs}");
+    }
+
+    public void PullBranchForWorktree(string branchName, string worktreePath)
+    {
+        // Execute the pull within the specified worktree without changing the current working directory
+        ExecuteGitCommand($"-C \"{worktreePath}\" pull origin {branchName}");
     }
 
     public void PushBranches(string[] branches, bool forceWithLease)

--- a/src/Stack/Git/GitClient.cs
+++ b/src/Stack/Git/GitClient.cs
@@ -27,12 +27,14 @@ public interface IGitClient
     string GetRootOfRepository();
     string? GetConfigValue(string key);
     bool IsAncestor(string ancestor, string descendant);
+
     void Fetch(bool prune);
 
     void ChangeBranch(string branchName);
     void CreateNewBranch(string branchName, string sourceBranch);
     void PushNewBranch(string branchName);
     void PullBranch(string branchName);
+    void FetchBranchRefSpecs(string[] branchNames);
     void PushBranches(string[] branches, bool forceWithLease);
     void DeleteLocalBranch(string branchName);
 
@@ -155,6 +157,17 @@ public class GitClient(ILogger logger, GitClientSettings settings) : IGitClient
     public void PullBranch(string branchName)
     {
         ExecuteGitCommand($"pull origin {branchName}");
+    }
+
+    public void FetchBranchRefSpecs(string[] branchNames)
+    {
+        if (branchNames is null || branchNames.Length == 0)
+        {
+            return;
+        }
+
+        var refSpecs = string.Join(" ", branchNames.Select(b => $"{b}:{b}"));
+        ExecuteGitCommand($"fetch origin {refSpecs}");
     }
 
     public void PushBranches(string[] branches, bool forceWithLease)


### PR DESCRIPTION
Currently when pulling changes for a stack, we change to each branch that is behind the remote and run `git pull` on it. This isn't very efficient and can cause issues if there are changes in the working index, or if a branch in the stack is checked out in another worktree.

This PR changes the way branches are pulled:
- If the branch is the current one we still use `git pull origin {BranchName}`.
- If the branch is checked out in another worktree we use `git -C {WorktreePath} pull origin {BranchName}` to pull the changes in the other worktree location.
- Otherwise we use `git fetch origin {BranchName}:{BranchName}` to fetch the changes directly into the branch without needing to change first.