### PR TITLE
Move PullChanges to separate interface to improve testing

### DIFF
--- a/src/Stack.Tests/Commands/Helpers/StackActionsTests.cs
+++ b/src/Stack.Tests/Commands/Helpers/StackActionsTests.cs
@@ -1,0 +1,84 @@
+using FluentAssertions;
+using NSubstitute;
+using Stack.Commands;
+using Stack.Commands.Helpers;
+using Stack.Git;
+using Stack.Infrastructure;
+using Xunit.Abstractions;
+
+namespace Stack.Tests.Helpers;
+
+public class StackActionsTests(ITestOutputHelper testOutputHelper)
+{
+    [Fact]
+    public void PullChanges_WhenSomeBranchesHaveChanges_AndOthersDoNot_OnlyPullsChangesForBranchesThatNeedIt()
+    {
+        // Arrange
+        var sourceBranch = Some.BranchName();
+        var branchWithRemoteChanges = Some.BranchName();
+        var branchWithoutRemoteChanges = Some.BranchName();
+
+        var gitClient = Substitute.For<IGitClient>();
+
+        var branchStatus = new Dictionary<string, GitBranchStatus>
+        {
+            { sourceBranch, new GitBranchStatus(sourceBranch, $"origin/{sourceBranch}", true, false, 0, 0, new Commit(Some.Sha(), Some.Name())) },
+            { branchWithRemoteChanges, new GitBranchStatus(branchWithRemoteChanges, $"origin/{branchWithRemoteChanges}", true, false, 0, 3, new Commit(Some.Sha(), Some.Name())) },
+            { branchWithoutRemoteChanges, new GitBranchStatus(branchWithoutRemoteChanges, $"origin/{branchWithoutRemoteChanges}", true, false, 0, 0, new Commit(Some.Sha(), Some.Name())) }
+        };
+
+        gitClient.GetBranchStatuses(Arg.Any<string[]>()).Returns(branchStatus);
+
+        var stack = new TestStackBuilder()
+            .WithSourceBranch(sourceBranch)
+            .WithBranch(b => b.WithName(branchWithRemoteChanges))
+            .WithBranch(b => b.WithName(branchWithoutRemoteChanges))
+            .Build();
+
+        var stackActions = new StackActions(gitClient, new TestLogger(testOutputHelper));
+
+        // Act
+        stackActions.PullChanges(stack);
+
+        // Assert
+        gitClient.DidNotReceive().PullBranch(sourceBranch);
+        gitClient.Received().PullBranch(branchWithRemoteChanges);
+        gitClient.DidNotReceive().PullBranch(branchWithoutRemoteChanges);
+    }
+
+    [Fact]
+    public void PullChanges_WhenSomeBranchesDoNotExistInRemote_OnlyPullsBranchesThatExistInRemote()
+    {
+        // Arrange
+        var sourceBranch = Some.BranchName();
+        var branchThatExistsInRemote = Some.BranchName();
+        var branchThatDoesNotExistInRemote = Some.BranchName();
+
+        var gitClient = Substitute.For<IGitClient>();
+
+        var branchStatus = new Dictionary<string, GitBranchStatus>
+        {
+            { sourceBranch, new GitBranchStatus(sourceBranch, $"origin/{sourceBranch}", true, false, 0, 0, new Commit(Some.Sha(), Some.Name())) },
+            { branchThatExistsInRemote, new GitBranchStatus(branchThatExistsInRemote, $"origin/{branchThatExistsInRemote}", true, false, 0, 2, new Commit(Some.Sha(), Some.Name())) },
+            { branchThatDoesNotExistInRemote, new GitBranchStatus(branchThatDoesNotExistInRemote, $"origin/{branchThatDoesNotExistInRemote}", false, false, 0, 0, new Commit(Some.Sha(), Some.Name())) }
+        };
+
+        gitClient.GetBranchStatuses(Arg.Any<string[]>()).Returns(branchStatus);
+
+        var stack = new TestStackBuilder()
+            .WithSourceBranch(sourceBranch)
+            .WithBranch(b => b.WithName(branchThatExistsInRemote))
+            .WithBranch(b => b.WithName(branchThatDoesNotExistInRemote))
+            .Build();
+
+        var stackActions = new StackActions(gitClient, new TestLogger(testOutputHelper));
+
+        // Act
+        stackActions.PullChanges(stack);
+
+        // Assert
+        gitClient.DidNotReceive().PullBranch(sourceBranch);
+        gitClient.Received().PullBranch(branchThatExistsInRemote);
+        gitClient.DidNotReceive().PullBranch(branchThatDoesNotExistInRemote);
+    }
+}

