### PR TITLE
Move PushChanges to separate interface to improve testing

### DIFF
--- a/src/Stack.Tests/Commands/Helpers/StackActionsTests.cs
+++ b/src/Stack.Tests/Commands/Helpers/StackActionsTests.cs
@@ -81,4 +81,242 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         gitClient.Received().PullBranch(branchThatExistsInRemote);
         gitClient.DidNotReceive().PullBranch(branchThatDoesNotExistInRemote);
     }
+
+    [Fact]
+    public void PushChanges_WhenSomeLocalBranchesAreAhead_OnlyPushesChangesForBranchesThatAreAhead()
+    {
+        // Arrange
+        var sourceBranch = Some.BranchName();
+        var branchAheadOfRemote = Some.BranchName();
+        var branchNotAheadOfRemote = Some.BranchName();
+
+        var gitClient = Substitute.For<IGitClient>();
+
+        var branchStatus = new Dictionary<string, GitBranchStatus>
+        {
+            { sourceBranch, new GitBranchStatus(sourceBranch, $"origin/{sourceBranch}", true, false, 0, 0, new Commit(Some.Sha(), Some.Name())) },
+            { branchAheadOfRemote, new GitBranchStatus(branchAheadOfRemote, $"origin/{branchAheadOfRemote}", true, false, 3, 0, new Commit(Some.Sha(), Some.Name())) },
+            { branchNotAheadOfRemote, new GitBranchStatus(branchNotAheadOfRemote, $"origin/{branchNotAheadOfRemote}", true, false, 0, 0, new Commit(Some.Sha(), Some.Name())) }
+        };
+
+        gitClient.GetBranchStatuses(Arg.Any<string[]>()).Returns(branchStatus);
+
+        var branchesPushedToRemote = new List<string>();
+
+        gitClient
+            .WhenForAnyArgs(g => g.PushBranches(Arg.Any<string[]>(), Arg.Any<bool>()))
+            .Do((c) => branchesPushedToRemote.AddRange(c.Arg<string[]>()));
+
+        var stack = new TestStackBuilder()
+            .WithSourceBranch(sourceBranch)
+            .WithBranch(b => b.WithName(branchAheadOfRemote))
+            .WithBranch(b => b.WithName(branchNotAheadOfRemote))
+            .Build();
+
+        var stackActions = new StackActions(gitClient, new TestLogger(testOutputHelper));
+
+        // Act
+        stackActions.PushChanges(stack, 5, false);
+
+        // Assert
+        branchesPushedToRemote.ToArray().Should().BeEquivalentTo([branchAheadOfRemote]);
+    }
+
+    [Fact]
+    public void PushChanges_WhenSomeBranchesDoNotExistInRemote_OnlyPushesBranchesThatExistInRemote()
+    {
+        // Arrange
+        var sourceBranch = Some.BranchName();
+        var branchThatExistsInRemoteAndIsAhead = Some.BranchName();
+        var branchThatDoesNotExistInRemoteButIsAhead = Some.BranchName();
+
+        var gitClient = Substitute.For<IGitClient>();
+
+        var branchStatus = new Dictionary<string, GitBranchStatus>
+        {
+            { sourceBranch, new GitBranchStatus(sourceBranch, $"origin/{sourceBranch}", true, false, 0, 0, new Commit(Some.Sha(), Some.Name())) },
+            { branchThatExistsInRemoteAndIsAhead, new GitBranchStatus(branchThatExistsInRemoteAndIsAhead, $"origin/{branchThatExistsInRemoteAndIsAhead}", true, false, 2, 0, new Commit(Some.Sha(), Some.Name())) },
+            { branchThatDoesNotExistInRemoteButIsAhead, new GitBranchStatus(branchThatDoesNotExistInRemoteButIsAhead, $"origin/{branchThatDoesNotExistInRemoteButIsAhead}", false, false, 2, 0, new Commit(Some.Sha(), Some.Name())) }
+        };
+
+        gitClient.GetBranchStatuses(Arg.Any<string[]>()).Returns(branchStatus);
+
+        var branchesPushedToRemote = new List<string>();
+
+        gitClient
+            .WhenForAnyArgs(g => g.PushBranches(Arg.Any<string[]>(), Arg.Any<bool>()))
+            .Do((c) => branchesPushedToRemote.AddRange(c.Arg<string[]>()));
+
+        var stack = new TestStackBuilder()
+            .WithSourceBranch(sourceBranch)
+            .WithBranch(b => b.WithName(branchThatExistsInRemoteAndIsAhead))
+            .WithBranch(b => b.WithName(branchThatDoesNotExistInRemoteButIsAhead))
+            .Build();
+
+        var stackActions = new StackActions(gitClient, new TestLogger(testOutputHelper));
+
+        // Act
+        stackActions.PushChanges(stack, 5, false);
+
+        // Assert
+        branchesPushedToRemote.ToArray().Should().BeEquivalentTo([branchThatExistsInRemoteAndIsAhead]);
+    }
+
+    [Fact]
+    public void PushChanges_WhenSomeBranchesHaveNoRemoteTrackingBranch_PushesThemAsNewBranches()
+    {
+        // Arrange
+        var sourceBranch = Some.BranchName();
+        var existingBranchAhead = Some.BranchName();
+        var newBranchWithNoRemote = Some.BranchName();
+
+        var gitClient = Substitute.For<IGitClient>();
+
+        var branchStatus = new Dictionary<string, GitBranchStatus>
+        {
+            { sourceBranch, new GitBranchStatus(sourceBranch, $"origin/{sourceBranch}", true, false, 0, 0, new Commit(Some.Sha(), Some.Name())) },
+            { existingBranchAhead, new GitBranchStatus(existingBranchAhead, $"origin/{existingBranchAhead}", true, false, 2, 0, new Commit(Some.Sha(), Some.Name())) },
+            { newBranchWithNoRemote, new GitBranchStatus(newBranchWithNoRemote, null, false, false, 0, 0, new Commit(Some.Sha(), Some.Name())) }
+        };
+
+        gitClient.GetBranchStatuses(Arg.Any<string[]>()).Returns(branchStatus);
+
+        var branchesPushedToRemote = new List<string>();
+        var newBranchesPushed = new List<string>();
+
+        gitClient
+            .WhenForAnyArgs(g => g.PushBranches(Arg.Any<string[]>(), Arg.Any<bool>()))
+            .Do((c) => branchesPushedToRemote.AddRange(c.Arg<string[]>()));
+
+        gitClient
+            .WhenForAnyArgs(g => g.PushNewBranch(Arg.Any<string>()))
+            .Do((c) => newBranchesPushed.Add(c.Arg<string>()));
+
+        var stack = new TestStackBuilder()
+            .WithSourceBranch(sourceBranch)
+            .WithBranch(b => b.WithName(existingBranchAhead))
+            .WithBranch(b => b.WithName(newBranchWithNoRemote))
+            .Build();
+
+        var stackActions = new StackActions(gitClient, new TestLogger(testOutputHelper));
+
+        // Act
+        stackActions.PushChanges(stack, 5, false);
+
+        // Assert
+        newBranchesPushed.Should().BeEquivalentTo([newBranchWithNoRemote]);
+        branchesPushedToRemote.Should().BeEquivalentTo([existingBranchAhead]);
+    }
+
+    [Fact]
+    public void PushChanges_WhenMaxBatchSizeIsSmaller_PushesBranchesInMultipleBatches()
+    {
+        // Arrange
+        var sourceBranch = Some.BranchName();
+        var branch1 = Some.BranchName();
+        var branch2 = Some.BranchName();
+        var branch3 = Some.BranchName();
+
+        var gitClient = Substitute.For<IGitClient>();
+
+        var branchStatus = new Dictionary<string, GitBranchStatus>
+        {
+            { sourceBranch, new GitBranchStatus(sourceBranch, $"origin/{sourceBranch}", true, false, 0, 0, new Commit(Some.Sha(), Some.Name())) },
+            { branch1, new GitBranchStatus(branch1, $"origin/{branch1}", true, false, 1, 0, new Commit(Some.Sha(), Some.Name())) },
+            { branch2, new GitBranchStatus(branch2, $"origin/{branch2}", true, false, 2, 0, new Commit(Some.Sha(), Some.Name())) },
+            { branch3, new GitBranchStatus(branch3, $"origin/{branch3}", true, false, 1, 0, new Commit(Some.Sha(), Some.Name())) }
+        };
+
+        gitClient.GetBranchStatuses(Arg.Any<string[]>()).Returns(branchStatus);
+
+        var pushCalls = new List<List<string>>();
+
+        gitClient
+            .WhenForAnyArgs(g => g.PushBranches(Arg.Any<string[]>(), Arg.Any<bool>()))
+            .Do((c) => pushCalls.Add(c.Arg<string[]>().ToList()));
+
+        var stack = new TestStackBuilder()
+            .WithSourceBranch(sourceBranch)
+            .WithBranch(b => b.WithName(branch1))
+            .WithBranch(b => b.WithName(branch2))
+            .WithBranch(b => b.WithName(branch3))
+            .Build();
+
+        var stackActions = new StackActions(gitClient, new TestLogger(testOutputHelper));
+
+        // Act
+        stackActions.PushChanges(stack, maxBatchSize: 2, forceWithLease: false);
+
+        // Assert
+        pushCalls.Should().HaveCount(2);
+        pushCalls[0].Should().HaveCount(2);
+        pushCalls[1].Should().HaveCount(1);
+        pushCalls.SelectMany(batch => batch).Should().BeEquivalentTo([branch1, branch2, branch3]);
+    }
+
+    [Fact]
+    public void PushChanges_WhenForceWithLeaseIsTrue_PassesForceWithLeaseParameterToPushBranches()
+    {
+        // Arrange
+        var sourceBranch = Some.BranchName();
+        var branchAhead = Some.BranchName();
+
+        var gitClient = Substitute.For<IGitClient>();
+
+        var branchStatus = new Dictionary<string, GitBranchStatus>
+        {
+            { sourceBranch, new GitBranchStatus(sourceBranch, $"origin/{sourceBranch}", true, false, 0, 0, new Commit(Some.Sha(), Some.Name())) },
+            { branchAhead, new GitBranchStatus(branchAhead, $"origin/{branchAhead}", true, false, 1, 0, new Commit(Some.Sha(), Some.Name())) }
+        };
+
+        gitClient.GetBranchStatuses(Arg.Any<string[]>()).Returns(branchStatus);
+
+        var stack = new TestStackBuilder()
+            .WithSourceBranch(sourceBranch)
+            .WithBranch(b => b.WithName(branchAhead))
+            .Build();
+
+        var stackActions = new StackActions(gitClient, new TestLogger(testOutputHelper));
+
+        // Act
+        stackActions.PushChanges(stack, maxBatchSize: 5, forceWithLease: true);
+
+        // Assert
+        gitClient.Received().PushBranches(Arg.Is<string[]>(branches => branches.Contains(branchAhead)), true);
+    }
+
+    [Fact]
+    public void PushChanges_WhenNoBranchesNeedToBePushed_DoesNotCallPushMethods()
+    {
+        // Arrange
+        var sourceBranch = Some.BranchName();
+        var branchUpToDate = Some.BranchName();
+        var branchBehind = Some.BranchName();
+
+        var gitClient = Substitute.For<IGitClient>();
+
+        var branchStatus = new Dictionary<string, GitBranchStatus>
+        {
+            { sourceBranch, new GitBranchStatus(sourceBranch, $"origin/{sourceBranch}", true, false, 0, 0, new Commit(Some.Sha(), Some.Name())) },
+            { branchUpToDate, new GitBranchStatus(branchUpToDate, $"origin/{branchUpToDate}", true, false, 0, 0, new Commit(Some.Sha(), Some.Name())) },
+            { branchBehind, new GitBranchStatus(branchBehind, $"origin/{branchBehind}", true, false, 0, 2, new Commit(Some.Sha(), Some.Name())) }
+        };
+
+        gitClient.GetBranchStatuses(Arg.Any<string[]>()).Returns(branchStatus);
+
+        var stack = new TestStackBuilder()
+            .WithSourceBranch(sourceBranch)
+            .WithBranch(b => b.WithName(branchUpToDate))
+            .WithBranch(b => b.WithName(branchBehind))
+            .Build();
+
+        var stackActions = new StackActions(gitClient, new TestLogger(testOutputHelper));
+
+        // Act
+        stackActions.PushChanges(stack, maxBatchSize: 5, forceWithLease: false);
+
+        // Assert
+        gitClient.DidNotReceive().PushBranches(Arg.Any<string[]>(), Arg.Any<bool>());
+        gitClient.DidNotReceive().PushNewBranch(Arg.Any<string>());
+    }
 }

