### PR TITLE
Remove specific formatting of parts of log messages

### DIFF
--- a/src/Stack/Commands/Branch/AddBranchCommand.cs
+++ b/src/Stack/Commands/Branch/AddBranchCommand.cs
@@ -99,7 +99,7 @@ public class AddBranchCommandHandler(
             }
         }
 
-        logger.AddingBranchToStack(branchName.Branch(), stack.Name.Stack());
+        logger.AddingBranchToStack(branchName, stack.Name);
 
         if (sourceBranch is not null)
         {
@@ -113,7 +113,7 @@ public class AddBranchCommandHandler(
 
         stackConfig.Save(stackData);
 
-        logger.BranchAdded(branchName.Branch(), stack.Name.Stack());
+        logger.BranchAdded(branchName, stack.Name);
     }
 }
 

--- a/src/Stack/Commands/Branch/NewBranchCommand.cs
+++ b/src/Stack/Commands/Branch/NewBranchCommand.cs
@@ -103,7 +103,7 @@ public class NewBranchCommandHandler(
 
         var sourceBranchName = sourceBranch?.Name ?? stack.SourceBranch;
 
-        logger.CreatingBranch(branchName.Branch(), sourceBranchName.Branch(), stack.Name.Stack());
+        logger.CreatingBranch(branchName, sourceBranchName, stack.Name);
 
         gitClient.CreateNewBranch(branchName, sourceBranchName);
 
@@ -119,16 +119,16 @@ public class NewBranchCommandHandler(
 
         stackConfig.Save(stackData);
 
-        logger.BranchCreated(branchName.Branch());
+        logger.BranchCreated(branchName);
 
         try
         {
-            logger.PushingBranchToRemote(branchName.Branch());
+            logger.PushingBranchToRemote(branchName);
             gitClient.PushNewBranch(branchName);
         }
         catch (Exception)
         {
-            logger.NewBranchPushWarning(branchName.Branch(), stack.Name);
+            logger.NewBranchPushWarning(branchName, stack.Name);
         }
 
         gitClient.ChangeBranch(branchName);

--- a/src/Stack/Commands/Branch/RemoveBranchCommand.cs
+++ b/src/Stack/Commands/Branch/RemoveBranchCommand.cs
@@ -108,7 +108,7 @@ public class RemoveBranchCommandHandler(
             stack.RemoveBranch(branchName, action);
             stackConfig.Save(stackData);
 
-            logger.BranchRemovedFromStack(branchName.Branch(), stack.Name.Stack());
+            logger.BranchRemovedFromStack(branchName, stack.Name);
         }
     }
 }

--- a/src/Stack/Commands/Helpers/StackActions.cs
+++ b/src/Stack/Commands/Helpers/StackActions.cs
@@ -53,7 +53,7 @@ namespace Stack.Commands.Helpers
 
             if (shouldPullCurrent)
             {
-                logger.PullingCurrentBranch(currentBranch.Branch());
+                logger.PullingCurrentBranch(currentBranch);
                 gitClient.PullBranch(currentBranch);
             }
 
@@ -61,13 +61,13 @@ namespace Stack.Commands.Helpers
             foreach (var branch in branchesInOtherWorktrees)
             {
                 var worktreePath = branchStatus[branch].WorktreePath!; // not null due to filter
-                logger.PullingWorktreeBranch(branch.Branch(), worktreePath);
+                logger.PullingWorktreeBranch(branch, worktreePath);
                 gitClient.PullBranchForWorktree(branch, worktreePath);
             }
 
             if (nonCurrentBranches.Length > 0)
             {
-                logger.FetchingNonCurrentBranches(string.Join(", ", nonCurrentBranches.Select(b => b.Branch())));
+                logger.FetchingNonCurrentBranches(string.Join(", ", nonCurrentBranches.Select(b => b)));
                 gitClient.FetchBranchRefSpecs(nonCurrentBranches);
             }
         }
@@ -86,7 +86,7 @@ namespace Stack.Commands.Helpers
 
             foreach (var branch in branchesThatHaveNotBeenPushedToRemote)
             {
-                logger.PushingNewBranch(branch.Branch());
+                logger.PushingNewBranch(branch);
                 gitClient.PushNewBranch(branch);
             }
 