--- a/src/Stack.Tests/Commands/Helpers/StackHelpersTests.cs
+++ b/src/Stack.Tests/Commands/Helpers/StackHelpersTests.cs
@@ -472,38 +472,4 @@ public class StackHelpersTests(ITestOutputHelper testOutputHelper)
         // Assert
         branchesPushedToRemote.ToArray().Should().BeEquivalentTo([branchAheadOfRemote]);
     }
-
-    [Fact]
-    public void PullChanges_WhenSomeBranchesHaveChanges_AndOthersDoNot_OnlyPullsChangesForBranchesThatNeedIt()
-    {
-        // Arrange
-        var sourceBranch = Some.BranchName();
-        var branchWithRemoteChanges = Some.BranchName();
-        var branchWithoutRemoteChanges = Some.BranchName();
-
-        var gitClient = Substitute.For<IGitClient>();
-
-        var branchStatus = new Dictionary<string, GitBranchStatus>
-        {
-            { sourceBranch, new GitBranchStatus(sourceBranch, $"origin/{sourceBranch}", true, false, 0, 0, new Commit(Some.Sha(), Some.Name())) },
-            { branchWithRemoteChanges, new GitBranchStatus(branchWithRemoteChanges, $"origin/{branchWithRemoteChanges}", true, false, 0, 3, new Commit(Some.Sha(), Some.Name())) },
-            { branchWithoutRemoteChanges, new GitBranchStatus(branchWithoutRemoteChanges, $"origin/{branchWithoutRemoteChanges}", true, false, 0, 0, new Commit(Some.Sha(), Some.Name())) }
-        };
-
-        gitClient.GetBranchStatuses(Arg.Any<string[]>()).Returns(branchStatus);
-
-        var stack = new TestStackBuilder()
-            .WithSourceBranch(sourceBranch)
-            .WithBranch(b => b.WithName(branchWithRemoteChanges))
-            .WithBranch(b => b.WithName(branchWithoutRemoteChanges))
-            .Build();
-
-        // Act
-        StackHelpers.PullChanges(stack, gitClient, new TestLogger(testOutputHelper));
-
-        // Assert
-        gitClient.DidNotReceive().PullBranch(sourceBranch);
-        gitClient.Received().PullBranch(branchWithRemoteChanges);
-        gitClient.DidNotReceive().PullBranch(branchWithoutRemoteChanges);
-    }
 }

