### PR TITLE
Improving logging and status display

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Usage:
 
 Options:
   --working-dir        The path to the directory containing the git repository. Defaults to the current directory.
+  --debug              Show debug output.
   --verbose            Show verbose output.
   -n, --name           The name of the stack. Must be unique within the repository.
   -s, --source-branch  The source branch to use for the new stack. Defaults to the default branch for the repository.
@@ -188,6 +189,7 @@ Usage:
 
 Options:
   --working-dir   The path to the directory containing the git repository. Defaults to the current directory.
+  --debug         Show debug output.
   --verbose       Show verbose output.
   --json          Output results as JSON.
   -?, -h, --help  Show help and usage information
@@ -203,6 +205,7 @@ Usage:
 
 Options:
   --working-dir   The path to the directory containing the git repository. Defaults to the current directory.
+  --debug         Show debug output.
   --verbose       Show verbose output.
   --json          Output results as JSON.
   -s, --stack     The name of the stack.
@@ -221,6 +224,7 @@ Usage:
 
 Options:
   --working-dir   The path to the directory containing the git repository. Defaults to the current directory.
+  --debug         Show debug output.
   --verbose       Show verbose output.
   -s, --stack     The name of the stack.
   -y, --yes       Confirm the command without prompting.
@@ -237,6 +241,7 @@ Usage:
 
 Options:
   --working-dir   The path to the directory containing the git repository. Defaults to the current directory.
+  --debug         Show debug output.
   --verbose       Show verbose output.
   -s, --stack     The name of the stack.
   -n, --name      The new name for the stack.
@@ -255,6 +260,7 @@ Usage:
 
 Options:
   --working-dir   The path to the directory containing the git repository. Defaults to the current directory.
+  --debug         Show debug output.
   --verbose       Show verbose output.
   -s, --stack     The name of the stack.
   --rebase        Use rebase when updating the stack. Overrides any setting in Git configuration.
@@ -272,6 +278,7 @@ Usage:
 
 Options:
   --working-dir   The path to the directory containing the git repository. Defaults to the current directory.
+  --debug         Show debug output.
   --verbose       Show verbose output.
   -b, --branch    The name of the branch.
   -?, -h, --help  Show help and usage information
@@ -287,6 +294,7 @@ Usage:
 
 Options:
   --working-dir   The path to the directory containing the git repository. Defaults to the current directory.
+  --debug         Show debug output.
   --verbose       Show verbose output.
   -s, --stack     The name of the stack.
   -y, --yes       Confirm the command without prompting.
@@ -303,6 +311,7 @@ Usage:
 
 Options:
   --working-dir   The path to the directory containing the git repository. Defaults to the current directory.
+  --debug         Show debug output.
   --verbose       Show verbose output.
   -s, --stack     The name of the stack.
   -b, --branch    The name of the branch.
@@ -320,6 +329,7 @@ Usage:
 
 Options:
   --working-dir   The path to the directory containing the git repository. Defaults to the current directory.
+  --debug         Show debug output.
   --verbose       Show verbose output.
   -s, --stack     The name of the stack.
   -b, --branch    The name of the branch.
@@ -337,6 +347,7 @@ Usage:
 
 Options:
   --working-dir              The path to the directory containing the git repository. Defaults to the current directory.
+  --debug                    Show debug output.
   --verbose                  Show verbose output.
   -s, --stack                The name of the stack.
   -b, --branch               The name of the branch.
@@ -358,6 +369,7 @@ Usage:
 
 Options:
   --working-dir   The path to the directory containing the git repository. Defaults to the current directory.
+  --debug         Show debug output.
   --verbose       Show verbose output.
   -s, --stack     The name of the stack.
   -?, -h, --help  Show help and usage information
@@ -373,6 +385,7 @@ Usage:
 
 Options:
   --working-dir       The path to the directory containing the git repository. Defaults to the current directory.
+  --debug             Show debug output.
   --verbose           Show verbose output.
   -s, --stack         The name of the stack.
   --max-batch-size    The maximum number of branches to process at once. [default: 5]
@@ -390,6 +403,7 @@ Usage:
 
 Options:
   --working-dir     The path to the directory containing the git repository. Defaults to the current directory.
+  --debug           Show debug output.
   --verbose         Show verbose output.
   -s, --stack       The name of the stack.
   --max-batch-size  The maximum number of branches to process at once. [default: 5]
@@ -412,6 +426,7 @@ Usage:
 
 Options:
   --working-dir   The path to the directory containing the git repository. Defaults to the current directory.
+  --debug         Show debug output.
   --verbose       Show verbose output.
   -s, --stack     The name of the stack.
   -?, -h, --help  Show help and usage information
@@ -427,6 +442,7 @@ Usage:
 
 Options:
   --working-dir   The path to the directory containing the git repository. Defaults to the current directory.
+  --debug         Show debug output.
   --verbose       Show verbose output.
   -s, --stack     The name of the stack.
   -?, -h, --help  Show help and usage information
@@ -444,6 +460,7 @@ Usage:
 
 Options:
   --working-dir   The path to the directory containing the git repository. Defaults to the current directory.