@@ -103,7 +103,7 @@ namespace Stack.Commands.Helpers
 
             foreach (var branches in branchGroupsToPush)
             {
-                logger.PushingBranches(string.Join(", ", branches.Select(b => b.Branch())));
+                logger.PushingBranches(string.Join(", ", branches.Select(b => b)));
                 gitClient.PushBranches([.. branches], forceWithLease);
             }
         }
@@ -136,7 +136,7 @@ namespace Stack.Commands.Helpers
             StackStatus status,
             CancellationToken cancellationToken)
         {
-            logger.UpdatingStackUsingMerge(status.Name.Stack());
+            logger.UpdatingStackUsingMerge(status.Name);
 
             var allBranchLines = status.GetAllBranchLines();
 
@@ -168,7 +168,7 @@ namespace Stack.Commands.Helpers
 
         private async Task MergeFromSourceBranch(string branch, string sourceBranchName, CancellationToken cancellationToken)
         {
-            logger.MergingBranch(sourceBranchName.Branch(), branch.Branch());
+            logger.MergingBranch(sourceBranchName, branch);
             gitClient.ChangeBranch(branch);
 
             try
@@ -201,7 +201,7 @@ namespace Stack.Commands.Helpers
             StackStatus status,
             CancellationToken cancellationToken)
         {
-            logger.UpdatingStackUsingRebase(status.Name.Stack());
+            logger.UpdatingStackUsingRebase(status.Name);
 
             var allBranchLines = status.GetAllBranchLines();
 
@@ -241,7 +241,7 @@ namespace Stack.Commands.Helpers
             // all commits from feature3 (and therefore from feature2) on top of the latest commits of main
             // which will include the squashed commit.
             //
-            logger.RebasingStackForBranchLine(status.Name.Stack(), status.SourceBranch.Name.Branch(), string.Join(" -> ", branchLine.Select(b => b.Name.Branch())));
+            logger.RebasingStackForBranchLine(status.Name, status.SourceBranch.Name, string.Join(" -> ", branchLine.Select(b => b.Name)));
 
             BranchDetail? lowestActionBranch = null;
             foreach (var branch in branchLine)
@@ -298,7 +298,7 @@ namespace Stack.Commands.Helpers
 
         private async Task RebaseFromSourceBranch(string branch, string sourceBranchName, CancellationToken cancellationToken)
         {
-            logger.RebasingBranchOnto(branch.Branch(), sourceBranchName.Branch());
+            logger.RebasingBranchOnto(branch, sourceBranchName);
             gitClient.ChangeBranch(branch);
 
             try
@@ -317,7 +317,7 @@ namespace Stack.Commands.Helpers
             string oldParentBranchName,
             CancellationToken cancellationToken)
         {
-            logger.RebasingBranchOntoNewParent(branch.Branch(), newParentBranchName.Branch());
+            logger.RebasingBranchOntoNewParent(branch, newParentBranchName);
             gitClient.ChangeBranch(branch);
 
             try

--- a/src/Stack/Commands/Helpers/StackActions.cs
+++ b/src/Stack/Commands/Helpers/StackActions.cs
@@ -67,7 +67,7 @@ namespace Stack.Commands.Helpers
 
             if (nonCurrentBranches.Length > 0)
             {
-                logger.FetchingNonCurrentBranches(string.Join(", ", nonCurrentBranches.Select(b => b)));
+                logger.FetchingNonCurrentBranches(string.Join(", ", nonCurrentBranches));
                 gitClient.FetchBranchRefSpecs(nonCurrentBranches);
             }
         }
@@ -103,7 +103,7 @@ namespace Stack.Commands.Helpers
 
             foreach (var branches in branchGroupsToPush)
             {
-                logger.PushingBranches(string.Join(", ", branches.Select(b => b)));
+                logger.PushingBranches(string.Join(", ", branches));
                 gitClient.PushBranches([.. branches], forceWithLease);
             }
         }

--- a/src/Stack/Commands/Helpers/StackHelpers.cs
+++ b/src/Stack/Commands/Helpers/StackHelpers.cs
@@ -142,7 +142,7 @@ public static class StackHelpers
             {
                 if (!branchStatuses.TryGetValue(stack.SourceBranch, out var sourceBranchStatus))
                 {
-                    logger.SourceBranchDoesNotExist(stack.SourceBranch.Branch());
+                    logger.SourceBranchDoesNotExist(stack.SourceBranch);
                     continue;
                 }
 
@@ -542,7 +542,7 @@ public static class StackHelpers
 
         foreach (var branch in branches)
         {
-            logger.BranchToCleanup(branch.Branch());
+            logger.BranchToCleanup(branch);
         }
     }
 
@@ -550,7 +550,7 @@ public static class StackHelpers
     {
         foreach (var branch in branches)
         {
-            logger.DeletingLocalBranch(branch.Branch());
+            logger.DeletingLocalBranch(branch);
             gitClient.DeleteLocalBranch(branch);
         }
     }

--- a/src/Stack/Commands/Helpers/StackHelpers.cs
+++ b/src/Stack/Commands/Helpers/StackHelpers.cs
@@ -447,21 +447,21 @@ public static class StackHelpers
         {
             await displayProvider.DisplayMessage("All branches exist locally but are either not in the remote repository or the pull request associated with the branch is no longer open. This stack might be able to be deleted.", cancellationToken);
             await displayProvider.DisplayNewLine(cancellationToken);
-            await displayProvider.DisplayMessage($"Run {"stack delete --stack \"{status.Name}\"".Example()} to delete the stack if it's no longer needed.", cancellationToken);
+            await displayProvider.DisplayMessage($"Run {$"stack delete --stack \"{status.Name}\"".Example()} to delete the stack if it's no longer needed.", cancellationToken);
             await displayProvider.DisplayNewLine(cancellationToken);
         }
         else if (allBranches.Any(branch => branch.CouldBeCleanedUp))
         {
             await displayProvider.DisplayMessage("Some branches exist locally but are either not in the remote repository or the pull request associated with the branch is no longer open.", cancellationToken);
             await displayProvider.DisplayNewLine(cancellationToken);
-            await displayProvider.DisplayMessage($"Run {"stack cleanup --stack \"{status.Name}\"".Example()} to clean up the stack if it's no longer needed.", cancellationToken);
+            await displayProvider.DisplayMessage($"Run {$"stack cleanup --stack \"{status.Name}\"".Example()} to clean up the stack if it's no longer needed.", cancellationToken);
             await displayProvider.DisplayNewLine(cancellationToken);
         }
         else if (allBranches.All(branch => !branch.Exists))
         {
             await displayProvider.DisplayMessage("No branches exist locally. This stack might be able to be deleted.", cancellationToken);
             await displayProvider.DisplayNewLine(cancellationToken);
-            await displayProvider.DisplayMessage($"Run {"stack delete --stack \"{status.Name}\"".Example()} to delete the stack if it's no longer needed.", cancellationToken);
+            await displayProvider.DisplayMessage($"Run {$"stack delete --stack \"{status.Name}\"".Example()} to delete the stack if it's no longer needed.", cancellationToken);
             await displayProvider.DisplayNewLine(cancellationToken);
         }
 
@@ -469,7 +469,7 @@ public static class StackHelpers
         {
             await displayProvider.DisplayMessage("There are changes in local branches that have not been pushed to the remote repository.", cancellationToken);
             await displayProvider.DisplayNewLine(cancellationToken);
-            await displayProvider.DisplayMessage($"Run {"stack push --stack \"{status.Name}\"".Example()} to push the changes to the remote repository.", cancellationToken);
+            await displayProvider.DisplayMessage($"Run {$"stack push --stack \"{status.Name}\"".Example()} to push the changes to the remote repository.", cancellationToken);
             await displayProvider.DisplayNewLine(cancellationToken);
         }
 
@@ -477,9 +477,9 @@ public static class StackHelpers
         {
             await displayProvider.DisplayMessage("There are changes in source branches that have not been applied to the stack.", cancellationToken);
             await displayProvider.DisplayNewLine(cancellationToken);
-            await displayProvider.DisplayMessage($"Run {"stack update --stack \"{status.Name}\"".Example()} to update the stack locally.", cancellationToken);
+            await displayProvider.DisplayMessage($"Run {$"stack update --stack \"{status.Name}\"".Example()} to update the stack locally.", cancellationToken);
             await displayProvider.DisplayNewLine(cancellationToken);
-            await displayProvider.DisplayMessage($"Run {"stack sync --stack \"{status.Name}\"".Example()} to sync the stack with the remote repository.", cancellationToken);
+            await displayProvider.DisplayMessage($"Run {$"stack sync --stack \"{status.Name}\"".Example()} to sync the stack with the remote repository.", cancellationToken);
             await displayProvider.DisplayNewLine(cancellationToken);
         }
     }