--- a/src/Stack.Tests/Commands/Remote/PullStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Remote/PullStackCommandHandlerTests.cs
@@ -13,44 +13,33 @@ namespace Stack.Tests.Commands.Remote;
 public class PullStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
 {
     [Fact]
-    public async Task WhenChangesExistOnTheRemote_TheyArePulledDownToTheLocalBranch()
+    public async Task WhenNoStackNameIsProvided_AsksForStack_PullsChangesForTheCorrectStack()
     {
         // Arrange
         var sourceBranch = Some.BranchName();
         var branch1 = Some.BranchName();
         var branch2 = Some.BranchName();
-        using var repo = new TestGitRepositoryBuilder()
-            .WithBranch(builder => builder.WithName(sourceBranch).PushToRemote())
-            .WithBranch(builder => builder.WithName(branch1).FromSourceBranch(sourceBranch).WithNumberOfEmptyCommits(10).PushToRemote())
-            .WithBranch(builder => builder.WithName(branch2).FromSourceBranch(branch1).WithNumberOfEmptyCommits(1).PushToRemote())
-            .WithNumberOfEmptyCommitsOnRemoteTrackingBranchOf(sourceBranch, 5, b => b.PushToRemote())
-            .WithNumberOfEmptyCommitsOnRemoteTrackingBranchOf(branch1, 3, b => b.PushToRemote())
-            .Build();
-
-        var tipOfRemoteSourceBranch = repo.GetTipOfRemoteBranch(sourceBranch);
-        var tipOfRemoteBranch1 = repo.GetTipOfRemoteBranch(branch1);
-
-        repo.GetCommitsReachableFromBranch(sourceBranch).Should().NotContain(tipOfRemoteSourceBranch);
-        repo.GetCommitsReachableFromBranch(branch1).Should().NotContain(tipOfRemoteBranch1);
+        var remoteUri = Some.HttpsUri().ToString();
 
         var stackConfig = new TestStackConfigBuilder()
             .WithStack(stack => stack
                 .WithName("Stack1")
-                .WithRemoteUri(repo.RemoteUri)
+                .WithRemoteUri(remoteUri)
                 .WithSourceBranch(sourceBranch)
                 .WithBranch(stackBranch => stackBranch.WithName(branch1).WithChildBranch(child => child.WithName(branch2))))
             .WithStack(stack => stack
                 .WithName("Stack2")
-                .WithRemoteUri(repo.RemoteUri)
+                .WithRemoteUri(remoteUri)
                 .WithSourceBranch(sourceBranch))
             .Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = new TestLogger(testOutputHelper);
-        var gitClient = new GitClient(logger, repo.GitClientSettings);
-        var handler = new PullStackCommandHandler(inputProvider, logger, gitClient, stackConfig);
+        var gitClient = Substitute.For<IGitClient>();
+        var stackActions = Substitute.For<IStackActions>();
+        var handler = new PullStackCommandHandler(inputProvider, logger, gitClient, stackConfig, stackActions);
 
-        gitClient.ChangeBranch(branch1);
-
+        gitClient.GetRemoteUri().Returns(remoteUri);
+        gitClient.GetCurrentBranch().Returns(branch1);
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
 
@@ -58,57 +47,48 @@ public class PullStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         await handler.Handle(new PullStackCommandInputs(null));
 
         // Assert
-        repo.GetCommitsReachableFromBranch(sourceBranch).Should().Contain(tipOfRemoteSourceBranch);
-        repo.GetCommitsReachableFromBranch(branch1).Should().Contain(tipOfRemoteBranch1);
+        var expectedStack = stackConfig.Load().Stacks.First(s => s.Name == "Stack1");
+        stackActions.Received(1).PullChanges(expectedStack);
+        gitClient.Received(1).ChangeBranch(branch1);
     }
 
     [Fact]
-    public async Task WhenNameIsProvided_DoesNotAskForName_PullsChangesFromRemoteForBranchesInStack()
+    public async Task WhenNameIsProvided_DoesNotAskForName_PullsChangesForTheCorrectStack()
     {
         // Arrange
         var sourceBranch = Some.BranchName();
         var branch1 = Some.BranchName();
         var branch2 = Some.BranchName();
-        using var repo = new TestGitRepositoryBuilder()
-            .WithBranch(builder => builder.WithName(sourceBranch).PushToRemote())
-            .WithBranch(builder => builder.WithName(branch1).FromSourceBranch(sourceBranch).WithNumberOfEmptyCommits(10).PushToRemote())
-            .WithBranch(builder => builder.WithName(branch2).FromSourceBranch(branch1).WithNumberOfEmptyCommits(1).PushToRemote())
-            .WithNumberOfEmptyCommitsOnRemoteTrackingBranchOf(sourceBranch, 5, b => b.PushToRemote())
-            .WithNumberOfEmptyCommitsOnRemoteTrackingBranchOf(branch1, 3, b => b.PushToRemote())
-            .Build();
-
-        var tipOfRemoteSourceBranch = repo.GetTipOfRemoteBranch(sourceBranch);
-        var tipOfRemoteBranch1 = repo.GetTipOfRemoteBranch(branch1);
-
-        repo.GetCommitsReachableFromBranch(sourceBranch).Should().NotContain(tipOfRemoteSourceBranch);
-        repo.GetCommitsReachableFromBranch(branch1).Should().NotContain(tipOfRemoteBranch1);
+        var remoteUri = Some.HttpsUri().ToString();
 
         var stackConfig = new TestStackConfigBuilder()
             .WithStack(stack => stack
                 .WithName("Stack1")
-                .WithRemoteUri(repo.RemoteUri)
+                .WithRemoteUri(remoteUri)
                 .WithSourceBranch(sourceBranch)
                 .WithBranch(stackBranch => stackBranch.WithName(branch1))
                 .WithBranch(stackBranch => stackBranch.WithName(branch2)))
             .WithStack(stack => stack
                 .WithName("Stack2")
-                .WithRemoteUri(repo.RemoteUri)
+                .WithRemoteUri(remoteUri)
                 .WithSourceBranch(sourceBranch))
             .Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = new TestLogger(testOutputHelper);
-        var gitClient = new GitClient(logger, repo.GitClientSettings);
-        var handler = new PullStackCommandHandler(inputProvider, logger, gitClient, stackConfig);
+        var gitClient = Substitute.For<IGitClient>();
+        var stackActions = Substitute.For<IStackActions>();
+        var handler = new PullStackCommandHandler(inputProvider, logger, gitClient, stackConfig, stackActions);
 
-        gitClient.ChangeBranch(branch1);
-
+        gitClient.GetRemoteUri().Returns(remoteUri);
+        gitClient.GetCurrentBranch().Returns(branch1);
 
         // Act
         await handler.Handle(new PullStackCommandInputs("Stack1"));
 
         // Assert
-        repo.GetCommitsReachableFromBranch(sourceBranch).Should().Contain(tipOfRemoteSourceBranch);
-        repo.GetCommitsReachableFromBranch(branch1).Should().Contain(tipOfRemoteBranch1);
+        var expectedStack = stackConfig.Load().Stacks.First(s => s.Name == "Stack1");
+        stackActions.Received(1).PullChanges(expectedStack);
+        gitClient.Received(1).ChangeBranch(branch1);
         inputProvider.DidNotReceive().Select(Questions.SelectStack, Arg.Any<string[]>());
     }
 
@@ -119,143 +99,33 @@ public class PullStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var sourceBranch = Some.BranchName();
         var branch1 = Some.BranchName();
         var branch2 = Some.BranchName();
-        using var repo = new TestGitRepositoryBuilder()
-            .WithBranch(builder => builder.WithName(sourceBranch).PushToRemote())
-            .WithBranch(builder => builder.WithName(branch1).FromSourceBranch(sourceBranch).WithNumberOfEmptyCommits(10).PushToRemote())
-            .WithBranch(builder => builder.WithName(branch2).FromSourceBranch(branch1).WithNumberOfEmptyCommits(1).PushToRemote())
-            .WithNumberOfEmptyCommitsOnRemoteTrackingBranchOf(sourceBranch, 5, b => b.PushToRemote())
-            .WithNumberOfEmptyCommitsOnRemoteTrackingBranchOf(branch1, 3, b => b.PushToRemote())
-            .Build();
-
-        var tipOfRemoteSourceBranch = repo.GetTipOfRemoteBranch(sourceBranch);
-        var tipOfRemoteBranch1 = repo.GetTipOfRemoteBranch(branch1);
-
-        repo.GetCommitsReachableFromBranch(sourceBranch).Should().NotContain(tipOfRemoteSourceBranch);
-        repo.GetCommitsReachableFromBranch(branch1).Should().NotContain(tipOfRemoteBranch1);
+        var remoteUri = Some.HttpsUri().ToString();
 
         var stackConfig = new TestStackConfigBuilder()
             .WithStack(stack => stack
                 .WithName("Stack1")
-                .WithRemoteUri(repo.RemoteUri)
+                .WithRemoteUri(remoteUri)
                 .WithSourceBranch(sourceBranch)
                 .WithBranch(stackBranch => stackBranch.WithName(branch1))
                 .WithBranch(stackBranch => stackBranch.WithName(branch2)))
             .WithStack(stack => stack
                 .WithName("Stack2")
-                .WithRemoteUri(repo.RemoteUri)
+                .WithRemoteUri(remoteUri)
                 .WithSourceBranch(sourceBranch))
             .Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = new TestLogger(testOutputHelper);
-        var gitClient = new GitClient(logger, repo.GitClientSettings);
-        var handler = new PullStackCommandHandler(inputProvider, logger, gitClient, stackConfig);
+        var gitClient = Substitute.For<IGitClient>();
+        var stackActions = Substitute.For<IStackActions>();
+        var handler = new PullStackCommandHandler(inputProvider, logger, gitClient, stackConfig, stackActions);
 
-        gitClient.ChangeBranch(branch1);
-
-
-        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
+        gitClient.GetRemoteUri().Returns(remoteUri);
+        gitClient.GetCurrentBranch().Returns(branch1);
 
         // Act and assert
         var invalidStackName = Some.Name();
         await handler.Invoking(async h => await h.Handle(new PullStackCommandInputs(invalidStackName)))
             .Should().ThrowAsync<InvalidOperationException>()
             .WithMessage($"Stack '{invalidStackName}' not found.");
-    }
-
-    [Fact]
-    public async Task WhenChangesExistOnTheRemote_ForABranchThatIsNotInTheStack_TheyAreNotPulledDownToTheLocalBranch()
-    {
-        // Arrange
-        var sourceBranch = Some.BranchName();
-        var branch1 = Some.BranchName();
-        var branch2 = Some.BranchName();
-        using var repo = new TestGitRepositoryBuilder()
-            .WithBranch(builder => builder.WithName(sourceBranch).PushToRemote())
-            .WithBranch(builder => builder.WithName(branch1).FromSourceBranch(sourceBranch).WithNumberOfEmptyCommits(10).PushToRemote())
-            .WithBranch(builder => builder.WithName(branch2).FromSourceBranch(branch1).WithNumberOfEmptyCommits(1).PushToRemote())
-            .WithNumberOfEmptyCommitsOnRemoteTrackingBranchOf(sourceBranch, 5, b => b.PushToRemote())
-            .WithNumberOfEmptyCommitsOnRemoteTrackingBranchOf(branch1, 3, b => b.PushToRemote())
-            .WithNumberOfEmptyCommitsOnRemoteTrackingBranchOf(branch2, 3, b => b.PushToRemote())
-            .Build();
-
-        var tipOfRemoteBranch2 = repo.GetTipOfRemoteBranch(branch2);
-
-        var stackConfig = new TestStackConfigBuilder()
-            .WithStack(stack => stack
-                .WithName("Stack1")
-                .WithRemoteUri(repo.RemoteUri)
-                .WithSourceBranch(sourceBranch)
-                .WithBranch(stackBranch => stackBranch.WithName(branch1)))
-            .WithStack(stack => stack
-                .WithName("Stack2")
-                .WithRemoteUri(repo.RemoteUri)
-                .WithSourceBranch(sourceBranch)
-                .WithBranch(stackBranch => stackBranch.WithName(branch2)))
-            .Build();
-        var inputProvider = Substitute.For<IInputProvider>();
-        var logger = new TestLogger(testOutputHelper);
-        var gitClient = new GitClient(logger, repo.GitClientSettings);
-        var handler = new PullStackCommandHandler(inputProvider, logger, gitClient, stackConfig);
-
-        gitClient.ChangeBranch(branch1);
-
-
-        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
-
-        // Act
-        await handler.Handle(new PullStackCommandInputs(null));
-
-        // Assert
-        repo.GetCommitsReachableFromBranch(branch2).Should().NotContain(tipOfRemoteBranch2);
-    }
-
-    [Fact]
-    public async Task WhenABranchDoesNotExistLocallyOrInTheRemote_ItIsNotPulled()
-    {
-        // Arrange
-        var sourceBranch = Some.BranchName();
-        var branch1 = Some.BranchName();
-        var branch2 = Some.BranchName();
-        using var repo = new TestGitRepositoryBuilder()
-            .WithBranch(builder => builder.WithName(sourceBranch).PushToRemote())
-            .WithBranch(builder => builder.WithName(branch2).FromSourceBranch(sourceBranch).WithNumberOfEmptyCommits(1).PushToRemote())
-            .WithNumberOfEmptyCommitsOnRemoteTrackingBranchOf(sourceBranch, 5, b => b.PushToRemote())
-            .WithNumberOfEmptyCommitsOnRemoteTrackingBranchOf(branch2, 3, b => b.PushToRemote())
-            .Build();
-
-        var tipOfRemoteSourceBranch = repo.GetTipOfRemoteBranch(sourceBranch);
-        var tipOfRemoteBranch2 = repo.GetTipOfRemoteBranch(branch2);
-
-        repo.GetCommitsReachableFromBranch(sourceBranch).Should().NotContain(tipOfRemoteSourceBranch);
-        repo.GetCommitsReachableFromBranch(branch2).Should().NotContain(tipOfRemoteBranch2);
-
-        var stackConfig = new TestStackConfigBuilder()
-            .WithStack(stack => stack
-                .WithName("Stack1")
-                .WithRemoteUri(repo.RemoteUri)
-                .WithSourceBranch(sourceBranch)
-                .WithBranch(stackBranch => stackBranch.WithName(branch1))
-                .WithBranch(stackBranch => stackBranch.WithName(branch2)))
-            .WithStack(stack => stack
-                .WithName("Stack2")
-                .WithRemoteUri(repo.RemoteUri)
-                .WithSourceBranch(sourceBranch))
-            .Build();
-        var inputProvider = Substitute.For<IInputProvider>();
-        var logger = new TestLogger(testOutputHelper);
-        var gitClient = new GitClient(logger, repo.GitClientSettings);
-        var handler = new PullStackCommandHandler(inputProvider, logger, gitClient, stackConfig);
-
-        gitClient.ChangeBranch(branch2);
-
-
-        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
-
-        // Act
-        await handler.Handle(new PullStackCommandInputs(null));
-
-        // Assert
-        repo.GetCommitsReachableFromBranch(sourceBranch).Should().Contain(tipOfRemoteSourceBranch);
-        repo.GetCommitsReachableFromBranch(branch2).Should().Contain(tipOfRemoteBranch2);
     }
 }