--- a/src/Stack.Tests/Commands/Remote/PushStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Remote/PushStackCommandHandlerTests.cs
@@ -16,39 +16,31 @@ public class PushStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
     public async Task WhenChangesExistLocally_TheyArePushedToTheRemote()
     {
         // Arrange
+        var remoteUri = Some.HttpsUri().ToString();
         var sourceBranch = Some.BranchName();
         var branch1 = Some.BranchName();
         var branch2 = Some.BranchName();
-        using var repo = new TestGitRepositoryBuilder()
-            .WithBranch(builder => builder.WithName(sourceBranch).PushToRemote())
-            .WithBranch(builder => builder.WithName(branch1).FromSourceBranch(sourceBranch).WithNumberOfEmptyCommits(10).PushToRemote())
-            .WithBranch(builder => builder.WithName(branch2).FromSourceBranch(branch1).WithNumberOfEmptyCommits(1).PushToRemote())
-            .WithNumberOfEmptyCommits(branch1, 3, false)
-            .WithNumberOfEmptyCommits(branch2, 2, false)
-            .Build();
-
-        var tipOfBranch1 = repo.GetTipOfBranch(branch1);
-        var tipOfBranch2 = repo.GetTipOfBranch(branch2);
-
-        repo.GetCommitsReachableFromRemoteBranch(branch1).Should().NotContain(tipOfBranch1);
-        repo.GetCommitsReachableFromRemoteBranch(branch2).Should().NotContain(tipOfBranch2);
+        var gitClient = Substitute.For<IGitClient>();
+        gitClient.GetRemoteUri().Returns(remoteUri);
+        gitClient.GetCurrentBranch().Returns(branch1);
 
         var stackConfig = new TestStackConfigBuilder()
             .WithStack(stack => stack
                 .WithName("Stack1")
-                .WithRemoteUri(repo.RemoteUri)
+                .WithRemoteUri(remoteUri)
                 .WithSourceBranch(sourceBranch)
                 .WithBranch(stackBranch => stackBranch.WithName(branch1))
                 .WithBranch(stackBranch => stackBranch.WithName(branch2)))
             .WithStack(stack => stack
                 .WithName("Stack2")
-                .WithRemoteUri(repo.RemoteUri)
+                .WithRemoteUri(remoteUri)
                 .WithSourceBranch(sourceBranch))
             .Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = new TestLogger(testOutputHelper);
-        var gitClient = new GitClient(logger, repo.GitClientSettings);
-        var handler = new PushStackCommandHandler(inputProvider, logger, gitClient, stackConfig);
+        var gitHubClient = Substitute.For<IGitHubClient>();
+        var stackActions = Substitute.For<IStackActions>();
+        var handler = new PushStackCommandHandler(inputProvider, logger, gitClient, stackConfig, stackActions);
 
         gitClient.ChangeBranch(branch1);
 
@@ -59,47 +51,38 @@ public class PushStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         await handler.Handle(PushStackCommandInputs.Default);
 
         // Assert
-        repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfBranch1);
-        repo.GetCommitsReachableFromRemoteBranch(branch2).Should().Contain(tipOfBranch2);
+        stackActions.Received(1).PushChanges(Arg.Is<Config.Stack>(s => s.Name == "Stack1"), 5, false);
     }
 
     [Fact]
     public async Task WhenNameIsProvided_DoesNotAskForName_PushesChangesToRemoteForBranchesInStack()
     {
         // Arrange
+        var remoteUri = Some.HttpsUri().ToString();
         var sourceBranch = Some.BranchName();
         var branch1 = Some.BranchName();
         var branch2 = Some.BranchName();
-        using var repo = new TestGitRepositoryBuilder()
-            .WithBranch(builder => builder.WithName(sourceBranch).PushToRemote())
-            .WithBranch(builder => builder.WithName(branch1).FromSourceBranch(sourceBranch).WithNumberOfEmptyCommits(10).PushToRemote())
-            .WithBranch(builder => builder.WithName(branch2).FromSourceBranch(branch1).WithNumberOfEmptyCommits(1).PushToRemote())
-            .WithNumberOfEmptyCommits(branch1, 3, false)
-            .WithNumberOfEmptyCommits(branch2, 2, false)
-            .Build();
-
-        var tipOfBranch1 = repo.GetTipOfBranch(branch1);
-        var tipOfBranch2 = repo.GetTipOfBranch(branch2);
-
-        repo.GetCommitsReachableFromRemoteBranch(branch1).Should().NotContain(tipOfBranch1);
-        repo.GetCommitsReachableFromRemoteBranch(branch2).Should().NotContain(tipOfBranch2);
+        var gitClient = Substitute.For<IGitClient>();
+        gitClient.GetRemoteUri().Returns(remoteUri);
+        gitClient.GetCurrentBranch().Returns(branch1);
 
         var stackConfig = new TestStackConfigBuilder()
             .WithStack(stack => stack
                 .WithName("Stack1")
-                .WithRemoteUri(repo.RemoteUri)
+                .WithRemoteUri(remoteUri)
                 .WithSourceBranch(sourceBranch)
                 .WithBranch(stackBranch => stackBranch.WithName(branch1))
                 .WithBranch(stackBranch => stackBranch.WithName(branch2)))
             .WithStack(stack => stack
                 .WithName("Stack2")
-                .WithRemoteUri(repo.RemoteUri)
+                .WithRemoteUri(remoteUri)
                 .WithSourceBranch(sourceBranch))
             .Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = new TestLogger(testOutputHelper);
-        var gitClient = new GitClient(logger, repo.GitClientSettings);
-        var handler = new PushStackCommandHandler(inputProvider, logger, gitClient, stackConfig);
+        var gitHubClient = Substitute.For<IGitHubClient>();
+        var stackActions = Substitute.For<IStackActions>();
+        var handler = new PushStackCommandHandler(inputProvider, logger, gitClient, stackConfig, stackActions);
 
         gitClient.ChangeBranch(branch1);
 
@@ -110,8 +93,7 @@ public class PushStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         await handler.Handle(new PushStackCommandInputs("Stack1", 5, false));
 
         // Assert
-        repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfBranch1);
-        repo.GetCommitsReachableFromRemoteBranch(branch2).Should().Contain(tipOfBranch2);
+        stackActions.Received(1).PushChanges(Arg.Is<Config.Stack>(s => s.Name == "Stack1"), 5, false);
         inputProvider.DidNotReceive().Select(Questions.SelectStack, Arg.Any<string[]>());
     }
 