--- a/src/Stack/Commands/Helpers/StackHelpers.cs
+++ b/src/Stack/Commands/Helpers/StackHelpers.cs
@@ -250,7 +250,7 @@ public static class StackHelpers
     public static async Task OutputStackStatus(
         List<StackStatus> statuses,
         IDisplayProvider displayProvider,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken)
     {
         foreach (var status in statuses)
         {

--- a/src/Stack/Commands/Helpers/StackHelpers.cs
+++ b/src/Stack/Commands/Helpers/StackHelpers.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using MoreLinq;
 using Spectre.Console;
@@ -246,20 +247,22 @@ public static class StackHelpers
         return statuses.First();
     }
 
-    public static void OutputStackStatus(
+    public static async Task OutputStackStatus(
         List<StackStatus> statuses,
-        IDisplayProvider displayProvider)
+        IDisplayProvider displayProvider,
+        CancellationToken cancellationToken = default)
     {
         foreach (var status in statuses)
         {
-            OutputStackStatus(status, displayProvider);
-            displayProvider.DisplayNewLine();
+            await OutputStackStatus(status, displayProvider, cancellationToken);
+            await displayProvider.DisplayNewLine(cancellationToken);
         }
     }
 
-    public static void OutputStackStatus(
+    public static async Task OutputStackStatus(
         StackStatus status,
         IDisplayProvider displayProvider,
+        CancellationToken cancellationToken,
         Func<BranchDetail, string?>? getBranchPullRequestDisplay = null)
     {
         var header = GetBranchStatusOutput(status.SourceBranch);
@@ -270,8 +273,8 @@ public static class StackHelpers
             items.Add(GetBranchAndPullRequestStatusOutput(branch, getBranchPullRequestDisplay));
         }
 
-        displayProvider.DisplayMessage(status.Name.Stack());
-        displayProvider.DisplayTree(header, [.. items]);
+        await displayProvider.DisplayMessage(status.Name.Stack(), cancellationToken);
+        await displayProvider.DisplayTree(header, [.. items], cancellationToken: cancellationToken);
     }
 
     public static TreeItem<string> GetBranchAndPullRequestStatusOutput(
@@ -434,49 +437,50 @@ public static class StackHelpers
         return branchNameBuilder.ToString();
     }
 
-    public static void OutputBranchAndStackActions(
+    public static async Task OutputBranchAndStackActions(
         StackStatus status,
-        ILogger logger)
+        IDisplayProvider displayProvider,
+        CancellationToken cancellationToken)
     {
         var allBranches = status.GetAllBranches();
         if (allBranches.All(branch => branch.CouldBeCleanedUp))
         {
-            logger.AllBranchesMightBeDeleted();
-            logger.NewLine();
-            logger.RunDeleteStackCommand(status.Name);
-            logger.NewLine();
+            await displayProvider.DisplayMessage("All branches exist locally but are either not in the remote repository or the pull request associated with the branch is no longer open. This stack might be able to be deleted.", cancellationToken);
+            await displayProvider.DisplayNewLine(cancellationToken);
+            await displayProvider.DisplayMessage($"Run {"stack delete --stack \"{status.Name}\"".Example()} to delete the stack if it's no longer needed.", cancellationToken);
+            await displayProvider.DisplayNewLine(cancellationToken);
         }
         else if (allBranches.Any(branch => branch.CouldBeCleanedUp))
         {
-            logger.SomeBranchesCouldBeCleanedUp();
-            logger.NewLine();
-            logger.RunCleanupStackCommand(status.Name);
-            logger.NewLine();
+            await displayProvider.DisplayMessage("Some branches exist locally but are either not in the remote repository or the pull request associated with the branch is no longer open.", cancellationToken);
+            await displayProvider.DisplayNewLine(cancellationToken);
+            await displayProvider.DisplayMessage($"Run {"stack cleanup --stack \"{status.Name}\"".Example()} to clean up the stack if it's no longer needed.", cancellationToken);
+            await displayProvider.DisplayNewLine(cancellationToken);
         }
         else if (allBranches.All(branch => !branch.Exists))
         {
-            logger.NoLocalBranchesStackMightBeDeleted();
-            logger.NewLine();
-            logger.RunDeleteStackCommand(status.Name);
-            logger.NewLine();
+            await displayProvider.DisplayMessage("No branches exist locally. This stack might be able to be deleted.", cancellationToken);
+            await displayProvider.DisplayNewLine(cancellationToken);
+            await displayProvider.DisplayMessage($"Run {"stack delete --stack \"{status.Name}\"".Example()} to delete the stack if it's no longer needed.", cancellationToken);
+            await displayProvider.DisplayNewLine(cancellationToken);
         }
 
         if (allBranches.Any(branch => branch.Exists && (branch.RemoteTrackingBranch is null || branch.RemoteTrackingBranch.Ahead > 0)))
         {
-            logger.ChangesNotPushedToRemote();
-            logger.NewLine();
-            logger.RunPushStackCommand(status.Name);
-            logger.NewLine();
+            await displayProvider.DisplayMessage("There are changes in local branches that have not been pushed to the remote repository.", cancellationToken);
+            await displayProvider.DisplayNewLine(cancellationToken);
+            await displayProvider.DisplayMessage($"Run {"stack push --stack \"{status.Name}\"".Example()} to push the changes to the remote repository.", cancellationToken);
+            await displayProvider.DisplayNewLine(cancellationToken);
         }
 
         if (allBranches.Any(branch => branch.Exists && branch.RemoteTrackingBranch is not null && branch.RemoteTrackingBranch.Behind > 0))
         {
-            logger.SourceChangesNotApplied();
-            logger.NewLine();
-            logger.RunUpdateStackCommand(status.Name);
-            logger.NewLine();
-            logger.RunSyncStackCommand(status.Name);
-            logger.NewLine();
+            await displayProvider.DisplayMessage("There are changes in source branches that have not been applied to the stack.", cancellationToken);
+            await displayProvider.DisplayNewLine(cancellationToken);
+            await displayProvider.DisplayMessage($"Run {"stack update --stack \"{status.Name}\"".Example()} to update the stack locally.", cancellationToken);
+            await displayProvider.DisplayNewLine(cancellationToken);
+            await displayProvider.DisplayMessage($"Run {"stack sync --stack \"{status.Name}\"".Example()} to sync the stack with the remote repository.", cancellationToken);
+            await displayProvider.DisplayNewLine(cancellationToken);
         }
     }
 
@@ -629,36 +633,6 @@ internal static partial class LoggerExtensionMethods
 {
     [LoggerMessage(Level = LogLevel.Warning, Message = "Source branch {SourceBranch} does not exist locally or in the remote repository.")]
     public static partial void SourceBranchDoesNotExist(this ILogger logger, string sourceBranch);
-
-    [LoggerMessage(Level = LogLevel.Information, Message = "All branches exist locally but are either not in the remote repository or the pull request associated with the branch is no longer open. This stack might be able to be deleted.")]
-    public static partial void AllBranchesMightBeDeleted(this ILogger logger);
-
-    [LoggerMessage(Level = LogLevel.Information, Message = "Run 'stack delete --stack \"{Stack}\"' to delete the stack if it's no longer needed.")]
-    public static partial void RunDeleteStackCommand(this ILogger logger, string stack);
-
-    [LoggerMessage(Level = LogLevel.Information, Message = "Some branches exist locally but are either not in the remote repository or the pull request associated with the branch is no longer open.")]
-    public static partial void SomeBranchesCouldBeCleanedUp(this ILogger logger);
-
-    [LoggerMessage(Level = LogLevel.Information, Message = "Run 'stack cleanup --stack \"{Stack}\"' to clean up local branches.")]
-    public static partial void RunCleanupStackCommand(this ILogger logger, string stack);
-
-    [LoggerMessage(Level = LogLevel.Information, Message = "No branches exist locally. This stack might be able to be deleted.")]
-    public static partial void NoLocalBranchesStackMightBeDeleted(this ILogger logger);
-
-    [LoggerMessage(Level = LogLevel.Information, Message = "There are changes in local branches that have not been pushed to the remote repository.")]
-    public static partial void ChangesNotPushedToRemote(this ILogger logger);
-
-    [LoggerMessage(Level = LogLevel.Information, Message = "Run 'stack push --stack \"{Stack}\"' to push the changes to the remote repository.")]
-    public static partial void RunPushStackCommand(this ILogger logger, string stack);
-
-    [LoggerMessage(Level = LogLevel.Information, Message = "There are changes in source branches that have not been applied to the stack.")]
-    public static partial void SourceChangesNotApplied(this ILogger logger);
-
-    [LoggerMessage(Level = LogLevel.Information, Message = "Run 'stack update --stack \"{Stack}\"' to update the stack locally.")]
-    public static partial void RunUpdateStackCommand(this ILogger logger, string stack);
-
-    [LoggerMessage(Level = LogLevel.Information, Message = "Run 'stack sync --stack \"{Stack}\"' to sync the stack with the remote repository.")]
-    public static partial void RunSyncStackCommand(this ILogger logger, string stack);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "The following branches exist locally but are either not in the remote repository or the pull request associated with the branch is no longer open:")]
     public static partial void BranchesToCleanupHeader(this ILogger logger);