--- a/src/Stack.Tests/Commands/Remote/SyncStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Remote/SyncStackCommandHandlerTests.cs
@@ -45,7 +45,8 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var logger = new TestLogger(testOutputHelper);
         var gitClient = new GitClient(logger, repo.GitClientSettings);
         var gitHubClient = Substitute.For<IGitHubClient>();
-        var handler = new SyncStackCommandHandler(inputProvider, logger, gitClient, gitHubClient, stackConfig);
+        var stackActions = new StackActions(gitClient, logger);
+        var handler = new SyncStackCommandHandler(inputProvider, logger, gitClient, gitHubClient, stackConfig, stackActions);
 
         gitClient.ChangeBranch(branch1);
 
@@ -93,7 +94,8 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var logger = new TestLogger(testOutputHelper);
         var gitClient = new GitClient(logger, repo.GitClientSettings);
         var gitHubClient = Substitute.For<IGitHubClient>();
-        var handler = new SyncStackCommandHandler(inputProvider, logger, gitClient, gitHubClient, stackConfig);
+        var stackActions = new StackActions(gitClient, logger);
+        var handler = new SyncStackCommandHandler(inputProvider, logger, gitClient, gitHubClient, stackConfig, stackActions);
 
         gitClient.ChangeBranch(branch1);
 
