### PR TITLE
Cache GitHub pull requests to improve performance

### DIFF
--- a/src/Stack.Tests/Git/CachingGitHubClientTests.cs
+++ b/src/Stack.Tests/Git/CachingGitHubClientTests.cs
@@ -1,0 +1,105 @@
+using System;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using NSubstitute;
+using Stack.Git;
+
+namespace Stack.Tests.Git;
+
+public class CachingGitHubClientTests
+{
+    [Fact]
+    public void GetPullRequest_WhenPullRequestExistsForBranch_CachesPullRequest()
+    {
+        var pr = new GitHubPullRequest(
+            Number: 123,
+            Title: "Test PR",
+            Body: "Body",
+            State: GitHubPullRequestStates.Open,
+            Url: new Uri("https://example.com/pr/123"),
+            IsDraft: false,
+            HeadRefName: "feature/test");
+
+        var inner = Substitute.For<IGitHubClient>();
+        inner.GetPullRequest("feature/test").Returns(pr);
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var sut = new CachingGitHubClient(inner, cache);
+
+        var first = sut.GetPullRequest("feature/test");
+        var second = sut.GetPullRequest("feature/test");
+
+        first.Should().BeSameAs(pr);
+        second.Should().BeSameAs(pr);
+        inner.Received(1).GetPullRequest("feature/test");
+    }
+
+    [Fact]
+    public void GetPullRequest_WhenNoPullRequestExistsForBranch_CachesNull()
+    {
+        var inner = Substitute.For<IGitHubClient>();
+        inner.GetPullRequest("missing").Returns((GitHubPullRequest?)null);
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var sut = new CachingGitHubClient(inner, cache);
+
+        sut.GetPullRequest("missing").Should().BeNull();
+        sut.GetPullRequest("missing").Should().BeNull();
+        inner.Received(1).GetPullRequest("missing");
+    }
+
+    [Fact]
+    public void CreatePullRequest_CachesTheCreatedPullRequestUsingTheHeadBranch()
+    {
+        var createdPr = new GitHubPullRequest(
+            Number: 123,
+            Title: "Test PR",
+            Body: "Body",
+            State: GitHubPullRequestStates.Open,
+            Url: new Uri("https://example.com/pr/123"),
+            IsDraft: false,
+            HeadRefName: "feature/test");
+
+        var inner = Substitute.For<IGitHubClient>();
+        inner.CreatePullRequest("feature/test", "main", "title", "body.md", false).Returns(createdPr);
+        inner.GetPullRequest("feature/test").Returns(null as GitHubPullRequest);
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var sut = new CachingGitHubClient(inner, cache);
+
+        // prime cache with null
+        sut.GetPullRequest("feature/test").Should().BeNull();
+
+        // create PR should update cache
+        var pr = sut.CreatePullRequest("feature/test", "main", "title", "body.md", false);
+        pr.Should().BeSameAs(createdPr);
+
+        sut.GetPullRequest("feature/test").Should().BeSameAs(createdPr);
+        inner.Received(1).GetPullRequest("feature/test"); // only initial null fetch
+        inner.Received(1).CreatePullRequest("feature/test", "main", "title", "body.md", false);
+    }
+
+    [Fact]
+    public void EditPullRequest_InvalidatesCacheEntryForBranch()
+    {
+        var pr = new GitHubPullRequest(
+            Number: 123,
+            Title: "Test PR",
+            Body: "Body",
+            State: GitHubPullRequestStates.Open,
+            Url: new Uri("https://example.com/pr/123"),
+            IsDraft: false,
+            HeadRefName: "feature/test");
+
+        var inner = Substitute.For<IGitHubClient>();
+        inner.GetPullRequest("feature/test").Returns(pr);
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var sut = new CachingGitHubClient(inner, cache);
+
+        var cachedPullRequest = sut.GetPullRequest("feature/test");
+        cachedPullRequest.Should().BeSameAs(pr);
+        inner.EditPullRequest(pr, "new body").Returns(pr with { Body = "new body" });
+
+        var updatedPr = sut.EditPullRequest(pr, "new body");
+
+        var afterEdit = sut.GetPullRequest("feature/test");
+        afterEdit?.Body.Should().Be(updatedPr.Body);
+    }
+}