@@ -119,39 +101,31 @@ public class PushStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
     public async Task WhenNameIsProvided_ButStackDoesNotExist_Throws()
     {
         // Arrange
+        var remoteUri = Some.HttpsUri().ToString();
         var sourceBranch = Some.BranchName();
         var branch1 = Some.BranchName();
         var branch2 = Some.BranchName();
-        using var repo = new TestGitRepositoryBuilder()
-            .WithBranch(builder => builder.WithName(sourceBranch).PushToRemote())
-            .WithBranch(builder => builder.WithName(branch1).FromSourceBranch(sourceBranch).WithNumberOfEmptyCommits(10).PushToRemote())
-            .WithBranch(builder => builder.WithName(branch2).FromSourceBranch(branch1).WithNumberOfEmptyCommits(1).PushToRemote())
-            .WithNumberOfEmptyCommits(branch1, 3, false)
-            .WithNumberOfEmptyCommits(branch2, 2, false)
-            .Build();
-
-        var tipOfBranch1 = repo.GetTipOfBranch(branch1);
-        var tipOfBranch2 = repo.GetTipOfBranch(branch2);
-
-        repo.GetCommitsReachableFromRemoteBranch(branch1).Should().NotContain(tipOfBranch1);
-        repo.GetCommitsReachableFromRemoteBranch(branch2).Should().NotContain(tipOfBranch2);
+        var gitClient = Substitute.For<IGitClient>();
+        gitClient.GetRemoteUri().Returns(remoteUri);
+        gitClient.GetCurrentBranch().Returns(branch1);
 
         var stackConfig = new TestStackConfigBuilder()
             .WithStack(stack => stack
                 .WithName("Stack1")
-                .WithRemoteUri(repo.RemoteUri)
+                .WithRemoteUri(remoteUri)
                 .WithSourceBranch(sourceBranch)
                 .WithBranch(stackBranch => stackBranch.WithName(branch1))
                 .WithBranch(stackBranch => stackBranch.WithName(branch2)))
             .WithStack(stack => stack
                 .WithName("Stack2")
-                .WithRemoteUri(repo.RemoteUri)
+                .WithRemoteUri(remoteUri)
                 .WithSourceBranch(sourceBranch))
             .Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = new TestLogger(testOutputHelper);
-        var gitClient = new GitClient(logger, repo.GitClientSettings);
-        var handler = new PushStackCommandHandler(inputProvider, logger, gitClient, stackConfig);
+        var gitHubClient = Substitute.For<IGitHubClient>();
+        var stackActions = Substitute.For<IStackActions>();
+        var handler = new PushStackCommandHandler(inputProvider, logger, gitClient, stackConfig, stackActions);
 
         gitClient.ChangeBranch(branch1);
 
@@ -166,92 +140,34 @@ public class PushStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    public async Task WhenChangesExistLocally_ForABranchThatIsNotInTheStack_TheyAreNotPushedToTheRemote()
-    {
-        // Arrange
-        var sourceBranch = Some.BranchName();
-        var branch1 = Some.BranchName();
-        var branch2 = Some.BranchName();
-        using var repo = new TestGitRepositoryBuilder()
-            .WithBranch(builder => builder.WithName(sourceBranch).PushToRemote())
-            .WithBranch(builder => builder.WithName(branch1).FromSourceBranch(sourceBranch).WithNumberOfEmptyCommits(10).PushToRemote())
-            .WithBranch(builder => builder.WithName(branch2).FromSourceBranch(branch1).WithNumberOfEmptyCommits(1).PushToRemote())
-            .WithNumberOfEmptyCommits(branch1, 3, false)
-            .WithNumberOfEmptyCommits(branch2, 2, false)
-            .Build();
-
-        var tipOfBranch1 = repo.GetTipOfBranch(branch1);
-        var tipOfBranch2 = repo.GetTipOfBranch(branch2);
-
-        repo.GetCommitsReachableFromRemoteBranch(branch1).Should().NotContain(tipOfBranch1);
-        repo.GetCommitsReachableFromRemoteBranch(branch2).Should().NotContain(tipOfBranch2);
-
-        var stackConfig = new TestStackConfigBuilder()
-            .WithStack(stack => stack
-                .WithName("Stack1")
-                .WithRemoteUri(repo.RemoteUri)
-                .WithSourceBranch(sourceBranch)
-                .WithBranch(stackBranch => stackBranch.WithName(branch1)))
-            .WithStack(stack => stack
-                .WithName("Stack2")
-                .WithRemoteUri(repo.RemoteUri)
-                .WithSourceBranch(sourceBranch)
-                .WithBranch(stackBranch => stackBranch.WithName(branch2)))
-            .Build();
-        var inputProvider = Substitute.For<IInputProvider>();
-        var logger = new TestLogger(testOutputHelper);
-        var gitClient = new GitClient(logger, repo.GitClientSettings);
-        var handler = new PushStackCommandHandler(inputProvider, logger, gitClient, stackConfig);
-
-        gitClient.ChangeBranch(branch1);
-
-
-        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
-
-        // Act
-        await handler.Handle(PushStackCommandInputs.Default);
-
-        // Assert
-        repo.GetCommitsReachableFromRemoteBranch(branch2).Should().NotContain(tipOfBranch2);
-    }
-
-    [Fact]
     public async Task WhenNumberOfBranchesIsGreaterThanMaxBatchSize_ChangesAreSuccessfullyPushedToTheRemoteInBatches()
     {
         // Arrange
+        var remoteUri = Some.HttpsUri().ToString();
         var sourceBranch = Some.BranchName();
         var branch1 = Some.BranchName();
         var branch2 = Some.BranchName();
-        using var repo = new TestGitRepositoryBuilder()
-            .WithBranch(builder => builder.WithName(sourceBranch).PushToRemote())
-            .WithBranch(builder => builder.WithName(branch1).FromSourceBranch(sourceBranch).WithNumberOfEmptyCommits(10).PushToRemote())
-            .WithBranch(builder => builder.WithName(branch2).FromSourceBranch(branch1).WithNumberOfEmptyCommits(1).PushToRemote())
-            .WithNumberOfEmptyCommits(branch1, 3, false)
-            .WithNumberOfEmptyCommits(branch2, 2, false)
-            .Build();
-
-        var tipOfBranch1 = repo.GetTipOfBranch(branch1);
-        var tipOfBranch2 = repo.GetTipOfBranch(branch2);
-
-        repo.GetCommitsReachableFromRemoteBranch(branch1).Should().NotContain(tipOfBranch1);
-        repo.GetCommitsReachableFromRemoteBranch(branch2).Should().NotContain(tipOfBranch2);
+        var gitClient = Substitute.For<IGitClient>();
+        gitClient.GetRemoteUri().Returns(remoteUri);
+        gitClient.GetCurrentBranch().Returns(branch1);
 
         var stackConfig = new TestStackConfigBuilder()
             .WithStack(stack => stack
                 .WithName("Stack1")
-                .WithRemoteUri(repo.RemoteUri)
+                .WithRemoteUri(remoteUri)
                 .WithSourceBranch(sourceBranch)
                 .WithBranch(stackBranch => stackBranch.WithName(branch1))
                 .WithBranch(stackBranch => stackBranch.WithName(branch2)))
             .WithStack(stack => stack
                 .WithName("Stack2")
-                .WithRemoteUri(repo.RemoteUri)
+                .WithRemoteUri(remoteUri)
                 .WithSourceBranch(sourceBranch))
             .Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = new TestLogger(testOutputHelper);
-        var gitClient = new GitClient(logger, repo.GitClientSettings);
-        var handler = new PushStackCommandHandler(inputProvider, logger, gitClient, stackConfig);
+        var gitHubClient = Substitute.For<IGitHubClient>();
+        var stackActions = Substitute.For<IStackActions>();
+        var handler = new PushStackCommandHandler(inputProvider, logger, gitClient, stackConfig, stackActions);
 
         gitClient.ChangeBranch(branch1);
 
@@ -262,58 +178,7 @@ public class PushStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         await handler.Handle(new PushStackCommandInputs(null, 1, false));
 
         // Assert
-        repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfBranch1);
-        repo.GetCommitsReachableFromRemoteBranch(branch2).Should().Contain(tipOfBranch2);
-    }
-
-    [Fact]
-    public async Task WhenBranchDoesNotExistOnRemote_ItIsPushedToTheRemote()
-    {
-        // Arrange
-        var sourceBranch = Some.BranchName();
-        var branch1 = Some.BranchName();
-        var branch2 = Some.BranchName();
-        using var repo = new TestGitRepositoryBuilder()
-            .WithBranch(builder => builder.WithName(sourceBranch).PushToRemote())
-            .WithBranch(builder => builder.WithName(branch1).FromSourceBranch(sourceBranch).WithNumberOfEmptyCommits(10).PushToRemote())
-            .WithBranch(builder => builder.WithName(branch2).FromSourceBranch(branch1).WithNumberOfEmptyCommits(1))
-            .WithNumberOfEmptyCommits(branch1, 3, false)
-            .WithNumberOfEmptyCommits(branch2, 2, false)
-            .Build();
-
-        var tipOfBranch1 = repo.GetTipOfBranch(branch1);
-        var tipOfBranch2 = repo.GetTipOfBranch(branch2);
-
-        repo.GetCommitsReachableFromRemoteBranch(branch1).Should().NotContain(tipOfBranch1);
-
-        var stackConfig = new TestStackConfigBuilder()
-            .WithStack(stack => stack
-                .WithName("Stack1")
-                .WithRemoteUri(repo.RemoteUri)
-                .WithSourceBranch(sourceBranch)
-                .WithBranch(stackBranch => stackBranch.WithName(branch1))
-                .WithBranch(stackBranch => stackBranch.WithName(branch2)))
-            .WithStack(stack => stack
-                .WithName("Stack2")
-                .WithRemoteUri(repo.RemoteUri)
-                .WithSourceBranch(sourceBranch))
-            .Build();
-        var inputProvider = Substitute.For<IInputProvider>();
-        var logger = new TestLogger(testOutputHelper);
-        var gitClient = new GitClient(logger, repo.GitClientSettings);
-        var handler = new PushStackCommandHandler(inputProvider, logger, gitClient, stackConfig);
-
-        gitClient.ChangeBranch(branch1);
-
-
-        inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>()).Returns("Stack1");
-
-        // Act
-        await handler.Handle(PushStackCommandInputs.Default);
-
-        // Assert
-        repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfBranch1);
-        repo.GetCommitsReachableFromRemoteBranch(branch2).Should().Contain(tipOfBranch2);
+        stackActions.Received(1).PushChanges(Arg.Is<Config.Stack>(s => s.Name == "Stack1"), 1, false);
     }
 
     [Fact]