@@ -141,7 +143,8 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var logger = new TestLogger(testOutputHelper);
         var gitClient = new GitClient(logger, repo.GitClientSettings);
         var gitHubClient = Substitute.For<IGitHubClient>();
-        var handler = new SyncStackCommandHandler(inputProvider, logger, gitClient, gitHubClient, stackConfig);
+        var stackActions = new StackActions(gitClient, logger);
+        var handler = new SyncStackCommandHandler(inputProvider, logger, gitClient, gitHubClient, stackConfig, stackActions);
 
         gitClient.ChangeBranch(branch1);
 
@@ -185,7 +188,8 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var logger = new TestLogger(testOutputHelper);
         var gitClient = new GitClient(logger, repo.GitClientSettings);
         var gitHubClient = Substitute.For<IGitHubClient>();
-        var handler = new SyncStackCommandHandler(inputProvider, logger, gitClient, gitHubClient, stackConfig);
+        var stackActions = new StackActions(gitClient, logger);
+        var handler = new SyncStackCommandHandler(inputProvider, logger, gitClient, gitHubClient, stackConfig, stackActions);
 
         // We are on a specific branch in the stack
         gitClient.ChangeBranch(branch1);
@@ -231,7 +235,8 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var logger = new TestLogger(testOutputHelper);
         var gitClient = new GitClient(logger, repo.GitClientSettings);
         var gitHubClient = Substitute.For<IGitHubClient>();