--- a/src/Stack.Tests/Helpers/TestGitHubRepositoryBuilder.cs
+++ b/src/Stack.Tests/Helpers/TestGitHubRepositoryBuilder.cs
@@ -78,15 +78,16 @@ public class TestGitHubRepository(Dictionary<string, GitHubPullRequest> PullRequ
         return pr;
     }
 
-    public void EditPullRequest(int number, string body)
+    public GitHubPullRequest EditPullRequest(GitHubPullRequest pullRequest, string body)
     {
-        if (!PullRequests.Any(pr => pr.Value.Number == number))
+        if (!PullRequests.Any(pr => pr.Value.Number == pullRequest.Number))
         {
             throw new InvalidOperationException("Pull request not found.");
         }
 
-        var pr = PullRequests.First(p => p.Value.Number == number);
+        var pr = PullRequests.First(p => p.Value.Number == pullRequest.Number);
         PullRequests[pr.Key] = pr.Value with { Body = body };
+        return PullRequests[pr.Key];
     }
 
     public GitHubPullRequest? GetPullRequest(string branch)

--- a/src/Stack/Commands/Helpers/StackHelpers.cs
+++ b/src/Stack/Commands/Helpers/StackHelpers.cs
@@ -689,7 +689,7 @@ public static class StackHelpers
 
                 logger.Information($"Updating pull request {pullRequest.GetPullRequestDisplay()} with stack details");
 
-                gitHubClient.EditPullRequest(pullRequest.Number, prBody);
+                gitHubClient.EditPullRequest(pullRequest, prBody);
             }
         }
     }

--- a/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
+++ b/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
@@ -21,7 +21,7 @@ public class CreatePullRequestsCommand : Command
             InputProvider,
             StdErrLogger,
             new GitClient(StdErrLogger, new GitClientSettings(Verbose, WorkingDirectory)),
-            new GitHubClient(StdErrLogger, new GitHubClientSettings(Verbose, WorkingDirectory)),
+            new CachingGitHubClient(new GitHubClient(StdErrLogger, new GitHubClientSettings(Verbose, WorkingDirectory))),
             new FileOperations(),
             new FileStackConfig());
 

--- a/src/Stack/Commands/PullRequests/OpenPullRequestsCommand.cs
+++ b/src/Stack/Commands/PullRequests/OpenPullRequestsCommand.cs
@@ -19,7 +19,7 @@ public class OpenPullRequestsCommand : Command
             InputProvider,
             StdErrLogger,
             new GitClient(StdErrLogger, new GitClientSettings(Verbose, WorkingDirectory)),