@@ -352,7 +217,9 @@ public class PushStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = new TestLogger(testOutputHelper);
         var gitClient = new GitClient(logger, repo.GitClientSettings);
-        var handler = new PushStackCommandHandler(inputProvider, logger, gitClient, stackConfig);
+        var gitHubClient = Substitute.For<IGitHubClient>();
+        var stackActions = Substitute.For<IStackActions>();
+        var handler = new PushStackCommandHandler(inputProvider, logger, gitClient, stackConfig, stackActions);
 
         gitClient.ChangeBranch(branch1);
 
@@ -363,7 +230,6 @@ public class PushStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         await handler.Handle(new PushStackCommandInputs(null, 5, true));
 
         // Assert
-        repo.GetCommitsReachableFromRemoteBranch(branch1).Should().Contain(tipOfBranch1);
-        repo.GetCommitsReachableFromRemoteBranch(branch2).Should().Contain(tipOfBranch2);
+        stackActions.Received(1).PushChanges(Arg.Is<Config.Stack>(s => s.Name == "Stack1"), 5, true);
     }
 }

--- a/src/Stack/Commands/Helpers/StackActions.cs
+++ b/src/Stack/Commands/Helpers/StackActions.cs
@@ -7,6 +7,7 @@ namespace Stack.Commands.Helpers
     public interface IStackActions
     {
         void PullChanges(Config.Stack stack);
+        void PushChanges(Config.Stack stack, int maxBatchSize, bool forceWithLease);
     }
 
     public class StackActions(IGitClient gitClient, ILogger logger) : IStackActions