--- a/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
+++ b/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
@@ -180,7 +180,7 @@ public class CreatePullRequestsCommandHandler(
         var pullRequests = new List<GitHubPullRequest>();
         foreach (var action in pullRequestCreateActions)
         {
-            logger.CreatingPullRequest(action.HeadBranch.Branch(), action.BaseBranch.Branch());
+            logger.CreatingPullRequest(action.HeadBranch, action.BaseBranch);
             var pullRequest = gitHubClient.CreatePullRequest(
                 action.HeadBranch,
                 action.BaseBranch,
@@ -190,7 +190,7 @@ public class CreatePullRequestsCommandHandler(
 
             if (pullRequest is not null)
             {
-                logger.PullRequestCreated(pullRequest.GetPullRequestDisplay(), action.HeadBranch.Branch(), action.BaseBranch.Branch());
+                logger.PullRequestCreated(pullRequest.GetPullRequestDisplay(), action.HeadBranch, action.BaseBranch);
                 pullRequests.Add(pullRequest);
             }
         }

--- a/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
+++ b/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
@@ -104,9 +104,9 @@ public class CreatePullRequestsCommandHandler(
             }
         }
 
-        StackHelpers.OutputStackStatus(status, displayProvider);
+        await StackHelpers.OutputStackStatus(status, displayProvider, cancellationToken);
 
-        logger.NewLine();
+        await displayProvider.DisplayNewLine(cancellationToken);
 
         if (pullRequestCreateActions.Count > 0)
         {
@@ -124,7 +124,7 @@ public class CreatePullRequestsCommandHandler(
                 logger.PullRequestSelected(action.Branch, action.BaseBranch);
             }
 
-            logger.NewLine();
+            await displayProvider.DisplayNewLine(cancellationToken);
 
             var pullRequestInformation = await GetPullRequestInformation(
                 inputProvider,
@@ -135,11 +135,11 @@ public class CreatePullRequestsCommandHandler(
                 selectedPullRequestActions,
                 cancellationToken);
 
-            logger.NewLine();
+            await displayProvider.DisplayNewLine(cancellationToken);
 
-            OutputUpdatedStackStatus(logger, displayProvider, stack, status, pullRequestInformation);
+            await OutputUpdatedStackStatus(logger, displayProvider, stack, status, pullRequestInformation, cancellationToken);
 
-            logger.NewLine();
+            await displayProvider.DisplayNewLine(cancellationToken);
 
             if (await inputProvider.Confirm(Questions.ConfirmCreatePullRequests, cancellationToken))
             {
@@ -198,16 +198,18 @@ public class CreatePullRequestsCommandHandler(
         return pullRequests;
     }
 
-    private static void OutputUpdatedStackStatus(
+    private static async Task OutputUpdatedStackStatus(
         ILogger logger,
         IDisplayProvider displayProvider,
         Config.Stack stack,
         StackStatus status,
-        List<PullRequestInformation> pullRequestInformation)
+        List<PullRequestInformation> pullRequestInformation,
+        CancellationToken cancellationToken)
     {
-        StackHelpers.OutputStackStatus(
+        await StackHelpers.OutputStackStatus(
             status,
             displayProvider,
+            cancellationToken,
             (branch) =>
             {
                 var pr = pullRequestInformation.FirstOrDefault(pr => pr.HeadBranch == branch.Name);
@@ -244,7 +246,7 @@ public class CreatePullRequestsCommandHandler(
 
         foreach (var action in pullRequestCreateActions)
         {
-            logger.NewLine();
+            await displayProvider.DisplayNewLine(cancellationToken);
             await displayProvider.DisplayHeader($"New pull request from {action.Branch.Branch()} -> {action.BaseBranch.Branch()}", cancellationToken);
 
             var title = inputProvider.Text(Questions.PullRequestTitle, cancellationToken).Result;

--- a/src/Stack/Commands/PullRequests/OpenPullRequestsCommand.cs
+++ b/src/Stack/Commands/PullRequests/OpenPullRequestsCommand.cs
@@ -83,7 +83,7 @@ public class OpenPullRequestsCommandHandler(
 
         if (pullRequestsInStack.Count == 0)
         {
-            logger.NoPullRequestsForStack(stack.Name.Stack());
+            logger.NoPullRequestsForStack(stack.Name);
             return;
         }
 

--- a/src/Stack/Commands/Remote/SyncStackCommand.cs
+++ b/src/Stack/Commands/Remote/SyncStackCommand.cs
@@ -111,7 +111,7 @@ public class SyncStackCommandHandler(
 
         if (inputs.Confirm || await inputProvider.Confirm(Questions.ConfirmSyncStack, cancellationToken))
         {
-            logger.SyncingStackWithRemote(stack.Name.Stack());
+            logger.SyncingStackWithRemote(stack.Name);
 
             stackActions.PullChanges(stack);
 

--- a/src/Stack/Commands/Remote/SyncStackCommand.cs
+++ b/src/Stack/Commands/Remote/SyncStackCommand.cs
@@ -105,9 +105,9 @@ public class SyncStackCommandHandler(
             gitHubClient,
             true);
 
-        StackHelpers.OutputStackStatus(status, displayProvider);
+        await StackHelpers.OutputStackStatus(status, displayProvider, cancellationToken);
 
-        logger.NewLine();
+        await displayProvider.DisplayNewLine(cancellationToken);
 
         if (inputs.Confirm || await inputProvider.Confirm(Questions.ConfirmSyncStack, cancellationToken))
         {

--- a/src/Stack/Commands/Stack/CleanupStackCommand.cs
+++ b/src/Stack/Commands/Stack/CleanupStackCommand.cs
@@ -79,7 +79,7 @@ public class CleanupStackCommandHandler(
         if (inputs.Confirm || await inputProvider.Confirm(Questions.ConfirmDeleteBranches, cancellationToken))
         {
             StackHelpers.CleanupBranches(gitClient, logger, branchesToCleanUp);
-            logger.StackCleanedUp(stack.Name.Stack());
+            logger.StackCleanedUp(stack.Name);
         }
     }
 }

--- a/src/Stack/Commands/Stack/DeleteStackCommand.cs
+++ b/src/Stack/Commands/Stack/DeleteStackCommand.cs
@@ -86,7 +86,7 @@ public class DeleteStackCommandHandler(
             stackData.Stacks.Remove(stack);
             stackConfig.Save(stackData);
 
-            logger.StackDeleted(stack.Name.Stack());
+            logger.StackDeleted(stack.Name);
         }
     }
 }

--- a/src/Stack/Commands/Stack/NewStackCommand.cs
+++ b/src/Stack/Commands/Stack/NewStackCommand.cs
@@ -119,12 +119,12 @@ public class NewStackCommandHandler(
 
             try
             {
-                logger.PushingBranch(branchName.Branch());
+                logger.PushingBranch(branchName);
                 gitClient.PushNewBranch(branchName);
             }
             catch (Exception)
             {
-                logger.NewBranchPushWarning(branchName.Branch(), name);
+                logger.NewBranchPushWarning(branchName, name);
             }
         }
         else if (branchAction == BranchAction.Add)
@@ -149,21 +149,21 @@ public class NewStackCommandHandler(
             }
             catch (Exception ex)
             {
-                logger.ChangeBranchWarning(branchName.Branch(), ex.Message);
+                logger.ChangeBranchWarning(branchName, ex.Message);
             }
         }
 
         if (branchAction is BranchAction.Create)
         {
-            logger.NewStackWithNewBranch(name.Stack(), sourceBranch.Branch(), branchName!.Branch());
+            logger.NewStackWithNewBranch(name, sourceBranch, branchName!);
         }
         else if (branchAction is BranchAction.Add)
         {
-            logger.NewStackWithExistingBranch(name.Stack(), sourceBranch.Branch(), branchName!.Branch());
+            logger.NewStackWithExistingBranch(name, sourceBranch, branchName!);
         }
         else
         {
-            logger.NewStackWithNoBranch(name.Stack(), sourceBranch.Branch());
+            logger.NewStackWithNoBranch(name, sourceBranch);
         }
     }
 }

--- a/src/Stack/Commands/Stack/StackStatusCommand.cs
+++ b/src/Stack/Commands/Stack/StackStatusCommand.cs
@@ -121,13 +121,12 @@ public class StackStatusCommand : CommandWithOutput<StackStatusCommandResponse>
 
     protected override async Task WriteDefaultOutput(StackStatusCommandResponse response, CancellationToken cancellationToken)
     {
-        await Task.CompletedTask;
-        StackHelpers.OutputStackStatus(response.Stacks, DisplayProvider);
+        await StackHelpers.OutputStackStatus(response.Stacks, DisplayProvider, cancellationToken);
 
         if (response.Stacks.Count == 1)
         {
             var stack = response.Stacks.First();
-            StackHelpers.OutputBranchAndStackActions(stack, Logger);
+            await StackHelpers.OutputBranchAndStackActions(stack, DisplayProvider, cancellationToken);
         }
     }
 

--- a/src/Stack/Infrastructure/LoggerExtensionMethods.cs
+++ b/src/Stack/Infrastructure/LoggerExtensionMethods.cs
@@ -5,8 +5,6 @@ namespace Stack.Infrastructure;
 
 public static partial class LoggerExtensionMethods
 {
-    public static void NewLine(this ILogger logger) => logger.LogInformation(string.Empty);
-
     [LoggerMessage(Level = LogLevel.Information, Message = "{Question}")]
     public static partial void Question(this ILogger logger, string question);
 

--- a/src/Stack/Infrastructure/OutputStyleExtensionMethods.cs
+++ b/src/Stack/Infrastructure/OutputStyleExtensionMethods.cs
@@ -7,5 +7,6 @@ public static class OutputStyleExtensionMethods
     public static string Stack(this string name) => $"[{Color.Yellow}]{name}[/]";
     public static string Branch(this string name) => $"[{Color.Blue}]{name}[/]";
     public static string Muted(this string name) => $"[{Color.Grey}]{name}[/]";
+    public static string Example(this string name) => $"[{Color.Aqua}]{name}[/]";
     public static string Highlighted(this string name) => $"[{Color.Green}]{name}[/]";
 }


### PR DESCRIPTION
Removes any specific formatting of parts of log messages, like the branch or stack name. Log messages are log messages, they are designed to be reviewed for diagnostics, and it was causing everything to be a bit over confusing from a visual perspective and was also becoming a challenge to introduce json logging later on. 

A few specific actions for users to do have been moved to the display provider and do now have formatting, e.g. commands to run.