-            new GitHubClient(StdErrLogger, new GitHubClientSettings(Verbose, WorkingDirectory)),
+            new CachingGitHubClient(new GitHubClient(StdErrLogger, new GitHubClientSettings(Verbose, WorkingDirectory))),
             new FileStackConfig());
 
         await handler.Handle(new OpenPullRequestsCommandInputs(

--- a/src/Stack/Commands/Remote/SyncStackCommand.cs
+++ b/src/Stack/Commands/Remote/SyncStackCommand.cs
@@ -26,7 +26,7 @@ public class SyncStackCommand : Command
     protected override async Task Execute(ParseResult parseResult, CancellationToken cancellationToken)
     {
         var gitClient = new GitClient(StdErrLogger, new GitClientSettings(Verbose, WorkingDirectory));
-        var gitHubClient = new GitHubClient(StdErrLogger, new GitHubClientSettings(Verbose, WorkingDirectory));
+        var gitHubClient = new CachingGitHubClient(new GitHubClient(StdErrLogger, new GitHubClientSettings(Verbose, WorkingDirectory)));
 
         var handler = new SyncStackCommandHandler(
             InputProvider,

--- a/src/Stack/Commands/Stack/CleanupStackCommand.cs
+++ b/src/Stack/Commands/Stack/CleanupStackCommand.cs
@@ -20,7 +20,7 @@ public class CleanupStackCommand : Command
             InputProvider,
             StdErrLogger,
             new GitClient(StdErrLogger, new GitClientSettings(Verbose, WorkingDirectory)),
-            new GitHubClient(StdErrLogger, new GitHubClientSettings(Verbose, WorkingDirectory)),
+            new CachingGitHubClient(new GitHubClient(StdErrLogger, new GitHubClientSettings(Verbose, WorkingDirectory))),
             new FileStackConfig());
 
         await handler.Handle(new CleanupStackCommandInputs(

--- a/src/Stack/Commands/Stack/DeleteStackCommand.cs
+++ b/src/Stack/Commands/Stack/DeleteStackCommand.cs
@@ -20,7 +20,7 @@ public class DeleteStackCommand : Command
             InputProvider,
             StdErrLogger,
             new GitClient(StdErrLogger, new GitClientSettings(Verbose, WorkingDirectory)),
-            new GitHubClient(StdErrLogger, new GitHubClientSettings(Verbose, WorkingDirectory)),
+            new CachingGitHubClient(new GitHubClient(StdErrLogger, new GitHubClientSettings(Verbose, WorkingDirectory))),
             new FileStackConfig());
 
         await handler.Handle(new DeleteStackCommandInputs(

--- a/src/Stack/Commands/Stack/StackStatusCommand.cs
+++ b/src/Stack/Commands/Stack/StackStatusCommand.cs
@@ -103,8 +103,8 @@ public class StackStatusCommand : CommandWithOutput<StackStatusCommandResponse>
         var handler = new StackStatusCommandHandler(
             InputProvider,
             StdErrLogger,
-            new GitClient(StdErrLogger, new GitClientSettings(Verbose, WorkingDirectory)),
-            new GitHubClient(StdErrLogger, new GitHubClientSettings(Verbose, WorkingDirectory)),
+                new GitClient(StdErrLogger, new GitClientSettings(Verbose, WorkingDirectory)),
+                new CachingGitHubClient(new GitHubClient(StdErrLogger, new GitHubClientSettings(Verbose, WorkingDirectory))),
             new FileStackConfig());
 
         return await handler.Handle(new StackStatusCommandInputs(

--- a/src/Stack/Commands/Stack/UpdateStackCommand.cs
+++ b/src/Stack/Commands/Stack/UpdateStackCommand.cs
@@ -18,7 +18,7 @@ public class UpdateStackCommand : Command
     protected override async Task Execute(ParseResult parseResult, CancellationToken cancellationToken)
     {
         var gitClient = new GitClient(StdErrLogger, new GitClientSettings(Verbose, WorkingDirectory));
-        var gitHubClient = new GitHubClient(StdErrLogger, new GitHubClientSettings(Verbose, WorkingDirectory));
+        var gitHubClient = new CachingGitHubClient(new GitHubClient(StdErrLogger, new GitHubClientSettings(Verbose, WorkingDirectory)));
 
         var handler = new UpdateStackCommandHandler(
             InputProvider,

--- a/src/Stack/Git/CachingGitHubClient.cs
+++ b/src/Stack/Git/CachingGitHubClient.cs
@@ -1,0 +1,52 @@
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Stack.Git;
+
+public class CachingGitHubClient : IGitHubClient
+{
+    readonly IGitHubClient inner;
+    readonly IMemoryCache cache;
+    readonly MemoryCacheEntryOptions cacheOptions;
+
+    public CachingGitHubClient(IGitHubClient inner, IMemoryCache? cache = null)
+    {
+        this.inner = inner;
+        this.cache = cache ?? new MemoryCache(new MemoryCacheOptions());
+        cacheOptions = new MemoryCacheEntryOptions();
+    }
+
+    public GitHubPullRequest? GetPullRequest(string branch)
+    {
+        var cacheKey = GetCacheKey(branch);
+        if (cache.TryGetValue(cacheKey, out GitHubPullRequest? cached))
+        {
+            // Cache null values if there is no PR as this isn't likely to change in the lifetime of a cli
+            return cached;
+        }
+
+        var pr = inner.GetPullRequest(branch);
+        cache.Set(cacheKey, pr, cacheOptions);
+        return pr;
+    }
+
+    public GitHubPullRequest CreatePullRequest(string headBranch, string baseBranch, string title, string bodyFilePath, bool draft)
+    {
+        var pr = inner.CreatePullRequest(headBranch, baseBranch, title, bodyFilePath, draft);
+        cache.Set(GetCacheKey(headBranch), pr, cacheOptions);
+        return pr;
+    }
+
+    public GitHubPullRequest EditPullRequest(GitHubPullRequest pullRequest, string body)
+    {
+        var updatedPullRequest = inner.EditPullRequest(pullRequest, body);
+        cache.Set(GetCacheKey(updatedPullRequest.HeadRefName), updatedPullRequest, cacheOptions);
+        return updatedPullRequest;
+    }
+
+    public void OpenPullRequest(GitHubPullRequest pullRequest)
+    {
+        inner.OpenPullRequest(pullRequest);
+    }
+
+    static string GetCacheKey(string branch) => $"pr:{branch}";
+}

--- a/src/Stack/Git/GitHubClient.cs
+++ b/src/Stack/Git/GitHubClient.cs
@@ -58,7 +58,7 @@ public interface IGitHubClient
         string title,
         string bodyFilePath,
         bool draft);
-    void EditPullRequest(int number, string body);
+    GitHubPullRequest EditPullRequest(GitHubPullRequest pullRequest, string body);
     void OpenPullRequest(GitHubPullRequest pullRequest);
 }
 
@@ -101,9 +101,10 @@ public class GitHubClient(ILogger logger, GitHubClientSettings settings) : IGitH
         return GetPullRequest(headBranch) ?? throw new Exception("Failed to create pull request.");
     }
 
-    public void EditPullRequest(int number, string body)
+    public GitHubPullRequest EditPullRequest(GitHubPullRequest pullRequest, string body)
     {
-        ExecuteGitHubCommand($"pr edit {number} --body \"{Sanitize(body)}\"");
+        ExecuteGitHubCommand($"pr edit {pullRequest.Number} --body \"{Sanitize(body)}\"");
+        return pullRequest with { Body = body };
     }
 
     public void OpenPullRequest(GitHubPullRequest pullRequest)

--- a/src/Stack/Stack.csproj
+++ b/src/Stack/Stack.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="morelinq" Version="4.4.0" />
     <PackageReference Include="Spectre.Console" Version="0.50.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta5.25306.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.8" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Adds caching of GitHub pull requests to improve performance during updating a stack.

## Details

The logic to update a stack got moved around in #328. A result of this is that we now get the status of a stack, including PRs multiple times, when syncing a stack (not updating) - once when we show the output and once to perform the update itself. This is to make the interface simpler for updating a stack.

I'm planning to change the way the underlying update works soon to not need to get a full status as we don't need the ahead/behind between branches to perform the update, we just need details like remote tracking branch and whether it exists, as well as the GitHub PR for cases when the remote branch doesn't get deleted. We'll probably still load the data multiple times but won't use the full status.

To avoid multiple requests to GitHub for pull requests, have added a caching implementation that decorates the inner one. 

## Background

<!-- stack-pr-list -->
- https://github.com/geofflamrock/stack/pull/323
- https://github.com/geofflamrock/stack/pull/326
  - https://github.com/geofflamrock/stack/pull/327
    - https://github.com/geofflamrock/stack/pull/328
      - https://github.com/geofflamrock/stack/pull/329
<!-- /stack-pr-list -->