-        var handler = new SyncStackCommandHandler(inputProvider, logger, gitClient, gitHubClient, stackConfig);
+        var stackActions = new StackActions(gitClient, logger);
+        var handler = new SyncStackCommandHandler(inputProvider, logger, gitClient, gitHubClient, stackConfig, stackActions);
 
         gitClient.ChangeBranch(branch1);
 
@@ -282,7 +287,8 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var logger = new TestLogger(testOutputHelper);
         var gitClient = new GitClient(logger, repo.GitClientSettings);
         var gitHubClient = Substitute.For<IGitHubClient>();
-        var handler = new SyncStackCommandHandler(inputProvider, logger, gitClient, gitHubClient, stackConfig);
+        var stackActions = new StackActions(gitClient, logger);
+        var handler = new SyncStackCommandHandler(inputProvider, logger, gitClient, gitHubClient, stackConfig, stackActions);
 
         gitClient.ChangeBranch(branch1);
 
@@ -334,7 +340,8 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var logger = new TestLogger(testOutputHelper);
         var gitClient = new GitClient(logger, repo.GitClientSettings);
         var gitHubClient = Substitute.For<IGitHubClient>();
-        var handler = new SyncStackCommandHandler(inputProvider, logger, gitClient, gitHubClient, stackConfig);
+        var stackActions = new StackActions(gitClient, logger);
+        var handler = new SyncStackCommandHandler(inputProvider, logger, gitClient, gitHubClient, stackConfig, stackActions);
 
         gitClient.ChangeBranch(branch1);
 
