### PR TITLE
Fix issue with markup in process exception logging

### DIFF
--- a/src/Stack/Git/ProcessHelpers.cs
+++ b/src/Stack/Git/ProcessHelpers.cs
@@ -65,7 +65,7 @@ public static class ProcessHelpers
             }
             else
             {
-                throw new ProcessException(errorBuilder.ToString(), result);
+                throw new ProcessException(errorBuilder.ToString(), fileName, command, result);
             }
         }
 
@@ -85,14 +85,11 @@ public static class ProcessHelpers
     }
 }
 
-public class ProcessException : Exception
+public class ProcessException(string message, string filePath, string command, int exitCode) : Exception(message)
 {
-    public int ExitCode { get; }
-
-    public ProcessException(string message, int exitCode) : base(message)
-    {
-        ExitCode = exitCode;
-    }
+    public string FilePath { get; } = filePath;
+    public string Command { get; } = command;
+    public int ExitCode { get; } = exitCode;
 }
 
 internal static partial class LoggerExtensionMethods

--- a/src/Stack/Infrastructure/Commands/Command.cs
+++ b/src/Stack/Infrastructure/Commands/Command.cs
@@ -1,5 +1,6 @@
 using System.CommandLine;
 using Microsoft.Extensions.Logging;
+using Spectre.Console;
 using Stack.Git;
 using Stack.Infrastructure;
 using Stack.Infrastructure.Settings;
@@ -42,7 +43,10 @@ public abstract class Command : System.CommandLine.Command
             }
             catch (ProcessException processException)
             {
-                Logger.ErrorMessage(processException.Message);
+                Logger.ProcessExceptionCommandDetails(
+                    Markup.Escape(processException.FilePath),
+                    Markup.Escape(processException.Command));
+                Logger.ProcessExceptionErrorMessage(Markup.Escape(processException.Message));
                 return processException.ExitCode;
             }
             catch (OperationCanceledException)
@@ -51,7 +55,7 @@ public abstract class Command : System.CommandLine.Command
             }
             catch (Exception ex)
             {
-                Logger.ErrorMessage(ex.Message);
+                Logger.ErrorMessage(Markup.Escape(ex.Message));
                 return 1;
             }
         });
@@ -64,6 +68,12 @@ public abstract class Command : System.CommandLine.Command
 
 internal static partial class LoggerExtensionMethods
 {
+    [LoggerMessage(Level = LogLevel.Error, Message = "An error occurred running command \"{FilePath} {Command}\"")]
+    public static partial void ProcessExceptionCommandDetails(this ILogger logger, string filePath, string command);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "{Message}")]
+    public static partial void ProcessExceptionErrorMessage(this ILogger logger, string message);
+
     [LoggerMessage(Level = LogLevel.Error, Message = "{Message}")]
     public static partial void ErrorMessage(this ILogger logger, string message);
 }


### PR DESCRIPTION
Fixes issue where if there was markup in the output of a failed process command e.g. 

```
From https://github.com/geofflamrock/stack-playground
 ! [rejected]        markup-testing-2 -> markup-testing-2  (non-fast-forward)
```

Then this would fail to log with an error `An error occurred while writing to logger(s). (Could not find color or style 'rejected'.)`.

Also improves the way that process exceptions are logged out to include the failed command so can tell what's happening.