@@ -25,6 +26,43 @@ namespace Stack.Commands.Helpers
                 logger.Information($"Pulling changes for {branch.Branch()} from remote");
                 gitClient.ChangeBranch(branch);
                 gitClient.PullBranch(branch);
+            }
+        }
+
+        public void PushChanges(
+            Config.Stack stack,
+            int maxBatchSize,
+            bool forceWithLease)
+        {
+            var branchStatus = gitClient.GetBranchStatuses([.. stack.AllBranchNames]);
+
+            var branchesThatHaveNotBeenPushedToRemote = branchStatus
+                .Where(b => b.Value.RemoteTrackingBranchName is null)
+                .Select(b => b.Value.BranchName)
+                .ToList();
+
+            foreach (var branch in branchesThatHaveNotBeenPushedToRemote)
+            {
+                logger.Information($"Pushing new branch {branch.Branch()} to remote");
+                gitClient.PushNewBranch(branch);
+            }
+
+            var branchesThatAreAheadOfTheRemote = branchStatus
+                .Where(b => b.Value.RemoteBranchExists && b.Value.Ahead > 0)
+                .Select(b => b.Value.BranchName)
+                .ToList();
+
+            var branchGroupsToPush = branchesThatAreAheadOfTheRemote
+                .Select((b, i) => new { Index = i, Value = b })
+                .GroupBy(b => b.Index / maxBatchSize)
+                .Select(g => g.Select(b => b.Value).ToList())
+                .ToList();
+
+            foreach (var branches in branchGroupsToPush)
+            {
+                logger.Information($"Pushing changes for {string.Join(", ", branches.Select(b => b.Branch()))} to remote");
+
+                gitClient.PushBranches([.. branches], forceWithLease);
             }
         }
     }

