### PR TITLE
Fix default for creating PR as draft

### DIFF
--- a/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
+++ b/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
@@ -263,7 +263,7 @@ public class CreatePullRequestsCommandHandler(
 
 {StackConstants.StackMarkerEnd}");
 
-            var draft = inputProvider.Confirm(Questions.CreatePullRequestAsDraft, cancellationToken).Result;
+            var draft = await inputProvider.Confirm(Questions.CreatePullRequestAsDraft, cancellationToken, false);
 
             pullRequestActions.Add(new PullRequestInformation(
                 action.Branch,


### PR DESCRIPTION
The default for whether to create a PR as draft should be false. This got accidentally mucked up in https://github.com/geofflamrock/stack/pull/352.