+  --debug         Show debug output.
   --verbose       Show verbose output.
   -?, -h, --help  Show help and usage information
 ```

--- a/src/Stack.Tests/Commands/Branch/NewBranchCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Branch/NewBranchCommandHandlerTests.cs
@@ -26,6 +26,7 @@ public class NewBranchCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<NewBranchCommandHandler>(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var stackConfig = new TestStackConfigBuilder()
             .WithStack(stack => stack
                 .WithName("Stack1")
@@ -37,7 +38,7 @@ public class NewBranchCommandHandlerTests(ITestOutputHelper testOutputHelper)
                 .WithRemoteUri(remoteUri)
                 .WithSourceBranch(sourceBranch))
             .Build();
-        var handler = new NewBranchCommandHandler(inputProvider, logger, gitClient, stackConfig);
+        var handler = new NewBranchCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig);
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>(), Arg.Any<CancellationToken>()).Returns("Stack1");
         inputProvider.Text(Questions.BranchName, Arg.Any<CancellationToken>(), Arg.Any<string>()).Returns(newBranch);
@@ -72,6 +73,7 @@ public class NewBranchCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<NewBranchCommandHandler>(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var stackConfig = new TestStackConfigBuilder()
             .WithStack(stack => stack
                 .WithName("Stack1")
@@ -83,7 +85,7 @@ public class NewBranchCommandHandlerTests(ITestOutputHelper testOutputHelper)
                 .WithRemoteUri(remoteUri)
                 .WithSourceBranch(sourceBranch))
             .Build();
-        var handler = new NewBranchCommandHandler(inputProvider, logger, gitClient, stackConfig);
+        var handler = new NewBranchCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig);
 
         inputProvider.Text(Questions.BranchName, Arg.Any<CancellationToken>(), Arg.Any<string>()).Returns(newBranch);
         inputProvider.Select(Questions.SelectParentBranch, Arg.Any<string[]>(), Arg.Any<CancellationToken>()).Returns(anotherBranch);
@@ -117,6 +119,7 @@ public class NewBranchCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<NewBranchCommandHandler>(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var stackConfig = new TestStackConfigBuilder()
             .WithStack(stack => stack
                 .WithName("Stack1")
@@ -124,7 +127,7 @@ public class NewBranchCommandHandlerTests(ITestOutputHelper testOutputHelper)
                 .WithSourceBranch(sourceBranch)
                 .WithBranch(branch => branch.WithName(anotherBranch)))
             .Build();
-        var handler = new NewBranchCommandHandler(inputProvider, logger, gitClient, stackConfig);
+        var handler = new NewBranchCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig);
 
         inputProvider.Text(Questions.BranchName, Arg.Any<CancellationToken>(), Arg.Any<string>()).Returns(newBranch);
         inputProvider.Select(Questions.SelectParentBranch, Arg.Any<string[]>(), Arg.Any<CancellationToken>()).Returns(anotherBranch);
@@ -157,6 +160,7 @@ public class NewBranchCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<NewBranchCommandHandler>(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var stackConfig = new TestStackConfigBuilder()
             .WithStack(stack => stack
                 .WithName("Stack1")
@@ -168,7 +172,7 @@ public class NewBranchCommandHandlerTests(ITestOutputHelper testOutputHelper)
                 .WithRemoteUri(remoteUri)
                 .WithSourceBranch(sourceBranch))
             .Build();
-        var handler = new NewBranchCommandHandler(inputProvider, logger, gitClient, stackConfig);
+        var handler = new NewBranchCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig);
 
         gitClient.GetRemoteUri().Returns(remoteUri);
         gitClient.GetCurrentBranch().Returns(sourceBranch);
@@ -194,6 +198,7 @@ public class NewBranchCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<NewBranchCommandHandler>(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var stackConfig = new TestStackConfigBuilder()
             .WithStack(stack => stack
                 .WithName("Stack1")
@@ -205,7 +210,7 @@ public class NewBranchCommandHandlerTests(ITestOutputHelper testOutputHelper)
                 .WithRemoteUri(remoteUri)
                 .WithSourceBranch(sourceBranch))
             .Build();
-        var handler = new NewBranchCommandHandler(inputProvider, logger, gitClient, stackConfig);
+        var handler = new NewBranchCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig);
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>(), Arg.Any<CancellationToken>()).Returns("Stack1");
         inputProvider.Select(Questions.SelectParentBranch, Arg.Any<string[]>(), Arg.Any<CancellationToken>()).Returns(anotherBranch);
@@ -238,6 +243,7 @@ public class NewBranchCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<NewBranchCommandHandler>(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var stackConfig = new TestStackConfigBuilder()
             .WithStack(stack => stack
                 .WithName("Stack1")
@@ -248,7 +254,7 @@ public class NewBranchCommandHandlerTests(ITestOutputHelper testOutputHelper)
                 .WithRemoteUri(remoteUri)
                 .WithSourceBranch(sourceBranch))
             .Build();
-        var handler = new NewBranchCommandHandler(inputProvider, logger, gitClient, stackConfig);
+        var handler = new NewBranchCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig);
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>(), Arg.Any<CancellationToken>()).Returns("Stack1");
         gitClient.GetRemoteUri().Returns(remoteUri);
@@ -276,6 +282,7 @@ public class NewBranchCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<NewBranchCommandHandler>(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var stackConfig = new TestStackConfigBuilder()
             .WithStack(stack => stack
                 .WithName("Stack1")
@@ -288,7 +295,7 @@ public class NewBranchCommandHandlerTests(ITestOutputHelper testOutputHelper)
                 .WithRemoteUri(remoteUri)
                 .WithSourceBranch(sourceBranch))
             .Build();
-        var handler = new NewBranchCommandHandler(inputProvider, logger, gitClient, stackConfig);
+        var handler = new NewBranchCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig);
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>(), Arg.Any<CancellationToken>()).Returns("Stack1");
         gitClient.GetRemoteUri().Returns(remoteUri);
@@ -315,6 +322,7 @@ public class NewBranchCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<NewBranchCommandHandler>(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var stackConfig = new TestStackConfigBuilder()
             .WithStack(stack => stack
                 .WithName("Stack1")
@@ -326,7 +334,7 @@ public class NewBranchCommandHandlerTests(ITestOutputHelper testOutputHelper)
                 .WithRemoteUri(remoteUri)
                 .WithSourceBranch(sourceBranch))
             .Build();
-        var handler = new NewBranchCommandHandler(inputProvider, logger, gitClient, stackConfig);
+        var handler = new NewBranchCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig);
 
         gitClient.When(gc => gc.PushNewBranch(newBranch)).Do(_ => { throw new Exception("Failed to push branch"); });
 
@@ -365,6 +373,7 @@ public class NewBranchCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<NewBranchCommandHandler>(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var stackConfig = new TestStackConfigBuilder()
             .WithStack(stack => stack
                 .WithName("Stack1")
@@ -376,7 +385,7 @@ public class NewBranchCommandHandlerTests(ITestOutputHelper testOutputHelper)
                 .WithRemoteUri(remoteUri)
                 .WithSourceBranch(sourceBranch))
             .Build();
-        var handler = new NewBranchCommandHandler(inputProvider, logger, gitClient, stackConfig);
+        var handler = new NewBranchCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig);
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>(), Arg.Any<CancellationToken>()).Returns("Stack1");
         inputProvider.Text(Questions.BranchName, Arg.Any<CancellationToken>(), Arg.Any<string>()).Returns(newBranch);
@@ -412,6 +421,7 @@ public class NewBranchCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<NewBranchCommandHandler>(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var stackConfig = new TestStackConfigBuilder()
             .WithStack(stack => stack
                 .WithName("Stack1")
@@ -423,7 +433,7 @@ public class NewBranchCommandHandlerTests(ITestOutputHelper testOutputHelper)
                 .WithRemoteUri(remoteUri)
                 .WithSourceBranch(sourceBranch))
             .Build();
-        var handler = new NewBranchCommandHandler(inputProvider, logger, gitClient, stackConfig);
+        var handler = new NewBranchCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig);
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>(), Arg.Any<CancellationToken>()).Returns("Stack1");
         inputProvider.Text(Questions.BranchName, Arg.Any<CancellationToken>(), Arg.Any<string>()).Returns(newBranch);

--- a/src/Stack.Tests/Commands/Remote/PullStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Remote/PullStackCommandHandlerTests.cs
@@ -35,9 +35,10 @@ public class PullStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
             .Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<PullStackCommandHandler>(testOutputHelper);
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
         var stackActions = Substitute.For<IStackActions>();
-        var handler = new PullStackCommandHandler(inputProvider, logger, gitClient, stackConfig, stackActions);
+        var handler = new PullStackCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig, stackActions);
 
         gitClient.GetRemoteUri().Returns(remoteUri);
         gitClient.GetCurrentBranch().Returns(branch1);
@@ -76,9 +77,10 @@ public class PullStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
             .Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<PullStackCommandHandler>(testOutputHelper);
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
         var stackActions = Substitute.For<IStackActions>();
-        var handler = new PullStackCommandHandler(inputProvider, logger, gitClient, stackConfig, stackActions);
+        var handler = new PullStackCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig, stackActions);
 
         gitClient.GetRemoteUri().Returns(remoteUri);
         gitClient.GetCurrentBranch().Returns(branch1);
@@ -116,9 +118,10 @@ public class PullStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
             .Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<PullStackCommandHandler>(testOutputHelper);
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
         var stackActions = Substitute.For<IStackActions>();
-        var handler = new PullStackCommandHandler(inputProvider, logger, gitClient, stackConfig, stackActions);
+        var handler = new PullStackCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig, stackActions);
 
         gitClient.GetRemoteUri().Returns(remoteUri);
         gitClient.GetCurrentBranch().Returns(branch1);

--- a/src/Stack.Tests/Commands/Remote/PushStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Remote/PushStackCommandHandlerTests.cs
@@ -39,9 +39,10 @@ public class PushStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
             .Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<PushStackCommandHandler>(testOutputHelper);
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitHubClient = Substitute.For<IGitHubClient>();
         var stackActions = Substitute.For<IStackActions>();
-        var handler = new PushStackCommandHandler(inputProvider, logger, gitClient, stackConfig, stackActions);
+        var handler = new PushStackCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig, stackActions);
 
         gitClient.ChangeBranch(branch1);
 
@@ -81,9 +82,10 @@ public class PushStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
             .Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<PushStackCommandHandler>(testOutputHelper);
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitHubClient = Substitute.For<IGitHubClient>();
         var stackActions = Substitute.For<IStackActions>();
-        var handler = new PushStackCommandHandler(inputProvider, logger, gitClient, stackConfig, stackActions);
+        var handler = new PushStackCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig, stackActions);
 
         gitClient.ChangeBranch(branch1);
 
@@ -124,9 +126,10 @@ public class PushStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
             .Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<PushStackCommandHandler>(testOutputHelper);
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitHubClient = Substitute.For<IGitHubClient>();
         var stackActions = Substitute.For<IStackActions>();
-        var handler = new PushStackCommandHandler(inputProvider, logger, gitClient, stackConfig, stackActions);
+        var handler = new PushStackCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig, stackActions);
 
         gitClient.ChangeBranch(branch1);
 
@@ -166,9 +169,10 @@ public class PushStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
             .Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<PushStackCommandHandler>(testOutputHelper);
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitHubClient = Substitute.For<IGitHubClient>();
         var stackActions = Substitute.For<IStackActions>();
-        var handler = new PushStackCommandHandler(inputProvider, logger, gitClient, stackConfig, stackActions);
+        var handler = new PushStackCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig, stackActions);
 
         gitClient.ChangeBranch(branch1);
 
@@ -208,9 +212,10 @@ public class PushStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
             .Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<PushStackCommandHandler>(testOutputHelper);
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitHubClient = Substitute.For<IGitHubClient>();
         var stackActions = Substitute.For<IStackActions>();
-        var handler = new PushStackCommandHandler(inputProvider, logger, gitClient, stackConfig, stackActions);
+        var handler = new PushStackCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig, stackActions);
 
         gitClient.ChangeBranch(branch1);
 

--- a/src/Stack.Tests/Commands/Stack/NewStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/NewStackCommandHandlerTests.cs
@@ -25,8 +25,9 @@ public class NewStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var stackConfig = new TestStackConfigBuilder().Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<NewStackCommandHandler>(testOutputHelper);
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
-        var handler = new NewStackCommandHandler(inputProvider, logger, gitClient, stackConfig);
+        var handler = new NewStackCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig);
 
         gitClient.GetLocalBranchesOrderedByMostRecentCommitterDate().Returns([sourceBranch, existingBranch]);
         gitClient.GetRemoteUri().Returns(remoteUri);
@@ -59,8 +60,9 @@ public class NewStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var stackConfig = new TestStackConfigBuilder().Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<NewStackCommandHandler>(testOutputHelper);
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
-        var handler = new NewStackCommandHandler(inputProvider, logger, gitClient, stackConfig);
+        var handler = new NewStackCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig);
 
         gitClient.GetLocalBranchesOrderedByMostRecentCommitterDate().Returns([sourceBranch, existingBranch]);
         gitClient.GetRemoteUri().Returns(remoteUri);
@@ -91,8 +93,9 @@ public class NewStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var stackConfig = new TestStackConfigBuilder().Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<NewStackCommandHandler>(testOutputHelper);
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
-        var handler = new NewStackCommandHandler(inputProvider, logger, gitClient, stackConfig);
+        var handler = new NewStackCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig);
 
         gitClient.GetLocalBranchesOrderedByMostRecentCommitterDate().Returns([sourceBranch]);
         gitClient.GetRemoteUri().Returns(remoteUri);
@@ -123,8 +126,9 @@ public class NewStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var stackConfig = new TestStackConfigBuilder().Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<NewStackCommandHandler>(testOutputHelper);
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
-        var handler = new NewStackCommandHandler(inputProvider, logger, gitClient, stackConfig);
+        var handler = new NewStackCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig);
 
         gitClient.GetLocalBranchesOrderedByMostRecentCommitterDate().Returns([sourceBranch]);
         gitClient.GetRemoteUri().Returns(remoteUri);
@@ -156,8 +160,9 @@ public class NewStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var stackConfig = new TestStackConfigBuilder().Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<NewStackCommandHandler>(testOutputHelper);
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
-        var handler = new NewStackCommandHandler(inputProvider, logger, gitClient, stackConfig);
+        var handler = new NewStackCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig);
 
         gitClient.GetLocalBranchesOrderedByMostRecentCommitterDate().Returns([sourceBranch]);
         gitClient.GetRemoteUri().Returns(remoteUri);
@@ -191,8 +196,9 @@ public class NewStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var stackConfig = new TestStackConfigBuilder().Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<NewStackCommandHandler>(testOutputHelper);
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
-        var handler = new NewStackCommandHandler(inputProvider, logger, gitClient, stackConfig);
+        var handler = new NewStackCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig);
 
         gitClient.GetLocalBranchesOrderedByMostRecentCommitterDate().Returns([sourceBranch]);
         gitClient.GetRemoteUri().Returns(remoteUri);
@@ -225,8 +231,9 @@ public class NewStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         var stackConfig = new TestStackConfigBuilder().Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<NewStackCommandHandler>(testOutputHelper);
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
-        var handler = new NewStackCommandHandler(inputProvider, logger, gitClient, stackConfig);
+        var handler = new NewStackCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig);
 
         gitClient.GetLocalBranchesOrderedByMostRecentCommitterDate().Returns([sourceBranch]);
         gitClient.GetRemoteUri().Returns(remoteUri);

--- a/src/Stack.Tests/Commands/Stack/UpdateStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/UpdateStackCommandHandlerTests.cs
@@ -35,9 +35,10 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
             .Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<UpdateStackCommandHandler>(testOutputHelper);
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
         var stackActions = Substitute.For<IStackActions>();
-        var handler = new UpdateStackCommandHandler(inputProvider, logger, gitClient, stackConfig, stackActions);
+        var handler = new UpdateStackCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig, stackActions);
 
         gitClient.GetRemoteUri().Returns(remoteUri);
         gitClient.GetCurrentBranch().Returns(branch1);
@@ -72,9 +73,10 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
             .Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<UpdateStackCommandHandler>(testOutputHelper);
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
         var stackActions = Substitute.For<IStackActions>();
-        var handler = new UpdateStackCommandHandler(inputProvider, logger, gitClient, stackConfig, stackActions);
+        var handler = new UpdateStackCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig, stackActions);
 
         gitClient.GetRemoteUri().Returns(remoteUri);
         gitClient.GetCurrentBranch().Returns(branch1);
@@ -108,9 +110,10 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
             .Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<UpdateStackCommandHandler>(testOutputHelper);
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
         var stackActions = Substitute.For<IStackActions>();
-        var handler = new UpdateStackCommandHandler(inputProvider, logger, gitClient, stackConfig, stackActions);
+        var handler = new UpdateStackCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig, stackActions);
 
         // We are on a specific branch in the stack
         gitClient.GetCurrentBranch().Returns(branch1);
@@ -143,9 +146,10 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
             .Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<UpdateStackCommandHandler>(testOutputHelper);
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
         var stackActions = Substitute.For<IStackActions>();
-        var handler = new UpdateStackCommandHandler(inputProvider, logger, gitClient, stackConfig, stackActions);
+        var handler = new UpdateStackCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig, stackActions);
 
         gitClient.GetRemoteUri().Returns(remoteUri);
         gitClient.GetCurrentBranch().Returns(branch1);
@@ -180,9 +184,10 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
             .Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<UpdateStackCommandHandler>(testOutputHelper);
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
         var stackActions = Substitute.For<IStackActions>();
-        var handler = new UpdateStackCommandHandler(inputProvider, logger, gitClient, stackConfig, stackActions);
+        var handler = new UpdateStackCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig, stackActions);
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>(), Arg.Any<CancellationToken>()).Returns("Stack1");
         gitClient.GetRemoteUri().Returns(remoteUri);
@@ -217,9 +222,10 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
             .Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<UpdateStackCommandHandler>(testOutputHelper);
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
         var stackActions = Substitute.For<IStackActions>();
-        var handler = new UpdateStackCommandHandler(inputProvider, logger, gitClient, stackConfig, stackActions);
+        var handler = new UpdateStackCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig, stackActions);
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>(), Arg.Any<CancellationToken>()).Returns("Stack1");
         gitClient.GetRemoteUri().Returns(remoteUri);
@@ -254,9 +260,10 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
             .Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<UpdateStackCommandHandler>(testOutputHelper);
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
         var stackActions = Substitute.For<IStackActions>();
-        var handler = new UpdateStackCommandHandler(inputProvider, logger, gitClient, stackConfig, stackActions);
+        var handler = new UpdateStackCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig, stackActions);
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>(), Arg.Any<CancellationToken>()).Returns("Stack1");
         gitClient.GetRemoteUri().Returns(remoteUri);
@@ -292,9 +299,10 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
             .Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<UpdateStackCommandHandler>(testOutputHelper);
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
         var stackActions = Substitute.For<IStackActions>();
-        var handler = new UpdateStackCommandHandler(inputProvider, logger, gitClient, stackConfig, stackActions);
+        var handler = new UpdateStackCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig, stackActions);
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>(), Arg.Any<CancellationToken>()).Returns("Stack1");
         gitClient.GetRemoteUri().Returns(remoteUri);
@@ -330,9 +338,10 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
             .Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<UpdateStackCommandHandler>(testOutputHelper);
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
         var stackActions = Substitute.For<IStackActions>();
-        var handler = new UpdateStackCommandHandler(inputProvider, logger, gitClient, stackConfig, stackActions);
+        var handler = new UpdateStackCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig, stackActions);
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>(), Arg.Any<CancellationToken>()).Returns("Stack1");
         gitClient.GetRemoteUri().Returns(remoteUri);
@@ -368,9 +377,10 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
             .Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<UpdateStackCommandHandler>(testOutputHelper);
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
         var stackActions = Substitute.For<IStackActions>();
-        var handler = new UpdateStackCommandHandler(inputProvider, logger, gitClient, stackConfig, stackActions);
+        var handler = new UpdateStackCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig, stackActions);
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>(), Arg.Any<CancellationToken>()).Returns("Stack1");
         inputProvider.Select(Questions.SelectUpdateStrategy, Arg.Any<UpdateStrategy[]>(), Arg.Any<CancellationToken>()).Returns(UpdateStrategy.Rebase);
@@ -407,9 +417,10 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
             .Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<UpdateStackCommandHandler>(testOutputHelper);
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
         var stackActions = Substitute.For<IStackActions>();
-        var handler = new UpdateStackCommandHandler(inputProvider, logger, gitClient, stackConfig, stackActions);
+        var handler = new UpdateStackCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig, stackActions);
 
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>(), Arg.Any<CancellationToken>()).Returns("Stack1");
         inputProvider.Select(Questions.SelectUpdateStrategy, Arg.Any<UpdateStrategy[]>(), Arg.Any<CancellationToken>()).Returns(UpdateStrategy.Merge);
@@ -441,9 +452,10 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
             .Build();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<UpdateStackCommandHandler>(testOutputHelper);
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
         var stackActions = Substitute.For<IStackActions>();
-        var handler = new UpdateStackCommandHandler(inputProvider, logger, gitClient, stackConfig, stackActions);
+        var handler = new UpdateStackCommandHandler(inputProvider, logger, displayProvider, gitClient, stackConfig, stackActions);
 
         gitClient.GetRemoteUri().Returns(remoteUri);
 

--- a/src/Stack.Tests/Helpers/TestDisplayProvider.cs
+++ b/src/Stack.Tests/Helpers/TestDisplayProvider.cs
@@ -6,9 +6,14 @@ namespace Stack.Tests.Helpers;
 
 public class TestDisplayProvider(ITestOutputHelper testOutputHelper) : IDisplayProvider
 {
+    public async Task<T> DisplayStatus<T>(string message, Func<CancellationToken, Task<T>> action, CancellationToken cancellationToken = default)
+    {
+        testOutputHelper.WriteLine($"STATUS: {message}");
+        return await action(cancellationToken);
+    }
+
     public async Task DisplayStatus(string message, Func<CancellationToken, Task> action, CancellationToken cancellationToken = default)
     {
-        await Task.CompletedTask;
         testOutputHelper.WriteLine($"STATUS: {message}");
         await action(cancellationToken);
     }

--- a/src/Stack/Commands/Config/OpenConfigCommand.cs
+++ b/src/Stack/Commands/Config/OpenConfigCommand.cs
@@ -46,6 +46,6 @@ public class OpenConfigCommand : Command
 
 internal static partial class LoggerExtensionMethods
 {
-    [LoggerMessage(Level = LogLevel.Information, Message = "No config file found.")]
+    [LoggerMessage(Level = LogLevel.Warning, Message = "No config file found.")]
     public static partial void NoConfigFileFound(this ILogger logger);
 }

--- a/src/Stack/Commands/Helpers/InputProviderExtensionMethods.cs
+++ b/src/Stack/Commands/Helpers/InputProviderExtensionMethods.cs
@@ -64,6 +64,11 @@ public static class InputProviderExtensionMethods
         string currentBranch,
         CancellationToken cancellationToken)
     {
+        if (stacks.Count == 0)
+        {
+            return null;
+        }
+
         if (name is not null)
         {
             return stacks.FirstOrDefault(s => s.Name.Equals(name, StringComparison.OrdinalIgnoreCase));

--- a/src/Stack/Commands/Helpers/StackActions.cs
+++ b/src/Stack/Commands/Helpers/StackActions.cs
@@ -302,7 +302,7 @@ namespace Stack.Commands.Helpers
 
         private async Task RebaseFromSourceBranch(string branch, string sourceBranchName, CancellationToken cancellationToken)
         {
-            await displayProvider.DisplayStatus($"Rebasing {branch} onto {sourceBranchName}", async ct =>
+            await displayProvider.DisplayStatusWithSuccess($"Rebasing {branch} onto {sourceBranchName}", async ct =>
             {
                 gitClient.ChangeBranch(branch);
 
@@ -333,8 +333,6 @@ namespace Stack.Commands.Helpers
                             break;
                     }
                 }
-
-                await displayProvider.DisplayMessage($"{Emoji.Known.CheckMark}  Rebasing {branch} onto {sourceBranchName}...", ct);
             }, cancellationToken);
         }
 

--- a/src/Stack/Commands/Helpers/StackActions.cs
+++ b/src/Stack/Commands/Helpers/StackActions.cs
@@ -2,6 +2,7 @@ using Stack.Config;
 using Stack.Infrastructure;
 using Stack.Git;
 using Microsoft.Extensions.Logging;
+using Spectre.Console;
 
 namespace Stack.Commands.Helpers
 {
@@ -301,36 +302,40 @@ namespace Stack.Commands.Helpers
 
         private async Task RebaseFromSourceBranch(string branch, string sourceBranchName, CancellationToken cancellationToken)
         {
-            logger.RebasingBranchOnto(branch, sourceBranchName);
-            gitClient.ChangeBranch(branch);
-
-            try
+            await displayProvider.DisplayStatus($"Rebasing {branch} onto {sourceBranchName}", async ct =>
             {
-                gitClient.RebaseFromLocalSourceBranch(sourceBranchName);
-            }
-            catch (ConflictException)
-            {
-                var result = await ConflictResolutionDetector.WaitForConflictResolution(
-                    gitClient,
-                    logger,
-                    ConflictOperationType.Rebase,
-                    TimeSpan.FromSeconds(1),
-                    null,
-                    cancellationToken);
+                gitClient.ChangeBranch(branch);
 
-                switch (result)
+                try
                 {
-                    case ConflictResolutionResult.Completed:
-                        break;
-                    case ConflictResolutionResult.Aborted:
-                        throw new Exception("Rebase aborted due to conflicts.");
-                    case ConflictResolutionResult.Timeout:
-                        throw new TimeoutException("Timed out waiting for rebase conflict resolution.");
-                    case ConflictResolutionResult.NotStarted:
-                        logger.LogWarning("Expected rebase to be in progress but marker not found. Proceeding cautiously.");
-                        break;
+                    gitClient.RebaseFromLocalSourceBranch(sourceBranchName);
                 }
-            }
+                catch (ConflictException)
+                {
+                    var result = await ConflictResolutionDetector.WaitForConflictResolution(
+                        gitClient,
+                        logger,
+                        ConflictOperationType.Rebase,
+                        TimeSpan.FromSeconds(1),
+                        null,
+                        cancellationToken);
+
+                    switch (result)
+                    {
+                        case ConflictResolutionResult.Completed:
+                            break;
+                        case ConflictResolutionResult.Aborted:
+                            throw new Exception("Rebase aborted due to conflicts.");
+                        case ConflictResolutionResult.Timeout:
+                            throw new TimeoutException("Timed out waiting for rebase conflict resolution.");
+                        case ConflictResolutionResult.NotStarted:
+                            logger.LogWarning("Expected rebase to be in progress but marker not found. Proceeding cautiously.");
+                            break;
+                    }
+                }
+
+                await displayProvider.DisplayMessage($"{Emoji.Known.CheckMark}  Rebasing {branch} onto {sourceBranchName}...", ct);
+            }, cancellationToken);
         }
 
         private async Task RebaseOntoNewParent(
@@ -375,42 +380,42 @@ namespace Stack.Commands.Helpers
 
 internal static partial class LoggerExtensionMethods
 {
-    [LoggerMessage(Level = LogLevel.Information, Message = "Pulling changes for {Branch} from remote")]
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Pulling changes for {Branch} from remote")]
     public static partial void PullingCurrentBranch(this ILogger logger, string branch);
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "Pulling changes for {Branch} (worktree: \"{WorktreePath}\") from remote")]
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Pulling changes for {Branch} (worktree: \"{WorktreePath}\") from remote")]
     public static partial void PullingWorktreeBranch(this ILogger logger, string branch, string worktreePath);
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "Fetching changes for {Branches} from remote")]
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Fetching changes for {Branches} from remote")]
     public static partial void FetchingNonCurrentBranches(this ILogger logger, string branches);
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "Pushing new branch {Branch} to remote")]
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Pushing new branch {Branch} to remote")]
     public static partial void PushingNewBranch(this ILogger logger, string branch);
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "Pushing changes for {Branches} to remote")]
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Pushing changes for {Branches} to remote")]
     public static partial void PushingBranches(this ILogger logger, string branches);
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "Updating stack \"{Stack}\" using merge...")]
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Updating stack \"{Stack}\" using merge...")]
     public static partial void UpdatingStackUsingMerge(this ILogger logger, string stack);
 
     [LoggerMessage(Level = LogLevel.Trace, Message = "Branch {Branch} no longer exists on the remote repository or the associated pull request is no longer open. Skipping...")]
     public static partial void TraceSkippingInactiveBranch(this ILogger logger, string branch);
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "Merging {SourceBranch} into {Branch}")]
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Merging {SourceBranch} into {Branch}")]
     public static partial void MergingBranch(this ILogger logger, string sourceBranch, string branch);
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "Updating stack \"{Stack}\" using rebase...")]
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Updating stack \"{Stack}\" using rebase...")]
     public static partial void UpdatingStackUsingRebase(this ILogger logger, string stack);
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "Rebasing stack \"{Stack}\" for branch line: {SourceBranch} --> {BranchLine}")]
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Rebasing stack \"{Stack}\" for branch line: {SourceBranch} --> {BranchLine}")]
     public static partial void RebasingStackForBranchLine(this ILogger logger, string stack, string sourceBranch, string branchLine);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "No active branches found for branch line.")]
     public static partial void NoActiveBranchesFound(this ILogger logger);
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "Rebasing {Branch} onto {SourceBranch}")]
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Rebasing {Branch} onto {SourceBranch}")]
     public static partial void RebasingBranchOnto(this ILogger logger, string branch, string sourceBranch);
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "Rebasing {Branch} onto new parent {NewParentBranch}")]
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Rebasing {Branch} onto new parent {NewParentBranch}")]
     public static partial void RebasingBranchOntoNewParent(this ILogger logger, string branch, string newParentBranch);
 }

--- a/src/Stack/Commands/Helpers/StackHelpers.cs
+++ b/src/Stack/Commands/Helpers/StackHelpers.cs
@@ -121,19 +121,7 @@ public static class StackHelpers
             .ToArray();
 
         var branchStatuses = gitClient.GetBranchStatuses(allBranchesInStacks);
-
-        if (includePullRequestStatus)
-        {
-            displayProvider.DisplayStatus("Checking status of GitHub pull requests...", async (ct) =>
-            {
-                await Task.CompletedTask;
-                EvaluateBranchStatusDetails(logger, gitClient, gitHubClient, includePullRequestStatus, stacksToReturnStatusFor, stacksOrderedByCurrentBranch, branchStatuses);
-            });
-        }
-        else
-        {
-            EvaluateBranchStatusDetails(logger, gitClient, gitHubClient, includePullRequestStatus, stacksToReturnStatusFor, stacksOrderedByCurrentBranch, branchStatuses);
-        }
+        EvaluateBranchStatusDetails(logger, gitClient, gitHubClient, includePullRequestStatus, stacksToReturnStatusFor, stacksOrderedByCurrentBranch, branchStatuses);
 
         return stacksToReturnStatusFor;
 
@@ -640,7 +628,7 @@ internal static partial class LoggerExtensionMethods
     [LoggerMessage(Level = LogLevel.Information, Message = "  {Branch}")]
     public static partial void BranchToCleanup(this ILogger logger, string branch);
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "Deleting local branch {Branch}")]
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Deleting local branch {Branch}")]
     public static partial void DeletingLocalBranch(this ILogger logger, string branch);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Updating pull request {PullRequest} with stack details")]

--- a/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
+++ b/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
@@ -292,7 +292,7 @@ internal static partial class LoggerExtensionMethods
     [LoggerMessage(Level = LogLevel.Information, Message = "Pull request selected: {HeadBranch} -> {BaseBranch}")]
     public static partial void PullRequestSelected(this ILogger logger, string headBranch, string baseBranch);
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "Creating pull request for branch {HeadBranch} to {BaseBranch}")]
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Creating pull request for branch {HeadBranch} to {BaseBranch}")]
     public static partial void CreatingPullRequest(this ILogger logger, string headBranch, string baseBranch);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Pull request \"{PullRequest}\" created for branch {HeadBranch} to {BaseBranch}")]
@@ -301,6 +301,6 @@ internal static partial class LoggerExtensionMethods
     [LoggerMessage(Level = LogLevel.Information, Message = "No new pull requests to create.")]
     public static partial void NoPullRequestsToCreate(this ILogger logger);
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "Found pull request template at \"{TemplatePath}\", this will be used as the default body for each pull request.")]
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Found pull request template at \"{TemplatePath}\", this will be used as the default body for each pull request.")]
     public static partial void FoundPullRequestTemplate(this ILogger logger, string templatePath);
 }

--- a/src/Stack/Commands/Remote/SyncStackCommand.cs
+++ b/src/Stack/Commands/Remote/SyncStackCommand.cs
@@ -95,7 +95,7 @@ public class SyncStackCommandHandler(
         if (stack is null)
             throw new InvalidOperationException($"Stack '{inputs.Stack}' not found.");
 
-        await displayProvider.DisplayStatus("Fetching changes from remote repository...", async (ct) =>
+        await displayProvider.DisplayStatusWithSuccess("Fetching changes from remote repository...", async (ct) =>
         {
             await Task.CompletedTask;
             gitClient.Fetch(true);
@@ -125,7 +125,7 @@ public class SyncStackCommandHandler(
             }
         }
 
-        await displayProvider.DisplayStatus("Pulling changes from remote repository...", async (ct) =>
+        await displayProvider.DisplayStatusWithSuccess("Pulling changes from remote repository...", async (ct) =>
         {
             await Task.CompletedTask;
             stackActions.PullChanges(stack);
@@ -144,7 +144,7 @@ public class SyncStackCommandHandler(
 
         if (!inputs.NoPush)
         {
-            await displayProvider.DisplayStatus("Pushing changes to remote repository...", async (ct) =>
+            await displayProvider.DisplayStatusWithSuccess("Pushing changes to remote repository...", async (ct) =>
             {
                 await Task.CompletedTask;
                 stackActions.PushChanges(stack, inputs.MaxBatchSize, forceWithLease);

--- a/src/Stack/Commands/Stack/NewStackCommand.cs
+++ b/src/Stack/Commands/Stack/NewStackCommand.cs
@@ -75,6 +75,7 @@ public record NewStackCommandInputs(string? Name, string? SourceBranch, string? 
 public class NewStackCommandHandler(
     IInputProvider inputProvider,
     ILogger<NewStackCommandHandler> logger,
+    IDisplayProvider displayProvider,
     IGitClient gitClient,
     IStackConfig stackConfig)
     : CommandHandlerBase<NewStackCommandInputs>
@@ -119,8 +120,11 @@ public class NewStackCommandHandler(
 
             try
             {
-                logger.PushingBranch(branchName);
+                await displayProvider.DisplayStatus($"Pushing branch '{branchName}' to remote repository...", async (ct) =>
+            {
+                await Task.CompletedTask;
                 gitClient.PushNewBranch(branchName);
+            }, cancellationToken);
             }
             catch (Exception)
             {

--- a/src/Stack/Commands/Stack/StackStatusCommand.cs
+++ b/src/Stack/Commands/Stack/StackStatusCommand.cs
@@ -232,14 +232,18 @@ public class StackStatusCommandHandler(
             stacksToCheckStatusFor.Add(stack);
         }
 
-        var stackStatusResults = StackHelpers.GetStackStatus(
-            stacksToCheckStatusFor,
-            currentBranch,
-            logger,
-            displayProvider,
-            gitClient,
-            gitHubClient,
-            inputs.Full);
+        var stackStatusResults = await displayProvider.DisplayStatus("Checking stack status...", async (ct) =>
+        {
+            await Task.CompletedTask;
+            return StackHelpers.GetStackStatus(
+                stacksToCheckStatusFor,
+                currentBranch,
+                logger,
+                displayProvider,
+                gitClient,
+                gitHubClient,
+                inputs.Full);
+        }, cancellationToken);
 
         return new StackStatusCommandResponse(stackStatusResults);
     }

--- a/src/Stack/Commands/Stack/StackStatusCommand.cs
+++ b/src/Stack/Commands/Stack/StackStatusCommand.cs
@@ -212,6 +212,13 @@ public class StackStatusCommandHandler(
 
         var remoteUri = gitClient.GetRemoteUri();
         var stacksForRemote = stackData.Stacks.Where(s => s.RemoteUri.Equals(remoteUri, StringComparison.OrdinalIgnoreCase)).ToList();
+
+        if (stacksForRemote.Count == 0)
+        {
+            logger.NoStacksForRepository();
+            return new StackStatusCommandResponse([]);
+        }
+
         var currentBranch = gitClient.GetCurrentBranch();
 
         var stacksToCheckStatusFor = new List<Config.Stack>();
@@ -226,6 +233,11 @@ public class StackStatusCommandHandler(
 
             if (stack is null)
             {
+                if (inputs.Stack is null)
+                {
+                    throw new InvalidOperationException("Stack not found.");
+                }
+
                 throw new InvalidOperationException($"Stack '{inputs.Stack}' not found.");
             }
 

--- a/src/Stack/Git/GitClient.cs
+++ b/src/Stack/Git/GitClient.cs
@@ -332,16 +332,7 @@ public class GitClient(ILogger<GitClient> logger, CliExecutionContext context) :
         bool captureStandardError = false,
         Func<int, Exception?>? exceptionHandler = null)
     {
-        var output = ExecuteGitCommandAndReturnOutput(command, captureStandardError, exceptionHandler);
-
-        // if (output.Length > 0)
-        // {
-        //     // We want to write the output of commands that perform
-        //     // changes to the Git repository as the output might be important.
-        //     // In verbose mode we would have already written the output
-        //     // of the command so don't write it again.
-        //     logger.DebugCommandOutput(Markup.Escape(output));
-        // }
+        ExecuteGitCommandAndReturnOutput(command, captureStandardError, exceptionHandler);
     }
 }
 

--- a/src/Stack/Git/GitClient.cs
+++ b/src/Stack/Git/GitClient.cs
@@ -334,14 +334,14 @@ public class GitClient(ILogger<GitClient> logger, CliExecutionContext context) :
     {
         var output = ExecuteGitCommandAndReturnOutput(command, captureStandardError, exceptionHandler);
 
-        if (output.Length > 0)
-        {
-            // We want to write the output of commands that perform
-            // changes to the Git repository as the output might be important.
-            // In verbose mode we would have already written the output
-            // of the command so don't write it again.
-            logger.DebugCommandOutput(Markup.Escape(output));
-        }
+        // if (output.Length > 0)
+        // {
+        //     // We want to write the output of commands that perform
+        //     // changes to the Git repository as the output might be important.
+        //     // In verbose mode we would have already written the output
+        //     // of the command so don't write it again.
+        //     logger.DebugCommandOutput(Markup.Escape(output));
+        // }
     }
 }
 

--- a/src/Stack/Git/ProcessHelpers.cs
+++ b/src/Stack/Git/ProcessHelpers.cs
@@ -16,7 +16,7 @@ public static class ProcessHelpers
         bool captureStandardError = false,
         Func<int, Exception?>? exceptionHandler = null)
     {
-        logger.TraceCommand(fileName, command);
+        logger.ExecutingCommand(fileName, command);
 
         var infoBuilder = new StringBuilder();
         var errorBuilder = new StringBuilder();
@@ -53,7 +53,7 @@ public static class ProcessHelpers
 
         if (result != 0)
         {
-            logger.TraceFailedCommand(fileName, command, result, errorBuilder.ToString());
+            logger.CommandFailed(fileName, command, result, errorBuilder.ToString());
 
             if (exceptionHandler != null)
             {
@@ -71,7 +71,7 @@ public static class ProcessHelpers
 
         if (infoBuilder.Length > 0)
         {
-            logger.TraceInfoOutput(Markup.Escape(infoBuilder.ToString()));
+            logger.CommandOutput(Markup.Escape(infoBuilder.ToString()));
         }
 
         var output = infoBuilder.ToString();
@@ -95,11 +95,11 @@ public class ProcessException(string message, string filePath, string command, i
 internal static partial class LoggerExtensionMethods
 {
     [LoggerMessage(Level = LogLevel.Trace, Message = "{FileName} {Command}")]
-    public static partial void TraceCommand(this ILogger logger, string fileName, string command);
+    public static partial void ExecutingCommand(this ILogger logger, string fileName, string command);
 
     [LoggerMessage(Level = LogLevel.Trace, Message = "Failed to execute command: {FileName} {Command}. Exit code: {ExitCode}. Error: {Error}.")]
-    public static partial void TraceFailedCommand(this ILogger logger, string fileName, string command, int exitCode, string error);
+    public static partial void CommandFailed(this ILogger logger, string fileName, string command, int exitCode, string error);
 
     [LoggerMessage(Level = LogLevel.Trace, Message = "{Info}")]
-    public static partial void TraceInfoOutput(this ILogger logger, string info);
+    public static partial void CommandOutput(this ILogger logger, string info);
 }

--- a/src/Stack/Infrastructure/AnsiConsoleLogger.cs
+++ b/src/Stack/Infrastructure/AnsiConsoleLogger.cs
@@ -41,9 +41,13 @@ public class AnsiConsoleLogger(IAnsiConsole console) : ILogger
                     break;
                 }
             case LogLevel.Debug:
+                {
+                    console.MarkupLine($"[grey58]{message}[/]");
+                    break;
+                }
             case LogLevel.Trace:
                 {
-                    console.MarkupLine($"[grey]{message}[/]");
+                    console.MarkupLine($"[grey30]{message}[/]");
                     break;
                 }
         }

--- a/src/Stack/Infrastructure/Commands/Command.cs
+++ b/src/Stack/Infrastructure/Commands/Command.cs
@@ -28,6 +28,7 @@ public abstract class Command : System.CommandLine.Command
         InputProvider = inputProvider;
 
         Add(CommonOptions.WorkingDirectory);
+        Add(CommonOptions.Debug);
         Add(CommonOptions.Verbose);
 
         SetAction(async (parseResult, cancellationToken) =>
@@ -71,7 +72,7 @@ internal static partial class LoggerExtensionMethods
     [LoggerMessage(Level = LogLevel.Error, Message = "An error occurred running command \"{FilePath} {Command}\"")]
     public static partial void ProcessExceptionCommandDetails(this ILogger logger, string filePath, string command);
 
-    [LoggerMessage(Level = LogLevel.Debug, Message = "{Message}")]
+    [LoggerMessage(Level = LogLevel.Information, Message = "{Message}")]
     public static partial void ProcessExceptionErrorMessage(this ILogger logger, string message);
 
     [LoggerMessage(Level = LogLevel.Error, Message = "{Message}")]

--- a/src/Stack/Infrastructure/CommonOptions.cs
+++ b/src/Stack/Infrastructure/CommonOptions.cs
@@ -8,13 +8,13 @@ public static class CommonOptions
         Required = false
     };
 
-    public static Option<bool> Debug { get; } = new Option<bool>("--debug", "-d")
+    public static Option<bool> Debug { get; } = new Option<bool>("--debug")
     {
         Description = "Show debug output.",
         Required = false
     };
 
-    public static Option<bool> Verbose { get; } = new Option<bool>("--verbose", "-v")
+    public static Option<bool> Verbose { get; } = new Option<bool>("--verbose")
     {
         Description = "Show verbose output.",
         Required = false

--- a/src/Stack/Infrastructure/CommonOptions.cs
+++ b/src/Stack/Infrastructure/CommonOptions.cs
@@ -8,7 +8,13 @@ public static class CommonOptions
         Required = false
     };
 
-    public static Option<bool> Verbose { get; } = new Option<bool>("--verbose")
+    public static Option<bool> Debug { get; } = new Option<bool>("--debug", "-d")
+    {
+        Description = "Show debug output.",
+        Required = false
+    };
+
+    public static Option<bool> Verbose { get; } = new Option<bool>("--verbose", "-v")
     {
         Description = "Show verbose output.",
         Required = false

--- a/src/Stack/Infrastructure/ConsoleDisplayProvider.cs
+++ b/src/Stack/Infrastructure/ConsoleDisplayProvider.cs
@@ -7,6 +7,7 @@ namespace Stack.Infrastructure;
 public interface IDisplayProvider
 {
     Task DisplayStatus(string message, Func<CancellationToken, Task> action, CancellationToken cancellationToken = default);
+    Task<T> DisplayStatus<T>(string message, Func<CancellationToken, Task<T>> action, CancellationToken cancellationToken = default);
     Task DisplayTree<T>(string header, IEnumerable<TreeItem<T>> items, Func<T, string>? itemFormatter = null, CancellationToken cancellationToken = default) where T : notnull;
     Task DisplayMessage(string message, CancellationToken cancellationToken = default);
     Task DisplayHeader(string header, CancellationToken cancellationToken = default);
@@ -15,12 +16,63 @@ public interface IDisplayProvider
 
 public class ConsoleDisplayProvider(IAnsiConsole console) : IDisplayProvider
 {
+    readonly AsyncLocal<StatusContext?> _currentStatusContext = new();
+
     public async Task DisplayStatus(string message, Func<CancellationToken, Task> action, CancellationToken cancellationToken = default)
     {
+        if (_currentStatusContext.Value is not null)
+        {
+            _currentStatusContext.Value.Status(message);
+            await action(cancellationToken);
+            return;
+        }
+
         await console
             .Status()
             .Spinner(Spinner.Known.Dots3)
-            .StartAsync(message, async (_) => await action(cancellationToken));
+            .StartAsync(message, async (context) =>
+            {
+                _currentStatusContext.Value = context;
+                try
+                {
+                    await action(cancellationToken);
+                }
+                finally
+                {
+                    if (ReferenceEquals(_currentStatusContext.Value, context))
+                    {
+                        _currentStatusContext.Value = null;
+                    }
+                }
+            });
+    }
+
+    public async Task<T> DisplayStatus<T>(string message, Func<CancellationToken, Task<T>> action, CancellationToken cancellationToken = default)
+    {
+        if (_currentStatusContext.Value is not null)
+        {
+            _currentStatusContext.Value.Status(message);
+            return await action(cancellationToken);
+        }
+
+        return await console
+            .Status()
+            .Spinner(Spinner.Known.Dots3)
+            .StartAsync(message, async (context) =>
+            {
+                _currentStatusContext.Value = context;
+                try
+                {
+                    return await action(cancellationToken);
+                }
+                finally
+                {
+                    if (ReferenceEquals(_currentStatusContext.Value, context))
+                    {
+                        _currentStatusContext.Value = null;
+                    }
+                }
+            });
     }
 
     public async Task DisplayTree<T>(string header, IEnumerable<TreeItem<T>> items, Func<T, string>? itemFormatter = null, CancellationToken cancellationToken = default)

--- a/src/Stack/Infrastructure/ConsoleDisplayProvider.cs
+++ b/src/Stack/Infrastructure/ConsoleDisplayProvider.cs
@@ -10,6 +10,16 @@ public interface IDisplayProvider
     Task<T> DisplayStatus<T>(string message, Func<CancellationToken, Task<T>> action, CancellationToken cancellationToken = default);
     Task DisplayTree<T>(string header, IEnumerable<TreeItem<T>> items, Func<T, string>? itemFormatter = null, CancellationToken cancellationToken = default) where T : notnull;
     Task DisplayMessage(string message, CancellationToken cancellationToken = default);
+    Task DisplaySuccess(string message, CancellationToken cancellationToken = default)
+        => DisplayMessage($"{Emoji.Known.CheckMark}  {message}", cancellationToken);
+    Task DisplayStatusWithSuccess(string message, Func<CancellationToken, Task> action, CancellationToken cancellationToken = default)
+    {
+        return DisplayStatus(message, async ct =>
+        {
+            await action(ct);
+            await DisplaySuccess(message, ct);
+        }, cancellationToken);
+    }
     Task DisplayHeader(string header, CancellationToken cancellationToken = default);
     Task DisplayNewLine(CancellationToken cancellationToken = default);
 }

--- a/src/Stack/Infrastructure/HostApplicationBuilderExtensions.cs
+++ b/src/Stack/Infrastructure/HostApplicationBuilderExtensions.cs
@@ -24,11 +24,11 @@ public static class HostApplicationBuilderExtensions
     {
         builder.Logging.SetMinimumLevel(LogLevel.Information);
 
-        if (args.Contains(CommonOptions.Debug.Name) || args.Any(a => CommonOptions.Debug.Aliases.Contains(a)))
+        if (args.Contains(CommonOptions.Debug.Name) || args.Any(CommonOptions.Debug.Aliases.Contains))
         {
             builder.Logging.SetMinimumLevel(LogLevel.Debug);
         }
-        else if (args.Contains(CommonOptions.Verbose.Name) || args.Any(a => CommonOptions.Verbose.Aliases.Contains(a)))
+        else if (args.Contains(CommonOptions.Verbose.Name) || args.Any(CommonOptions.Verbose.Aliases.Contains))
         {
             builder.Logging.SetMinimumLevel(LogLevel.Trace);
         }

--- a/src/Stack/Infrastructure/HostApplicationBuilderExtensions.cs
+++ b/src/Stack/Infrastructure/HostApplicationBuilderExtensions.cs
@@ -22,9 +22,13 @@ public static class HostApplicationBuilderExtensions
 
     public static IHostApplicationBuilder ConfigureLogging(this IHostApplicationBuilder builder, string[] args)
     {
-        builder.Logging.SetMinimumLevel(LogLevel.Debug);
+        builder.Logging.SetMinimumLevel(LogLevel.Information);
 
-        if (args.Contains("--verbose") || args.Contains("-v"))
+        if (args.Contains(CommonOptions.Debug.Name) || args.Any(a => CommonOptions.Debug.Aliases.Contains(a)))
+        {
+            builder.Logging.SetMinimumLevel(LogLevel.Debug);
+        }
+        else if (args.Contains(CommonOptions.Verbose.Name) || args.Any(a => CommonOptions.Verbose.Aliases.Contains(a)))
         {
             builder.Logging.SetMinimumLevel(LogLevel.Trace);
         }


### PR DESCRIPTION
Improves logging and status output: 
- Adds new `--debug` option to allow separation between debug (e.g. "rebasing my-feature-branch onto main") and verbose logging (e.g. "running command 'git ...'").
- Change logging levels of some message to make normal usage not so noisy.
- Only log command output in verbose mode.
- Wrap long running actions in a status display to make it clearer what is happening.
- Add "success" messages to show completed progress during sync command