### PR TITLE
Remove support for different schema versions in commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Once you've done some work on the first branch within the stack, at some point y
 - Give the branch a name.
 - Select the branch to create the new branch from.
 
-The new branch will be created from the branch at the bottom of the stack and the current branch will be changed so you can make more changes.
+The new branch will be created from the selected parent branch and the current branch will be changed so you can make more changes.
 
 If a new branch was not able to be pushed to the remote, you can use the `stack push` command to push the branch to the remote later.
 

--- a/src/Stack.Tests/Config/FileStackConfigTests.cs
+++ b/src/Stack.Tests/Config/FileStackConfigTests.cs
@@ -23,7 +23,7 @@ public class FileStackConfigTests
         var stackData = fileStackConfig.Load();
 
         // Assert
-        stackData.Should().BeEquivalentTo(new StackData(SchemaVersion.V2, []));
+        stackData.Should().BeEquivalentTo(new StackData([]));
     }
 
     [Fact]
@@ -67,7 +67,7 @@ public class FileStackConfigTests
         var stackData = fileStackConfig.Load();
 
         // Assert
-        stackData.Should().BeEquivalentTo(new StackData(SchemaVersion.V2, [expectedStack]));
+        stackData.Should().BeEquivalentTo(new StackData([expectedStack]));
         var savedJson = File.ReadAllText(configPath);
         var expectedJson = $@"{{
     ""SchemaVersion"": 2,
@@ -162,62 +162,7 @@ public class FileStackConfigTests
         var stackData = fileStackConfig.Load();
 
         // Assert
-        stackData.Should().BeEquivalentTo(new StackData(SchemaVersion.V2, [expectedStack]));
-    }
-
-    [Fact]
-    public void Save_WhenConfigFileIsInV1Format_AndAllStacksHaveASingleTree_SavesCorrectlyInV1Format()
-    {
-        // Arrange
-        using var tempDirectory = TemporaryDirectory.Create();
-        var configPath = Path.Combine(tempDirectory.DirectoryPath, "stack", "config.json");
-        var stackName = Some.Name();
-        var remoteUri = Some.HttpsUri().ToString();
-        var sourceBranch = Some.BranchName();
-        var branch1 = Some.BranchName();
-        var branch2 = Some.BranchName();
-
-        // Create an empty config file
-        Directory.CreateDirectory(Path.GetDirectoryName(configPath)!);
-        File.WriteAllText(configPath, "[]");
-
-        // Create a Stack object with a simple tree structure that should be saved in V1 format
-        var stack = new Config.Stack(
-            stackName,
-            remoteUri,
-            sourceBranch,
-            [
-                new(branch1,
-                    [
-                        new(branch2, [])
-                    ])
-            ]);
-
-        // Act
-        var fileStackConfig = new FileStackConfig(tempDirectory.DirectoryPath);
-        fileStackConfig.Save(new StackData(SchemaVersion.V1, [stack]));
-
-        // Assert
-        var savedJson = File.ReadAllText(configPath);
-
-        // Format the expected JSON string with proper indentation
-        var expectedJson = $@"[
-    {{
-        ""Name"": ""{stackName}"",
-        ""RemoteUri"": ""{remoteUri}"",
-        ""SourceBranch"": ""{sourceBranch}"",
-        ""Branches"": [
-            ""{branch1}"",
-            ""{branch2}""
-        ]
-    }}
-]";
-
-        // Normalize both JSON strings to remove whitespace differences
-        var normalizedSavedJson = NormalizeJsonString(savedJson);
-        var normalizedExpectedJson = NormalizeJsonString(expectedJson);
-
-        normalizedSavedJson.Should().Be(normalizedExpectedJson);
+        stackData.Should().BeEquivalentTo(new StackData([expectedStack]));
     }
 
     [Fact]
@@ -258,7 +203,7 @@ public class FileStackConfigTests
         var fileStackConfig = new FileStackConfig(tempDirectory.DirectoryPath);
 
         // Act
-        fileStackConfig.Save(new StackData(SchemaVersion.V2, [stack]));
+        fileStackConfig.Save(new StackData([stack]));
 
         // Assert
         var savedJson = File.ReadAllText(configPath);