@@ -387,7 +394,8 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var logger = new TestLogger(testOutputHelper);
         var gitClient = new GitClient(logger, repo.GitClientSettings);
         var gitHubClient = Substitute.For<IGitHubClient>();
-        var handler = new SyncStackCommandHandler(inputProvider, logger, gitClient, gitHubClient, stackConfig);
+        var stackActions = new StackActions(gitClient, logger);
+        var handler = new SyncStackCommandHandler(inputProvider, logger, gitClient, gitHubClient, stackConfig, stackActions);
 
         gitClient.ChangeBranch(branch1);
 
@@ -440,7 +448,8 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var logger = new TestLogger(testOutputHelper);
         var gitClient = new GitClient(logger, repo.GitClientSettings);
         var gitHubClient = Substitute.For<IGitHubClient>();
-        var handler = new SyncStackCommandHandler(inputProvider, logger, gitClient, gitHubClient, stackConfig);
+        var stackActions = new StackActions(gitClient, logger);
+        var handler = new SyncStackCommandHandler(inputProvider, logger, gitClient, gitHubClient, stackConfig, stackActions);
 
         gitClient.ChangeBranch(branch1);
 
@@ -493,7 +502,8 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var logger = new TestLogger(testOutputHelper);
         var gitClient = new GitClient(logger, repo.GitClientSettings);
         var gitHubClient = Substitute.For<IGitHubClient>();
-        var handler = new SyncStackCommandHandler(inputProvider, logger, gitClient, gitHubClient, stackConfig);
+        var stackActions = new StackActions(gitClient, logger);
+        var handler = new SyncStackCommandHandler(inputProvider, logger, gitClient, gitHubClient, stackConfig, stackActions);
 
         gitClient.ChangeBranch(branch1);
 
@@ -546,7 +556,8 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var logger = new TestLogger(testOutputHelper);
         var gitClient = new GitClient(logger, repo.GitClientSettings);
         var gitHubClient = Substitute.For<IGitHubClient>();
-        var handler = new SyncStackCommandHandler(inputProvider, logger, gitClient, gitHubClient, stackConfig);
+        var stackActions = new StackActions(gitClient, logger);
+        var handler = new SyncStackCommandHandler(inputProvider, logger, gitClient, gitHubClient, stackConfig, stackActions);
 
         gitClient.ChangeBranch(branch1);
 
@@ -599,7 +610,8 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var logger = new TestLogger(testOutputHelper);
         var gitClient = new GitClient(logger, repo.GitClientSettings);
         var gitHubClient = Substitute.For<IGitHubClient>();
-        var handler = new SyncStackCommandHandler(inputProvider, logger, gitClient, gitHubClient, stackConfig);
+        var stackActions = new StackActions(gitClient, logger);
+        var handler = new SyncStackCommandHandler(inputProvider, logger, gitClient, gitHubClient, stackConfig, stackActions);
 
         gitClient.ChangeBranch(branch1);
 
@@ -653,7 +665,8 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var logger = new TestLogger(testOutputHelper);
         var gitClient = new GitClient(logger, repo.GitClientSettings);
         var gitHubClient = Substitute.For<IGitHubClient>();
-        var handler = new SyncStackCommandHandler(inputProvider, logger, gitClient, gitHubClient, stackConfig);
+        var stackActions = new StackActions(gitClient, logger);
+        var handler = new SyncStackCommandHandler(inputProvider, logger, gitClient, gitHubClient, stackConfig, stackActions);
 
         gitClient.ChangeBranch(branch1);
 