--- a/src/Stack/Commands/Helpers/StackHelpers.cs
+++ b/src/Stack/Commands/Helpers/StackHelpers.cs
@@ -587,45 +587,6 @@ public static class StackHelpers
         }
     }
 
-    public static void PushChanges(
-        Config.Stack stack,
-        int maxBatchSize,
-        bool forceWithLease,
-        IGitClient gitClient,
-        ILogger logger)
-    {
-        var branchStatus = gitClient.GetBranchStatuses([.. stack.AllBranchNames]);
-
-        var branchesThatHaveNotBeenPushedToRemote = branchStatus
-            .Where(b => b.Value.RemoteTrackingBranchName is null)
-            .Select(b => b.Value.BranchName)
-            .ToList();
-
-        foreach (var branch in branchesThatHaveNotBeenPushedToRemote)
-        {
-            logger.Information($"Pushing new branch {branch.Branch()} to remote");
-            gitClient.PushNewBranch(branch);
-        }
-
-        var branchesThatAreAheadOfTheRemote = branchStatus
-            .Where(b => b.Value.RemoteBranchExists && b.Value.Ahead > 0)
-            .Select(b => b.Value.BranchName)
-            .ToList();
-
-        var branchGroupsToPush = branchesThatAreAheadOfTheRemote
-            .Select((b, i) => new { Index = i, Value = b })
-            .GroupBy(b => b.Index / maxBatchSize)
-            .Select(g => g.Select(b => b.Value).ToList())
-            .ToList();
-
-        foreach (var branches in branchGroupsToPush)
-        {
-            logger.Information($"Pushing changes for {string.Join(", ", branches.Select(b => b.Branch()))} to remote");
-
-            gitClient.PushBranches([.. branches], forceWithLease);
-        }
-    }
-
     public static string[] GetBranchesNeedingCleanup(Config.Stack stack, ILogger logger, IGitClient gitClient, IGitHubClient gitHubClient)
     {
         var currentBranch = gitClient.GetCurrentBranch();

--- a/src/Stack/Commands/Remote/SyncStackCommand.cs
+++ b/src/Stack/Commands/Remote/SyncStackCommand.cs
@@ -120,7 +120,7 @@ public class SyncStackCommandHandler(
             var forceWithLease = updateStrategy == UpdateStrategy.Rebase;
 
             if (!inputs.NoPush)
-                StackHelpers.PushChanges(stack, inputs.MaxBatchSize, forceWithLease, gitClient, logger);
+                stackActions.PushChanges(stack, inputs.MaxBatchSize, forceWithLease);
 
             if (stack.SourceBranch.Equals(currentBranch, StringComparison.InvariantCultureIgnoreCase) ||
                 stack.AllBranchNames.Contains(currentBranch, StringComparer.OrdinalIgnoreCase))


### PR DESCRIPTION
Moves `StackHelpers.PushChanges` into `StackActions` to improve the ability to test commands without needing to have a full Git repo. 

Part of a series of PRs:

<!-- stack-pr-list -->
- https://github.com/geofflamrock/stack/pull/323
- https://github.com/geofflamrock/stack/pull/326
  - https://github.com/geofflamrock/stack/pull/327
    - https://github.com/geofflamrock/stack/pull/328
      - https://github.com/geofflamrock/stack/pull/329
- https://github.com/geofflamrock/stack/pull/330
- https://github.com/geofflamrock/stack/pull/332
- https://github.com/geofflamrock/stack/pull/333
- https://github.com/geofflamrock/stack/pull/341
- https://github.com/geofflamrock/stack/pull/342
- https://github.com/geofflamrock/stack/pull/346
- https://github.com/geofflamrock/stack/pull/347
- https://github.com/geofflamrock/stack/pull/349
<!-- /stack-pr-list -->