--- a/src/Stack.Tests/Helpers/TestStackConfigBuilder.cs
+++ b/src/Stack.Tests/Helpers/TestStackConfigBuilder.cs
@@ -7,7 +7,6 @@ namespace Stack.Tests.Helpers;
 public class TestStackConfigBuilder
 {
     readonly List<Action<TestStackBuilder>> stackBuilders = [];
-    SchemaVersion schemaVersion = SchemaVersion.V1;
 
     public TestStackConfigBuilder WithStack(Action<TestStackBuilder> stackBuilder)
     {
@@ -15,16 +14,10 @@ public class TestStackConfigBuilder
         return this;
     }
 
-    public TestStackConfigBuilder WithSchemaVersion(SchemaVersion version)
-    {
-        schemaVersion = version;
-        return this;
-    }
-
     public TestStackConfig Build()
     {
         return new TestStackConfig(
-            new StackData(schemaVersion, [.. stackBuilders.Select(builder =>
+            new StackData([.. stackBuilders.Select(builder =>
             {
                 var stackBuilder = new TestStackBuilder();
                 builder(stackBuilder);

--- a/src/Stack/Commands/Branch/AddBranchCommand.cs
+++ b/src/Stack/Commands/Branch/AddBranchCommand.cs
@@ -60,11 +60,6 @@ public class AddBranchCommandHandler(
             return;
         }
 
-        if (stackData.SchemaVersion == SchemaVersion.V1 && inputs.ParentBranchName is not null)
-        {
-            throw new InvalidOperationException("Parent branches are not supported in stacks with schema version v1. Please migrate the stack to v2 format.");
-        }
-
         var stack = inputProvider.SelectStack(logger, inputs.StackName, stacksForRemote, currentBranch);
 
         if (stack is null)
@@ -86,22 +81,14 @@ public class AddBranchCommandHandler(
 
         Branch? sourceBranch = null;
 
-        if (stackData.SchemaVersion == SchemaVersion.V1)
-        {
-            // In V1 schema there is only a single set of branches, we always add to the end.
-            sourceBranch = stack.GetAllBranches().LastOrDefault();
-        }
-        if (stackData.SchemaVersion == SchemaVersion.V2)
-        {
-            var parentBranchName = inputProvider.SelectParentBranch(logger, inputs.ParentBranchName, stack);
+        var parentBranchName = inputProvider.SelectParentBranch(logger, inputs.ParentBranchName, stack);
 
-            if (parentBranchName != stack.SourceBranch)
+        if (parentBranchName != stack.SourceBranch)
+        {
+            sourceBranch = stack.GetAllBranches().FirstOrDefault(b => b.Name.Equals(parentBranchName, StringComparison.OrdinalIgnoreCase));
+            if (sourceBranch is null)
             {
-                sourceBranch = stack.GetAllBranches().FirstOrDefault(b => b.Name.Equals(parentBranchName, StringComparison.OrdinalIgnoreCase));
-                if (sourceBranch is null)
-                {
-                    throw new InvalidOperationException($"Branch '{parentBranchName}' not found in stack '{stack.Name}'.");
-                }
+                throw new InvalidOperationException($"Branch '{parentBranchName}' not found in stack '{stack.Name}'.");
             }
         }
 

--- a/src/Stack/Commands/Branch/RemoveBranchCommand.cs
+++ b/src/Stack/Commands/Branch/RemoveBranchCommand.cs
@@ -87,17 +87,12 @@ public class RemoveBranchCommandHandler(
             throw new InvalidOperationException($"Branch '{branchName}' not found in stack '{stack.Name}'.");
         }
 
-        var action = RemoveBranchChildAction.MoveChildrenToParent;
-
-        if (stackData.SchemaVersion == SchemaVersion.V2)
-        {
-            action =
-                inputs.RemoveChildrenAction ??
-                inputProvider.Select(
-                    Questions.RemoveBranchChildAction,
-                    [RemoveBranchChildAction.MoveChildrenToParent, RemoveBranchChildAction.RemoveChildren],
-                    (action) => action.Humanize());
-        }
+        var action =
+            inputs.RemoveChildrenAction ??
+            inputProvider.Select(
+                Questions.RemoveBranchChildAction,
+                [RemoveBranchChildAction.MoveChildrenToParent, RemoveBranchChildAction.RemoveChildren],
+                (action) => action.Humanize());
 
         if (inputs.Confirm || inputProvider.Confirm(Questions.ConfirmRemoveBranch))
         {

--- a/src/Stack/Commands/Helpers/StackHelpers.cs
+++ b/src/Stack/Commands/Helpers/StackHelpers.cs
@@ -239,19 +239,17 @@ public static class StackHelpers
     }
 
     public static void OutputStackStatus(
-        SchemaVersion schemaVersion,
         List<StackStatus> statuses,
         ILogger logger)
     {
         foreach (var status in statuses)
         {
-            OutputStackStatus(schemaVersion, status, logger);
+            OutputStackStatus(status, logger);
             logger.NewLine();
         }
     }
 
     public static void OutputStackStatus(
-        SchemaVersion schemaVersion,
         StackStatus status,
         ILogger logger,
         Func<BranchDetail, string?>? getBranchPullRequestDisplay = null)
@@ -262,11 +260,6 @@ public static class StackHelpers
         foreach (var branch in status.Branches)
         {
             items.Add(GetBranchAndPullRequestStatusOutput(branch, getBranchPullRequestDisplay));
-        }
-
-        if (schemaVersion == SchemaVersion.V1 && items.Count > 0)
-        {
-            items = [.. MoreEnumerable.TraverseDepthFirst(items.First(), i => i.Children).Select(i => new TreeItem<string>(i.Value, []))];
         }
 
         logger.Information(status.Name.Stack());

--- a/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
+++ b/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
@@ -97,7 +97,7 @@ public class CreatePullRequestsCommandHandler(
             }
         }
 
-        StackHelpers.OutputStackStatus(stackData.SchemaVersion, status, logger);
+        StackHelpers.OutputStackStatus(status, logger);
 
         logger.NewLine();
 
@@ -128,7 +128,7 @@ public class CreatePullRequestsCommandHandler(
 
             logger.NewLine();
 
-            OutputUpdatedStackStatus(logger, stackData.SchemaVersion, stack, status, pullRequestInformation);
+            OutputUpdatedStackStatus(logger, stack, status, pullRequestInformation);
 
             logger.NewLine();
 
@@ -191,13 +191,11 @@ public class CreatePullRequestsCommandHandler(
 
     private static void OutputUpdatedStackStatus(
         ILogger logger,
-        SchemaVersion schemaVersion,
         Config.Stack stack,
         StackStatus status,
         List<PullRequestInformation> pullRequestInformation)
     {
         StackHelpers.OutputStackStatus(
-            schemaVersion,
             status,
             logger,
             (branch) =>

--- a/src/Stack/Commands/Remote/SyncStackCommand.cs
+++ b/src/Stack/Commands/Remote/SyncStackCommand.cs
@@ -101,7 +101,7 @@ public class SyncStackCommandHandler(
             gitHubClient,
             true);
 
-        StackHelpers.OutputStackStatus(stackData.SchemaVersion, status, logger);
+        StackHelpers.OutputStackStatus(status, logger);
 
         logger.NewLine();
 

--- a/src/Stack/Commands/Stack/StackStatusCommand.cs
+++ b/src/Stack/Commands/Stack/StackStatusCommand.cs
@@ -115,7 +115,7 @@ public class StackStatusCommand : CommandWithOutput<StackStatusCommandResponse>
 
     protected override void WriteDefaultOutput(StackStatusCommandResponse response)
     {
-        StackHelpers.OutputStackStatus(response.SchemaVersion, response.Stacks, StdOutLogger);
+        StackHelpers.OutputStackStatus(response.Stacks, StdOutLogger);
 
         if (response.Stacks.Count == 1)
         {
@@ -188,7 +188,7 @@ public class StackStatusCommand : CommandWithOutput<StackStatusCommandResponse>
 }
 
 public record StackStatusCommandInputs(string? Stack, bool All, bool Full);
-public record StackStatusCommandResponse(SchemaVersion SchemaVersion, List<StackStatus> Stacks);
+public record StackStatusCommandResponse(List<StackStatus> Stacks);
 
 public class StackStatusCommandHandler(
     IInputProvider inputProvider,
@@ -233,6 +233,6 @@ public class StackStatusCommandHandler(
             gitHubClient,
             inputs.Full);
 
-        return new StackStatusCommandResponse(stackData.SchemaVersion, stackStatusResults);
+        return new StackStatusCommandResponse(stackStatusResults);
     }
 }


### PR DESCRIPTION
Support for a [tree structure multiple branches in any level of a stack got added in `v0.12.0`](https://github.com/geofflamrock/stack/releases/tag/v0.12.0). As part of this there was a new v2 schema introduced with a command to migrate from v1 to v2. This allowed me to add all the support in stages. This is all done now and I've been using full tree support for some time and am ready to make it the only structure supported.

This PR removes all support for different schema versions in commands. Previously if the schema was v1 format some options and behaviours weren't supported as the structure only supported the tree structure from v2. 

<!-- stack-pr-list -->
- https://github.com/geofflamrock/stack/pull/343
- https://github.com/geofflamrock/stack/pull/344
  - https://github.com/geofflamrock/stack/pull/345
<!-- /stack-pr-list -->