@@ -681,7 +694,8 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var logger = new TestLogger(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
         var gitHubClient = Substitute.For<IGitHubClient>();
-        var handler = new SyncStackCommandHandler(inputProvider, logger, gitClient, gitHubClient, stackConfig);
+        var stackActions = new StackActions(gitClient, logger);
+        var handler = new SyncStackCommandHandler(inputProvider, logger, gitClient, gitHubClient, stackConfig, stackActions);
 
         // Act and assert
         await handler
@@ -723,7 +737,8 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var logger = new TestLogger(testOutputHelper);
         var gitClient = new GitClient(logger, repo.GitClientSettings);
         var gitHubClient = Substitute.For<IGitHubClient>();
-        var handler = new SyncStackCommandHandler(inputProvider, logger, gitClient, gitHubClient, stackConfig);
+        var stackActions = new StackActions(gitClient, logger);
+        var handler = new SyncStackCommandHandler(inputProvider, logger, gitClient, gitHubClient, stackConfig, stackActions);
 
         gitClient.ChangeBranch(branch1);
 
@@ -771,7 +786,8 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var logger = new TestLogger(testOutputHelper);
         var gitClient = new GitClient(logger, repo.GitClientSettings);
         var gitHubClient = Substitute.For<IGitHubClient>();
-        var handler = new SyncStackCommandHandler(inputProvider, logger, gitClient, gitHubClient, stackConfig);
+        var stackActions = new StackActions(gitClient, logger);
+        var handler = new SyncStackCommandHandler(inputProvider, logger, gitClient, gitHubClient, stackConfig, stackActions);
 
         gitClient.ChangeBranch(branch1);
 

--- a/src/Stack/Commands/Helpers/StackActions.cs
+++ b/src/Stack/Commands/Helpers/StackActions.cs
@@ -1,0 +1,31 @@
+using Stack.Config;
+using Stack.Infrastructure;
+using Stack.Git;
+
+namespace Stack.Commands.Helpers
+{
+    public interface IStackActions
+    {
+        void PullChanges(Config.Stack stack);
+    }
+
+    public class StackActions(IGitClient gitClient, ILogger logger) : IStackActions
+    {
+        public void PullChanges(Config.Stack stack)
+        {
+            List<string> allBranchesInStacks = [stack.SourceBranch, .. stack.AllBranchNames];
+            var branchStatus = gitClient.GetBranchStatuses([.. allBranchesInStacks]);
+
+            foreach (var branch in allBranchesInStacks
+                .Where(b =>
+                    branchStatus.ContainsKey(b) &&
+                    branchStatus[b].RemoteBranchExists &&
+                    branchStatus[b].Behind > 0))
+            {
+                logger.Information($"Pulling changes for {branch.Branch()} from remote");
+                gitClient.ChangeBranch(branch);
+                gitClient.PullBranch(branch);
+            }
+        }
+    }
+}

--- a/src/Stack/Commands/Helpers/StackHelpers.cs
+++ b/src/Stack/Commands/Helpers/StackHelpers.cs
@@ -587,23 +587,6 @@ public static class StackHelpers
         }
     }
 
-    public static void PullChanges(Config.Stack stack, IGitClient gitClient, ILogger logger)
-    {
-        List<string> allBranchesInStacks = [stack.SourceBranch, .. stack.AllBranchNames];
-        var branchStatus = gitClient.GetBranchStatuses([.. allBranchesInStacks]);
-
-        foreach (var branch in allBranchesInStacks
-            .Where(b =>
-                branchStatus.ContainsKey(b) &&
-                branchStatus[b].RemoteBranchExists &&
-                branchStatus[b].Behind > 0))
-        {
-            logger.Information($"Pulling changes for {branch.Branch()} from remote");
-            gitClient.ChangeBranch(branch);
-            gitClient.PullBranch(branch);
-        }
-    }
-
     public static void PushChanges(
         Config.Stack stack,
         int maxBatchSize,


### PR DESCRIPTION
Introduces `IStackActions` and moves `StackHelpers.PullChanges` to improve the ability to test commands without needing to have a full Git repo. 

Part of a series of PRs:

<!-- stack-pr-list -->
- https://github.com/geofflamrock/stack/pull/323
- https://github.com/geofflamrock/stack/pull/326
  - https://github.com/geofflamrock/stack/pull/327
    - https://github.com/geofflamrock/stack/pull/328
      - https://github.com/geofflamrock/stack/pull/329
- https://github.com/geofflamrock/stack/pull/330
- https://github.com/geofflamrock/stack/pull/332
- https://github.com/geofflamrock/stack/pull/333
- https://github.com/geofflamrock/stack/pull/341
- https://github.com/geofflamrock/stack/pull/342
- https://github.com/geofflamrock/stack/pull/346
- https://github.com/geofflamrock/stack/pull/347
- https://github.com/geofflamrock/stack/pull/349
<!-- /stack-pr-list -->
