### PR TITLE
Default to updating stack without checking pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This is where `stack` comes in: It lets you manage multiple branches that form t
   - [Adding a new branch](#adding-a-new-branch)
   - [Incorporating changes from the remote repository](#incorporating-changes-from-the-remote-repository)
     - [Specifying an update strategy](#specifying-an-update-strategy)
+    - [Checking pull requests during update](#checking-pull-requests-during-update)
   - [Creating pull requests](#creating-pull-requests)
 - [Commands](#commands)
 
@@ -123,7 +124,7 @@ To use the merge strategy, either:
 
 Updating a stack using merge, particularly if it has a number of branches in it, can result in lots of merge commits.
 
-If you merge a pull request using "Squash and merge" then you might find that the first update to a stack after that results in merge conflicts that you need to resolve. This can be a bit of a pain.
+If you merge a pull request using "Squash and merge" then you might find that the first update to a stack after that results in merge conflicts that you need to resolve.
 
 ##### Rebase <!-- omit from toc -->
 
@@ -143,6 +144,10 @@ A common pattern when using pull requests is to Squash Merge the pull request wh
 Stack has handling to detect when a squash merge happens during updating a stack using rebase as the update strategy. It will skip the commits that were squash merged, avoiding conflicts.
 
 The remote tracking branch for the branch that was squash merged needs to be deleted for this handling to be enabled.
+
+#### Checking pull requests during update
+
+A branch will be skipped during the update of a stack if it's remote tracking branch has been deleted, which normally happens when a pull request is merged. If you don't delete the remote tracking branch when merging pull requests you can skip branches where the pull request is merged with the `--check-pull-requests` option.
 
 ### Creating pull requests
 
@@ -209,14 +214,14 @@ Usage:
   stack status [options]
 
 Options:
-  --working-dir   The path to the directory containing the git repository. Defaults to the current directory.
-  --debug         Show debug output.
-  --verbose       Show verbose output.
-  --json          Write output and log messages as JSON. Log messages will be written to stderr.
-  -s, --stack     The name of the stack.
-  --all           Show status of all stacks.
-  --full          Show full status including pull requests.
-  -?, -h, --help  Show help and usage information
+  --working-dir          The path to the directory containing the git repository. Defaults to the current directory.
+  --debug                Show debug output.
+  --verbose              Show verbose output.
+  --json                 Write output and log messages as JSON. Log messages will be written to stderr.
+  -s, --stack            The name of the stack.
+  --all                  Show status of all stacks.
+  --check-pull-requests  Include the status of pull requests in output.
+  -?, -h, --help         Show help and usage information
 ```
 
 #### `stack delete` <!-- omit from toc -->
@@ -266,14 +271,15 @@ Usage:
   stack update [options]
 
 Options:
-  --working-dir   The path to the directory containing the git repository. Defaults to the current directory.
-  --debug         Show debug output.
-  --verbose       Show verbose output.
-  --json          Write output and log messages as JSON. Log messages will be written to stderr.
-  -s, --stack     The name of the stack.
-  --rebase        Use rebase when updating the stack. Overrides any setting in Git configuration.
-  --merge         Use merge when updating the stack. Overrides any setting in Git configuration.
-  -?, -h, --help  Show help and usage information
+  --working-dir          The path to the directory containing the git repository. Defaults to the current directory.
+  --debug                Show debug output.
+  --verbose              Show verbose output.
+  --json                 Write output and log messages as JSON. Log messages will be written to stderr.
+  -s, --stack            The name of the stack.
+  --rebase               Use rebase when updating the stack. Overrides any setting in Git configuration.
+  --merge                Use merge when updating the stack. Overrides any setting in Git configuration.
+  --check-pull-requests  Check the status of pull requests when determining if a branch should be included in updating the stack.
+  -?, -h, --help         Show help and usage information
 ```
 
 #### `stack switch` <!-- omit from toc -->
@@ -438,17 +444,18 @@ Usage:
   stack sync [options]
 
 Options:
-  --working-dir     The path to the directory containing the git repository. Defaults to the current directory.
-  --debug           Show debug output.
-  --verbose         Show verbose output.
-  --json            Write output and log messages as JSON. Log messages will be written to stderr.
-  -s, --stack       The name of the stack.
-  --max-batch-size  The maximum number of branches to process at once. [default: 5]
-  --rebase          Use rebase when updating the stack. Overrides any setting in Git configuration.
-  --merge           Use merge when updating the stack. Overrides any setting in Git configuration.
-  -y, --yes         Confirm the command without prompting.
-  --no-push         Don't push changes to the remote repository
-  -?, -h, --help    Show help and usage information
+  --working-dir          The path to the directory containing the git repository. Defaults to the current directory.
+  --debug                Show debug output.
+  --verbose              Show verbose output.
+  --json                 Write output and log messages as JSON. Log messages will be written to stderr.
+  -s, --stack            The name of the stack.
+  --max-batch-size       The maximum number of branches to process at once. [default: 5]
+  --rebase               Use rebase when updating the stack. Overrides any setting in Git configuration.
+  --merge                Use merge when updating the stack. Overrides any setting in Git configuration.
+  -y, --yes              Confirm the command without prompting.
+  --check-pull-requests  Check the status of pull requests when determining if a branch should be included in updating the stack.
+  --no-push              Don't push changes to the remote repository
+  -?, -h, --help         Show help and usage information
 ```
 
 ### GitHub commands <!-- omit from toc -->

--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ Options:
   --rebase               Use rebase when updating the stack. Overrides any setting in Git configuration.
   --merge                Use merge when updating the stack. Overrides any setting in Git configuration.
   -y, --yes              Confirm the command without prompting.
-  --check-pull-requests  Check the status of pull requests when determining if a branch should be included in updating the stack.
+  --check-pull-requests  Check the status of pull requests as part of determining if a branch should be included when updating the stack.
   --no-push              Don't push changes to the remote repository
   -?, -h, --help         Show help and usage information
 ```

--- a/src/Stack.Tests/Commands/Helpers/StackActionsTests.cs
+++ b/src/Stack.Tests/Commands/Helpers/StackActionsTests.cs
@@ -21,7 +21,6 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
-        var gitHubClient = Substitute.For<IGitHubClient>();
         var conflictResolutionDetector = Substitute.For<IConflictResolutionDetector>();
         var stack = new Config.Stack("Stack1", Some.HttpsUri().ToString(), sourceBranch, new List<Config.Branch> { new(feature, []) });
 
@@ -40,7 +39,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var executionContext = new CliExecutionContext { WorkingDirectory = "/repo" };
         var factory = Substitute.For<IGitClientFactory>();
         factory.Create(Arg.Any<string>()).Returns(gitClient);
-        var actions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var actions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         var act = async () => await actions.UpdateStack(stack, UpdateStrategy.Merge, CancellationToken.None);
@@ -59,7 +58,6 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
-        var gitHubClient = Substitute.For<IGitHubClient>();
         var conflictResolutionDetector = Substitute.For<IConflictResolutionDetector>();
         var stack = new Config.Stack("Stack1", Some.HttpsUri().ToString(), sourceBranch, new List<Config.Branch> { new(feature, []) });
 
@@ -77,7 +75,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var executionContext = new CliExecutionContext { WorkingDirectory = "/repo" };
         var factory = Substitute.For<IGitClientFactory>();
         factory.Create(Arg.Any<string>()).Returns(gitClient);
-        var actions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var actions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         await actions.UpdateStack(stack, UpdateStrategy.Merge, CancellationToken.None);
@@ -96,7 +94,6 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
-        var gitHubClient = Substitute.For<IGitHubClient>();
         var conflictResolutionDetector = Substitute.For<IConflictResolutionDetector>();
         var stack = new Config.Stack("Stack1", Some.HttpsUri().ToString(), source, new List<Config.Branch> { new(feature, []) });
 
@@ -114,7 +111,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var executionContext = new CliExecutionContext { WorkingDirectory = "/repo" };
         var factory = Substitute.For<IGitClientFactory>();
         factory.Create(Arg.Any<string>()).Returns(gitClient);
-        var actions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var actions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         var act = async () => await actions.UpdateStack(stack, UpdateStrategy.Rebase, CancellationToken.None);
@@ -133,7 +130,6 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
-        var gitHubClient = Substitute.For<IGitHubClient>();
         var conflictResolutionDetector = Substitute.For<IConflictResolutionDetector>();
         var stack = new Config.Stack("Stack1", Some.HttpsUri().ToString(), source, new List<Config.Branch> { new(feature, []) });
 
@@ -151,7 +147,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var executionContext = new CliExecutionContext { WorkingDirectory = "/repo" };
         var factory = Substitute.For<IGitClientFactory>();
         factory.Create(Arg.Any<string>()).Returns(gitClient);
-        var actions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var actions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         await actions.UpdateStack(stack, UpdateStrategy.Rebase, CancellationToken.None);
@@ -192,7 +188,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var executionContext = new CliExecutionContext { WorkingDirectory = "/repo" };
         var factory = Substitute.For<IGitClientFactory>();
         factory.Create(executionContext.WorkingDirectory).Returns(gitClient);
-        var stackActions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PullChanges(stack);
@@ -211,7 +207,6 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var branchThatDoesNotExistInRemote = Some.BranchName();
 
         var gitClient = Substitute.For<IGitClient>();
-        var gitHubClient = Substitute.For<IGitHubClient>();
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
         var conflictResolutionDetector = Substitute.For<IConflictResolutionDetector>();
@@ -234,7 +229,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var executionContext = new CliExecutionContext { WorkingDirectory = "/repo" };
         var factory = Substitute.For<IGitClientFactory>();
         factory.Create(executionContext.WorkingDirectory).Returns(gitClient);
-        var stackActions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PullChanges(stack);
@@ -279,7 +274,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var worktreePath = "/worktree";
         factory.Create(executionContext.WorkingDirectory).Returns(gitClient);
         factory.Create(worktreePath).Returns(worktreeGitClient);
-        var stackActions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PullChanges(stack);
@@ -295,7 +290,6 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         // Arrange
         var sourceBranch = Some.BranchName();
         var gitClient = Substitute.For<IGitClient>();
-        var gitHubClient = Substitute.For<IGitHubClient>();
         gitClient.GetCurrentBranch().Returns(sourceBranch);
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
@@ -312,7 +306,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var executionContext = new CliExecutionContext { WorkingDirectory = "/repo" };
         var factory = Substitute.For<IGitClientFactory>();
         factory.Create(Arg.Any<string>()).Returns(gitClient);
-        var stackActions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PullChanges(stack);
@@ -329,7 +323,6 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var sourceBranch = Some.BranchName();
         var otherBranch = Some.BranchName();
         var gitClient = Substitute.For<IGitClient>();
-        var gitHubClient = Substitute.For<IGitHubClient>();
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
         var conflictResolutionDetector = Substitute.For<IConflictResolutionDetector>();
@@ -350,7 +343,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var executionContext = new CliExecutionContext { WorkingDirectory = "/repo" };
         var factory = Substitute.For<IGitClientFactory>();
         factory.Create(Arg.Any<string>()).Returns(gitClient);
-        var stackActions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PullChanges(stack);
@@ -367,7 +360,6 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var sourceBranch = Some.BranchName();
         var otherBranch = Some.BranchName();
         var gitClient = Substitute.For<IGitClient>();
-        var gitHubClient = Substitute.For<IGitHubClient>();
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
         var conflictResolutionDetector = Substitute.For<IConflictResolutionDetector>();
@@ -384,7 +376,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var executionContext = new CliExecutionContext { WorkingDirectory = "/repo" };
         var factory = Substitute.For<IGitClientFactory>();
         factory.Create(Arg.Any<string>()).Returns(gitClient);
-        var stackActions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PullChanges(stack);
@@ -404,7 +396,6 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
 
         var defaultGitClient = Substitute.For<IGitClient>();
         var worktreeGitClient = Substitute.For<IGitClient>();
-        var gitHubClient = Substitute.For<IGitHubClient>();
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
         var conflictResolutionDetector = Substitute.For<IConflictResolutionDetector>();
@@ -427,7 +418,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         factory.Create(executionContext.WorkingDirectory).Returns(defaultGitClient);
         factory.Create(worktreePath).Returns(worktreeGitClient);
 
-        var stackActions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PullChanges(stack);
@@ -446,7 +437,6 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var branchNotAheadOfRemote = Some.BranchName();
 
         var gitClient = Substitute.For<IGitClient>();
-        var gitHubClient = Substitute.For<IGitHubClient>();
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
         var conflictResolutionDetector = Substitute.For<IConflictResolutionDetector>();
@@ -475,7 +465,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var executionContext = new CliExecutionContext { WorkingDirectory = "/repo" };
         var factory = Substitute.For<IGitClientFactory>();
         factory.Create(Arg.Any<string>()).Returns(gitClient);
-        var stackActions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PushChanges(stack, 5, false);
@@ -493,7 +483,6 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var branchThatDoesNotExistInRemoteButIsAhead = Some.BranchName();
 
         var gitClient = Substitute.For<IGitClient>();
-        var gitHubClient = Substitute.For<IGitHubClient>();
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
         var conflictResolutionDetector = Substitute.For<IConflictResolutionDetector>();
@@ -522,7 +511,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var executionContext = new CliExecutionContext { WorkingDirectory = "/repo" };
         var factory = Substitute.For<IGitClientFactory>();
         factory.Create(Arg.Any<string>()).Returns(gitClient);
-        var stackActions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PushChanges(stack, 5, false);
@@ -540,7 +529,6 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var newBranchWithNoRemote = Some.BranchName();
 
         var gitClient = Substitute.For<IGitClient>();
-        var gitHubClient = Substitute.For<IGitHubClient>();
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
         var conflictResolutionDetector = Substitute.For<IConflictResolutionDetector>();
@@ -574,7 +562,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var executionContext = new CliExecutionContext { WorkingDirectory = "/repo" };
         var factory = Substitute.For<IGitClientFactory>();
         factory.Create(Arg.Any<string>()).Returns(gitClient);
-        var stackActions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PushChanges(stack, 5, false);
@@ -594,7 +582,6 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var branch3 = Some.BranchName();
 
         var gitClient = Substitute.For<IGitClient>();
-        var gitHubClient = Substitute.For<IGitHubClient>();
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
         var conflictResolutionDetector = Substitute.For<IConflictResolutionDetector>();
@@ -625,7 +612,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var executionContext = new CliExecutionContext { WorkingDirectory = "/repo" };
         var factory = Substitute.For<IGitClientFactory>();
         factory.Create(Arg.Any<string>()).Returns(gitClient);
-        var stackActions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PushChanges(stack, maxBatchSize: 2, forceWithLease: false);
@@ -645,7 +632,6 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var branchAhead = Some.BranchName();
 
         var gitClient = Substitute.For<IGitClient>();
-        var gitHubClient = Substitute.For<IGitHubClient>();
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
         var conflictResolutionDetector = Substitute.For<IConflictResolutionDetector>();
@@ -666,7 +652,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var executionContext = new CliExecutionContext { WorkingDirectory = "/repo" };
         var factory = Substitute.For<IGitClientFactory>();
         factory.Create(Arg.Any<string>()).Returns(gitClient);
-        var stackActions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PushChanges(stack, maxBatchSize: 5, forceWithLease: true);
@@ -684,7 +670,6 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var branchBehind = Some.BranchName();
 
         var gitClient = Substitute.For<IGitClient>();
-        var gitHubClient = Substitute.For<IGitHubClient>();
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
         var conflictResolutionDetector = Substitute.For<IConflictResolutionDetector>();
@@ -707,7 +692,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var executionContext = new CliExecutionContext { WorkingDirectory = "/repo" };
         var factory = Substitute.For<IGitClientFactory>();
         factory.Create(Arg.Any<string>()).Returns(gitClient);
-        var stackActions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PushChanges(stack, maxBatchSize: 5, forceWithLease: false);
@@ -726,7 +711,6 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var worktreePath = $"C:/temp/{Some.Name()}";
 
         var gitClient = Substitute.For<IGitClient>();
-        var gitHubClient = Substitute.For<IGitHubClient>();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
@@ -752,7 +736,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         );
 
         var executionContext = new CliExecutionContext { WorkingDirectory = "/some/path" };
-        var stackActions = new StackActions(gitClientFactory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, executionContext, logger, displayProvider, conflictResolutionDetector);
 
         gitClientFactory.Create(executionContext.WorkingDirectory).Returns(gitClient);
 
@@ -774,8 +758,6 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var worktreePath = $"C:/temp/{Some.Name()}";
 
         var gitClient = Substitute.For<IGitClient>();
-        var gitHubClient = Substitute.For<IGitHubClient>();
-        var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitClientFactory = Substitute.For<IGitClientFactory>();
@@ -800,7 +782,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         );
 
         var executionContext = new CliExecutionContext { WorkingDirectory = "/some/path" };
-        var stackActions = new StackActions(gitClientFactory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, executionContext, logger, displayProvider, conflictResolutionDetector);
 
         gitClientFactory.Create(executionContext.WorkingDirectory).Returns(gitClient);
 

--- a/src/Stack.Tests/Commands/Helpers/StackActionsTests.cs
+++ b/src/Stack.Tests/Commands/Helpers/StackActionsTests.cs
@@ -1,4 +1,3 @@
-using System.Net.Http.Headers;
 using FluentAssertions;
 using Meziantou.Extensions.Logging.Xunit;
 using NSubstitute;

--- a/src/Stack.Tests/Commands/Helpers/StackActionsTests.cs
+++ b/src/Stack.Tests/Commands/Helpers/StackActionsTests.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 using FluentAssertions;
 using Meziantou.Extensions.Logging.Xunit;
 using NSubstitute;
@@ -21,6 +22,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
+        var gitHubClient = Substitute.For<IGitHubClient>();
         var conflictResolutionDetector = Substitute.For<IConflictResolutionDetector>();
         var stack = new Config.Stack("Stack1", Some.HttpsUri().ToString(), sourceBranch, new List<Config.Branch> { new(feature, []) });
 
@@ -39,7 +41,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var executionContext = new CliExecutionContext { WorkingDirectory = "/repo" };
         var factory = Substitute.For<IGitClientFactory>();
         factory.Create(Arg.Any<string>()).Returns(gitClient);
-        var actions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
+        var actions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         var act = async () => await actions.UpdateStack(stack, UpdateStrategy.Merge, CancellationToken.None);
@@ -58,6 +60,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
+        var gitHubClient = Substitute.For<IGitHubClient>();
         var conflictResolutionDetector = Substitute.For<IConflictResolutionDetector>();
         var stack = new Config.Stack("Stack1", Some.HttpsUri().ToString(), sourceBranch, new List<Config.Branch> { new(feature, []) });
 
@@ -75,7 +78,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var executionContext = new CliExecutionContext { WorkingDirectory = "/repo" };
         var factory = Substitute.For<IGitClientFactory>();
         factory.Create(Arg.Any<string>()).Returns(gitClient);
-        var actions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
+        var actions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         await actions.UpdateStack(stack, UpdateStrategy.Merge, CancellationToken.None);
@@ -94,6 +97,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
+        var gitHubClient = Substitute.For<IGitHubClient>();
         var conflictResolutionDetector = Substitute.For<IConflictResolutionDetector>();
         var stack = new Config.Stack("Stack1", Some.HttpsUri().ToString(), source, new List<Config.Branch> { new(feature, []) });
 
@@ -111,7 +115,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var executionContext = new CliExecutionContext { WorkingDirectory = "/repo" };
         var factory = Substitute.For<IGitClientFactory>();
         factory.Create(Arg.Any<string>()).Returns(gitClient);
-        var actions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
+        var actions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         var act = async () => await actions.UpdateStack(stack, UpdateStrategy.Rebase, CancellationToken.None);
@@ -130,6 +134,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitClient = Substitute.For<IGitClient>();
+        var gitHubClient = Substitute.For<IGitHubClient>();
         var conflictResolutionDetector = Substitute.For<IConflictResolutionDetector>();
         var stack = new Config.Stack("Stack1", Some.HttpsUri().ToString(), source, new List<Config.Branch> { new(feature, []) });
 
@@ -147,7 +152,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var executionContext = new CliExecutionContext { WorkingDirectory = "/repo" };
         var factory = Substitute.For<IGitClientFactory>();
         factory.Create(Arg.Any<string>()).Returns(gitClient);
-        var actions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
+        var actions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         await actions.UpdateStack(stack, UpdateStrategy.Rebase, CancellationToken.None);
@@ -188,7 +193,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var executionContext = new CliExecutionContext { WorkingDirectory = "/repo" };
         var factory = Substitute.For<IGitClientFactory>();
         factory.Create(executionContext.WorkingDirectory).Returns(gitClient);
-        var stackActions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PullChanges(stack);
@@ -207,6 +212,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var branchThatDoesNotExistInRemote = Some.BranchName();
 
         var gitClient = Substitute.For<IGitClient>();
+        var gitHubClient = Substitute.For<IGitHubClient>();
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
         var conflictResolutionDetector = Substitute.For<IConflictResolutionDetector>();
@@ -229,7 +235,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var executionContext = new CliExecutionContext { WorkingDirectory = "/repo" };
         var factory = Substitute.For<IGitClientFactory>();
         factory.Create(executionContext.WorkingDirectory).Returns(gitClient);
-        var stackActions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PullChanges(stack);
@@ -274,7 +280,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var worktreePath = "/worktree";
         factory.Create(executionContext.WorkingDirectory).Returns(gitClient);
         factory.Create(worktreePath).Returns(worktreeGitClient);
-        var stackActions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PullChanges(stack);
@@ -290,6 +296,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         // Arrange
         var sourceBranch = Some.BranchName();
         var gitClient = Substitute.For<IGitClient>();
+        var gitHubClient = Substitute.For<IGitHubClient>();
         gitClient.GetCurrentBranch().Returns(sourceBranch);
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
@@ -306,7 +313,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var executionContext = new CliExecutionContext { WorkingDirectory = "/repo" };
         var factory = Substitute.For<IGitClientFactory>();
         factory.Create(Arg.Any<string>()).Returns(gitClient);
-        var stackActions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PullChanges(stack);
@@ -323,6 +330,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var sourceBranch = Some.BranchName();
         var otherBranch = Some.BranchName();
         var gitClient = Substitute.For<IGitClient>();
+        var gitHubClient = Substitute.For<IGitHubClient>();
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
         var conflictResolutionDetector = Substitute.For<IConflictResolutionDetector>();
@@ -343,7 +351,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var executionContext = new CliExecutionContext { WorkingDirectory = "/repo" };
         var factory = Substitute.For<IGitClientFactory>();
         factory.Create(Arg.Any<string>()).Returns(gitClient);
-        var stackActions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PullChanges(stack);
@@ -360,6 +368,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var sourceBranch = Some.BranchName();
         var otherBranch = Some.BranchName();
         var gitClient = Substitute.For<IGitClient>();
+        var gitHubClient = Substitute.For<IGitHubClient>();
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
         var conflictResolutionDetector = Substitute.For<IConflictResolutionDetector>();
@@ -376,7 +385,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var executionContext = new CliExecutionContext { WorkingDirectory = "/repo" };
         var factory = Substitute.For<IGitClientFactory>();
         factory.Create(Arg.Any<string>()).Returns(gitClient);
-        var stackActions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PullChanges(stack);
@@ -396,6 +405,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
 
         var defaultGitClient = Substitute.For<IGitClient>();
         var worktreeGitClient = Substitute.For<IGitClient>();
+        var gitHubClient = Substitute.For<IGitHubClient>();
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
         var conflictResolutionDetector = Substitute.For<IConflictResolutionDetector>();
@@ -418,7 +428,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         factory.Create(executionContext.WorkingDirectory).Returns(defaultGitClient);
         factory.Create(worktreePath).Returns(worktreeGitClient);
 
-        var stackActions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PullChanges(stack);
@@ -437,6 +447,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var branchNotAheadOfRemote = Some.BranchName();
 
         var gitClient = Substitute.For<IGitClient>();
+        var gitHubClient = Substitute.For<IGitHubClient>();
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
         var conflictResolutionDetector = Substitute.For<IConflictResolutionDetector>();
@@ -465,7 +476,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var executionContext = new CliExecutionContext { WorkingDirectory = "/repo" };
         var factory = Substitute.For<IGitClientFactory>();
         factory.Create(Arg.Any<string>()).Returns(gitClient);
-        var stackActions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PushChanges(stack, 5, false);
@@ -483,6 +494,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var branchThatDoesNotExistInRemoteButIsAhead = Some.BranchName();
 
         var gitClient = Substitute.For<IGitClient>();
+        var gitHubClient = Substitute.For<IGitHubClient>();
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
         var conflictResolutionDetector = Substitute.For<IConflictResolutionDetector>();
@@ -511,7 +523,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var executionContext = new CliExecutionContext { WorkingDirectory = "/repo" };
         var factory = Substitute.For<IGitClientFactory>();
         factory.Create(Arg.Any<string>()).Returns(gitClient);
-        var stackActions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PushChanges(stack, 5, false);
@@ -529,6 +541,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var newBranchWithNoRemote = Some.BranchName();
 
         var gitClient = Substitute.For<IGitClient>();
+        var gitHubClient = Substitute.For<IGitHubClient>();
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
         var conflictResolutionDetector = Substitute.For<IConflictResolutionDetector>();
@@ -562,7 +575,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var executionContext = new CliExecutionContext { WorkingDirectory = "/repo" };
         var factory = Substitute.For<IGitClientFactory>();
         factory.Create(Arg.Any<string>()).Returns(gitClient);
-        var stackActions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PushChanges(stack, 5, false);
@@ -582,6 +595,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var branch3 = Some.BranchName();
 
         var gitClient = Substitute.For<IGitClient>();
+        var gitHubClient = Substitute.For<IGitHubClient>();
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
         var conflictResolutionDetector = Substitute.For<IConflictResolutionDetector>();
@@ -612,7 +626,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var executionContext = new CliExecutionContext { WorkingDirectory = "/repo" };
         var factory = Substitute.For<IGitClientFactory>();
         factory.Create(Arg.Any<string>()).Returns(gitClient);
-        var stackActions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PushChanges(stack, maxBatchSize: 2, forceWithLease: false);
@@ -632,6 +646,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var branchAhead = Some.BranchName();
 
         var gitClient = Substitute.For<IGitClient>();
+        var gitHubClient = Substitute.For<IGitHubClient>();
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
         var conflictResolutionDetector = Substitute.For<IConflictResolutionDetector>();
@@ -652,7 +667,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var executionContext = new CliExecutionContext { WorkingDirectory = "/repo" };
         var factory = Substitute.For<IGitClientFactory>();
         factory.Create(Arg.Any<string>()).Returns(gitClient);
-        var stackActions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PushChanges(stack, maxBatchSize: 5, forceWithLease: true);
@@ -670,6 +685,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var branchBehind = Some.BranchName();
 
         var gitClient = Substitute.For<IGitClient>();
+        var gitHubClient = Substitute.For<IGitHubClient>();
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
         var conflictResolutionDetector = Substitute.For<IConflictResolutionDetector>();
@@ -692,7 +708,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var executionContext = new CliExecutionContext { WorkingDirectory = "/repo" };
         var factory = Substitute.For<IGitClientFactory>();
         factory.Create(Arg.Any<string>()).Returns(gitClient);
-        var stackActions = new StackActions(factory, executionContext, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(factory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PushChanges(stack, maxBatchSize: 5, forceWithLease: false);
@@ -711,6 +727,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var worktreePath = $"C:/temp/{Some.Name()}";
 
         var gitClient = Substitute.For<IGitClient>();
+        var gitHubClient = Substitute.For<IGitHubClient>();
         var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
@@ -736,7 +753,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         );
 
         var executionContext = new CliExecutionContext { WorkingDirectory = "/some/path" };
-        var stackActions = new StackActions(gitClientFactory, executionContext, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         gitClientFactory.Create(executionContext.WorkingDirectory).Returns(gitClient);
 
@@ -758,6 +775,8 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var worktreePath = $"C:/temp/{Some.Name()}";
 
         var gitClient = Substitute.For<IGitClient>();
+        var gitHubClient = Substitute.For<IGitHubClient>();
+        var inputProvider = Substitute.For<IInputProvider>();
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
         var gitClientFactory = Substitute.For<IGitClientFactory>();
@@ -782,7 +801,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         );
 
         var executionContext = new CliExecutionContext { WorkingDirectory = "/some/path" };
-        var stackActions = new StackActions(gitClientFactory, executionContext, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         gitClientFactory.Create(executionContext.WorkingDirectory).Returns(gitClient);
 
@@ -793,5 +812,44 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         gitClientFactory.Received(1).Create(worktreePath);
         worktreeGitClient.Received(1).RebaseFromLocalSourceBranch(sourceBranch);
         gitClient.DidNotReceive().ChangeBranch(branchInWorktree); // Should not change branch since it's in a worktree
+    }
+
+    [Fact]
+    public async Task UpdateStack_WhenCheckingPullRequests_AndGitHubClientIsNotAvailable_Throws()
+    {
+        // Arrange
+        var sourceBranch = Some.BranchName();
+
+        var gitClient = Substitute.For<IGitClient>();
+        var gitHubClient = new TestGitHubRepositoryBuilder().NotAvailable().Build();
+        var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
+        var gitClientFactory = Substitute.For<IGitClientFactory>();
+        var conflictResolutionDetector = Substitute.For<IConflictResolutionDetector>();
+
+        gitClient.GetCurrentBranch().Returns(sourceBranch);
+        gitClientFactory.Create(Arg.Any<string>()).Returns(gitClient);
+
+        var branchStatuses = new Dictionary<string, GitBranchStatus>
+        {
+            { sourceBranch, new GitBranchStatus(sourceBranch, $"origin/{sourceBranch}", true, true, 0, 0, new Commit(Some.Sha(), Some.Name()), null) }
+        };
+        gitClient.GetBranchStatuses(Arg.Any<string[]>()).Returns(branchStatuses);
+
+        var stack = new Config.Stack(
+            "Stack1",
+            Some.HttpsUri().ToString(),
+            sourceBranch,
+            []
+        );
+
+        var executionContext = new CliExecutionContext();
+        var stackActions = new StackActions(gitClientFactory, executionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+
+        gitClientFactory.Create(executionContext.WorkingDirectory).Returns(gitClient);
+
+        // Act + Assert
+        await stackActions.Invoking(async a => await a.UpdateStack(stack, UpdateStrategy.Rebase, CancellationToken.None, true))
+            .Should().ThrowAsync<InvalidOperationException>();
     }
 }

--- a/src/Stack.Tests/Commands/Remote/SyncStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Remote/SyncStackCommandHandlerTests.cs
@@ -817,4 +817,110 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         stackActions.DidNotReceive().PushChanges(Arg.Any<Config.Stack>(), Arg.Any<int>(), Arg.Any<bool>());
         gitClient.Received().ChangeBranch(branch1);
     }
+
+    [Fact]
+    public async Task WhenCheckPullRequestsIsTrue_UpdatesStackWithCheckPullRequestsEnabled()
+    {
+        // Arrange
+        var sourceBranch = Some.BranchName();
+        var branch1 = Some.BranchName();
+        var branch2 = Some.BranchName();
+        var remoteUri = Some.HttpsUri().ToString();
+
+        var stackConfig = new TestStackConfigBuilder()
+            .WithStack(stack => stack
+                .WithName("Stack1")
+                .WithRemoteUri(remoteUri)
+                .WithSourceBranch(sourceBranch)
+                .WithBranch(stackBranch => stackBranch.WithName(branch1))
+                .WithBranch(stackBranch => stackBranch.WithName(branch2)))
+            .Build();
+        var inputProvider = Substitute.For<IInputProvider>();
+        var logger = XUnitLogger.CreateLogger<SyncStackCommandHandler>(testOutputHelper);
+        var gitClient = Substitute.For<IGitClient>();
+        var gitHubClient = Substitute.For<IGitHubClient>();
+        var stackActions = Substitute.For<IStackActions>();
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
+        var gitClientFactory = Substitute.For<IGitClientFactory>();
+        var executionContext = new CliExecutionContext { WorkingDirectory = "/some/path" };
+        var outputProvider = Substitute.For<IOutputProvider>();
+        var handler = new SyncStackCommandHandler(inputProvider, logger, outputProvider, displayProvider, gitClientFactory, executionContext, gitHubClient, stackConfig, stackActions);
+
+        gitClientFactory.Create(executionContext.WorkingDirectory).Returns(gitClient);
+
+        gitClient.GetRemoteUri().Returns(remoteUri);
+        gitClient.GetCurrentBranch().Returns(branch1);
+        gitClient.GetBranchStatuses(Arg.Any<string[]>()).Returns(new Dictionary<string, GitBranchStatus>
+        {
+            { sourceBranch, new GitBranchStatus(sourceBranch, $"origin/{sourceBranch}", true, false, 0, 0, new Commit("abc1234", "Test commit message")) },
+            { branch1, new GitBranchStatus(branch1, $"origin/{branch1}", true, true, 0, 0, new Commit("abc1234", "Test commit message")) },
+            { branch2, new GitBranchStatus(branch2, $"origin/{branch2}", true, false, 0, 0, new Commit("def5678", "Test commit message")) }
+        });
+        gitClient.GetConfigValue("stack.update.strategy").Returns((string?)null);
+
+        inputProvider.Confirm(Questions.ConfirmSyncStack, Arg.Any<CancellationToken>(), Arg.Any<bool>()).Returns(Task.FromResult(true));
+        inputProvider.Select(Questions.SelectUpdateStrategy, Arg.Any<UpdateStrategy[]>(), Arg.Any<CancellationToken>(), Arg.Any<Func<UpdateStrategy, string>>()).Returns(Task.FromResult(UpdateStrategy.Merge));
+
+        // Act
+        await handler.Handle(new SyncStackCommandInputs("Stack1", 5, false, false, false, false, true), CancellationToken.None);
+
+        // Assert
+        stackActions.Received().PullChanges(Arg.Is<Config.Stack>(s => s.Name == "Stack1"));
+        await stackActions.Received().UpdateStack(Arg.Is<Config.Stack>(s => s.Name == "Stack1"), UpdateStrategy.Merge, Arg.Any<CancellationToken>(), true);
+        stackActions.Received().PushChanges(Arg.Is<Config.Stack>(s => s.Name == "Stack1"), 5, false);
+        gitClient.Received().ChangeBranch(branch1);
+    }
+
+    [Fact]
+    public async Task WhenCheckPullRequestsIsFalse_UpdatesStackWithCheckPullRequestsDisabled()
+    {
+        // Arrange
+        var sourceBranch = Some.BranchName();
+        var branch1 = Some.BranchName();
+        var branch2 = Some.BranchName();
+        var remoteUri = Some.HttpsUri().ToString();
+
+        var stackConfig = new TestStackConfigBuilder()
+            .WithStack(stack => stack
+                .WithName("Stack1")
+                .WithRemoteUri(remoteUri)
+                .WithSourceBranch(sourceBranch)
+                .WithBranch(stackBranch => stackBranch.WithName(branch1))
+                .WithBranch(stackBranch => stackBranch.WithName(branch2)))
+            .Build();
+        var inputProvider = Substitute.For<IInputProvider>();
+        var logger = XUnitLogger.CreateLogger<SyncStackCommandHandler>(testOutputHelper);
+        var gitClient = Substitute.For<IGitClient>();
+        var gitHubClient = Substitute.For<IGitHubClient>();
+        var stackActions = Substitute.For<IStackActions>();
+        var displayProvider = new TestDisplayProvider(testOutputHelper);
+        var gitClientFactory = Substitute.For<IGitClientFactory>();
+        var executionContext = new CliExecutionContext { WorkingDirectory = "/some/path" };
+        var outputProvider = Substitute.For<IOutputProvider>();
+        var handler = new SyncStackCommandHandler(inputProvider, logger, outputProvider, displayProvider, gitClientFactory, executionContext, gitHubClient, stackConfig, stackActions);
+
+        gitClientFactory.Create(executionContext.WorkingDirectory).Returns(gitClient);
+
+        gitClient.GetRemoteUri().Returns(remoteUri);
+        gitClient.GetCurrentBranch().Returns(branch1);
+        gitClient.GetBranchStatuses(Arg.Any<string[]>()).Returns(new Dictionary<string, GitBranchStatus>
+        {
+            { sourceBranch, new GitBranchStatus(sourceBranch, $"origin/{sourceBranch}", true, false, 0, 0, new Commit("abc1234", "Test commit message")) },
+            { branch1, new GitBranchStatus(branch1, $"origin/{branch1}", true, true, 0, 0, new Commit("abc1234", "Test commit message")) },
+            { branch2, new GitBranchStatus(branch2, $"origin/{branch2}", true, false, 0, 0, new Commit("def5678", "Test commit message")) }
+        });
+        gitClient.GetConfigValue("stack.update.strategy").Returns((string?)null);
+
+        inputProvider.Confirm(Questions.ConfirmSyncStack, Arg.Any<CancellationToken>(), Arg.Any<bool>()).Returns(Task.FromResult(true));
+        inputProvider.Select(Questions.SelectUpdateStrategy, Arg.Any<UpdateStrategy[]>(), Arg.Any<CancellationToken>(), Arg.Any<Func<UpdateStrategy, string>>()).Returns(Task.FromResult(UpdateStrategy.Merge));
+
+        // Act
+        await handler.Handle(new SyncStackCommandInputs("Stack1", 5, false, false, false, false, false), CancellationToken.None);
+
+        // Assert
+        stackActions.Received().PullChanges(Arg.Is<Config.Stack>(s => s.Name == "Stack1"));
+        await stackActions.Received().UpdateStack(Arg.Is<Config.Stack>(s => s.Name == "Stack1"), UpdateStrategy.Merge, Arg.Any<CancellationToken>(), false);
+        stackActions.Received().PushChanges(Arg.Is<Config.Stack>(s => s.Name == "Stack1"), 5, false);
+        gitClient.Received().ChangeBranch(branch1);
+    }
 }

--- a/src/Stack.Tests/Commands/Remote/SyncStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Remote/SyncStackCommandHandlerTests.cs
@@ -62,7 +62,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Select(Questions.SelectUpdateStrategy, Arg.Any<UpdateStrategy[]>(), Arg.Any<CancellationToken>(), Arg.Any<Func<UpdateStrategy, string>>()).Returns(Task.FromResult(UpdateStrategy.Merge));
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs("Stack1", 5, false, false, false, false), CancellationToken.None);
+        await handler.Handle(new SyncStackCommandInputs("Stack1", 5, false, false, false, false, false), CancellationToken.None);
 
         // Assert
         stackActions.Received().PullChanges(Arg.Is<Config.Stack>(s => s.Name == "Stack1"));
@@ -111,7 +111,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
 
         // Act and assert
         var invalidStackName = Some.Name();
-        await handler.Invoking(async h => await h.Handle(new SyncStackCommandInputs(invalidStackName, 5, false, false, false, false), CancellationToken.None))
+        await handler.Invoking(async h => await h.Handle(new SyncStackCommandInputs(invalidStackName, 5, false, false, false, false, false), CancellationToken.None))
             .Should().ThrowAsync<InvalidOperationException>()
             .WithMessage($"Stack '{invalidStackName}' not found.");
     }
@@ -166,7 +166,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Select(Questions.SelectUpdateStrategy, Arg.Any<UpdateStrategy[]>(), Arg.Any<CancellationToken>(), Arg.Any<Func<UpdateStrategy, string>>()).Returns(Task.FromResult(UpdateStrategy.Merge));
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs(null, 5, false, false, false, false), CancellationToken.None);
+        await handler.Handle(new SyncStackCommandInputs(null, 5, false, false, false, false, false), CancellationToken.None);
 
         // Assert
         stackActions.Received().PullChanges(Arg.Is<Config.Stack>(s => s.Name == "Stack1"));
@@ -219,7 +219,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Select(Questions.SelectUpdateStrategy, Arg.Any<UpdateStrategy[]>(), Arg.Any<CancellationToken>(), Arg.Any<Func<UpdateStrategy, string>>()).Returns(Task.FromResult(UpdateStrategy.Merge));
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs(null, 5, false, false, false, false), CancellationToken.None);
+        await handler.Handle(new SyncStackCommandInputs(null, 5, false, false, false, false, false), CancellationToken.None);
 
         // Assert
         stackActions.Received().PullChanges(Arg.Is<Config.Stack>(s => s.Name == "Stack1"));
@@ -276,7 +276,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Confirm(Questions.ConfirmSyncStack, Arg.Any<CancellationToken>(), Arg.Any<bool>()).Returns(Task.FromResult(true));
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs(null, 5, true, false, false, false), CancellationToken.None);
+        await handler.Handle(new SyncStackCommandInputs(null, 5, true, false, false, false, false), CancellationToken.None);
 
         // Assert
         stackActions.Received().PullChanges(Arg.Is<Config.Stack>(s => s.Name == "Stack1"));
@@ -332,7 +332,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Confirm(Questions.ConfirmSyncStack, Arg.Any<CancellationToken>()).Returns(true);
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs(null, 5, false, true, false, false), CancellationToken.None);
+        await handler.Handle(new SyncStackCommandInputs(null, 5, false, true, false, false, false), CancellationToken.None);
 
         // Assert
         stackActions.Received().PullChanges(Arg.Is<Config.Stack>(s => s.Name == "Stack1"));
@@ -388,7 +388,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Confirm(Questions.ConfirmSyncStack, Arg.Any<CancellationToken>()).Returns(true);
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs(null, 5, null, null, false, false), CancellationToken.None);
+        await handler.Handle(new SyncStackCommandInputs(null, 5, null, null, false, false, false), CancellationToken.None);
 
         // Assert
         stackActions.Received().PullChanges(Arg.Is<Config.Stack>(s => s.Name == "Stack1"));
@@ -444,7 +444,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Confirm(Questions.ConfirmSyncStack, Arg.Any<CancellationToken>()).Returns(true);
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs(null, 5, null, null, false, false), CancellationToken.None);
+        await handler.Handle(new SyncStackCommandInputs(null, 5, null, null, false, false, false), CancellationToken.None);
 
         // Assert
         stackActions.Received().PullChanges(Arg.Is<Config.Stack>(s => s.Name == "Stack1"));
@@ -500,7 +500,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Confirm(Questions.ConfirmSyncStack, Arg.Any<CancellationToken>()).Returns(true);
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs(null, 5, true, null, false, false), CancellationToken.None);
+        await handler.Handle(new SyncStackCommandInputs(null, 5, true, null, false, false, false), CancellationToken.None);
 
         // Assert
         stackActions.Received().PullChanges(Arg.Is<Config.Stack>(s => s.Name == "Stack1"));
@@ -556,7 +556,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Confirm(Questions.ConfirmSyncStack, Arg.Any<CancellationToken>()).Returns(true);
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs(null, 5, null, true, false, false), CancellationToken.None);
+        await handler.Handle(new SyncStackCommandInputs(null, 5, null, true, false, false, false), CancellationToken.None);
 
         // Assert
         stackActions.Received().PullChanges(Arg.Is<Config.Stack>(s => s.Name == "Stack1"));
@@ -613,7 +613,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Confirm(Questions.ConfirmSyncStack, Arg.Any<CancellationToken>()).Returns(true);
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs(null, 5, null, null, false, false), CancellationToken.None);
+        await handler.Handle(new SyncStackCommandInputs(null, 5, null, null, false, false, false), CancellationToken.None);
 
         // Assert
         stackActions.Received().PullChanges(Arg.Is<Config.Stack>(s => s.Name == "Stack1"));
@@ -670,7 +670,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Confirm(Questions.ConfirmSyncStack, Arg.Any<CancellationToken>()).Returns(true);
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs(null, 5, null, null, false, false), CancellationToken.None);
+        await handler.Handle(new SyncStackCommandInputs(null, 5, null, null, false, false, false), CancellationToken.None);
 
         // Assert
         stackActions.Received().PullChanges(Arg.Is<Config.Stack>(s => s.Name == "Stack1"));
@@ -699,7 +699,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
 
         // Act and assert
         await handler
-            .Invoking(h => h.Handle(new SyncStackCommandInputs(null, 5, true, true, false, false), CancellationToken.None))
+            .Invoking(h => h.Handle(new SyncStackCommandInputs(null, 5, true, true, false, false, false), CancellationToken.None))
             .Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("Cannot specify both rebase and merge.");
     }
@@ -751,7 +751,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>(), Arg.Any<CancellationToken>()).Returns("Stack1");
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs(null, 5, false, false, true, false), CancellationToken.None);
+        await handler.Handle(new SyncStackCommandInputs(null, 5, false, false, true, false, false), CancellationToken.None);
 
         // Assert
         stackActions.Received().PullChanges(Arg.Is<Config.Stack>(s => s.Name == "Stack1"));
@@ -809,7 +809,7 @@ public class SyncStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Confirm(Questions.ConfirmSyncStack, Arg.Any<CancellationToken>()).Returns(true);
 
         // Act
-        await handler.Handle(new SyncStackCommandInputs(null, 5, false, false, false, true), CancellationToken.None);
+        await handler.Handle(new SyncStackCommandInputs(null, 5, false, false, false, true, false), CancellationToken.None);
 
         // Assert
         stackActions.Received().PullChanges(Arg.Is<Config.Stack>(s => s.Name == "Stack1"));

--- a/src/Stack.Tests/Commands/Stack/UpdateStackCommandHandlerTests.cs
+++ b/src/Stack.Tests/Commands/Stack/UpdateStackCommandHandlerTests.cs
@@ -49,7 +49,7 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         gitClient.GetCurrentBranch().Returns(branch1);
 
         // Act
-        await handler.Handle(new UpdateStackCommandInputs("Stack1", false, true), CancellationToken.None);
+        await handler.Handle(new UpdateStackCommandInputs("Stack1", false, true, false), CancellationToken.None);
 
         // Assert
         await inputProvider.DidNotReceive().Select(Questions.SelectStack, Arg.Any<string[]>(), Arg.Any<CancellationToken>());
@@ -92,7 +92,7 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
 
         // Act and assert
         var invalidStackName = Some.Name();
-        await handler.Invoking(async h => await h.Handle(new UpdateStackCommandInputs(invalidStackName, false, false), CancellationToken.None))
+        await handler.Invoking(async h => await h.Handle(new UpdateStackCommandInputs(invalidStackName, false, false, false), CancellationToken.None))
             .Should().ThrowAsync<InvalidOperationException>()
             .WithMessage($"Stack '{invalidStackName}' not found.");
     }
@@ -135,7 +135,7 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         inputProvider.Select(Questions.SelectStack, Arg.Any<string[]>(), Arg.Any<CancellationToken>()).Returns("Stack1");
 
         // Act
-        await handler.Handle(new UpdateStackCommandInputs(null, false, true), CancellationToken.None);
+        await handler.Handle(new UpdateStackCommandInputs(null, false, true, false), CancellationToken.None);
 
         // Assert current branch preserved
         gitClient.Received().ChangeBranch(branch1);
@@ -172,7 +172,7 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         gitClient.GetCurrentBranch().Returns(branch1);
 
         // Act
-        await handler.Handle(new UpdateStackCommandInputs(null, false, true), CancellationToken.None);
+        await handler.Handle(new UpdateStackCommandInputs(null, false, true, false), CancellationToken.None);
 
         // Assert
         await inputProvider.DidNotReceive().Select(Questions.SelectStack, Arg.Any<string[]>(), Arg.Any<CancellationToken>());
@@ -215,7 +215,7 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         gitClient.GetCurrentBranch().Returns(branch1);
 
         // Act
-        await handler.Handle(new UpdateStackCommandInputs(null, true, false), CancellationToken.None);
+        await handler.Handle(new UpdateStackCommandInputs(null, true, false, false), CancellationToken.None);
 
         // Assert
         await stackActions.Received().UpdateStack(Arg.Is<Config.Stack>(s => s.Name == "Stack1"), UpdateStrategy.Rebase, Arg.Any<CancellationToken>());
@@ -258,7 +258,7 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         gitClient.GetConfigValue("stack.update.strategy").Returns(UpdateStrategy.Rebase.ToString().ToLower());
 
         // Act
-        await handler.Handle(new UpdateStackCommandInputs(null, null, null), CancellationToken.None);
+        await handler.Handle(new UpdateStackCommandInputs(null, null, null, false), CancellationToken.None);
 
         // Assert
         await stackActions.Received().UpdateStack(Arg.Is<Config.Stack>(s => s.Name == "Stack1"), UpdateStrategy.Rebase, Arg.Any<CancellationToken>());
@@ -300,7 +300,7 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         gitClient.GetConfigValue("stack.update.strategy").Returns(UpdateStrategy.Rebase.ToString().ToLower());
 
         // Act
-        await handler.Handle(new UpdateStackCommandInputs(null, null, true), CancellationToken.None);
+        await handler.Handle(new UpdateStackCommandInputs(null, null, true, false), CancellationToken.None);
 
         // Assert
         await stackActions.Received().UpdateStack(Arg.Is<Config.Stack>(s => s.Name == "Stack1"), UpdateStrategy.Merge, Arg.Any<CancellationToken>());
@@ -343,7 +343,7 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         gitClient.GetConfigValue("stack.update.strategy").Returns(UpdateStrategy.Merge.ToString().ToLower());
 
         // Act
-        await handler.Handle(new UpdateStackCommandInputs(null, null, null), CancellationToken.None);
+        await handler.Handle(new UpdateStackCommandInputs(null, null, null, false), CancellationToken.None);
 
         // Assert
         await stackActions.Received().UpdateStack(Arg.Is<Config.Stack>(s => s.Name == "Stack1"), UpdateStrategy.Merge, Arg.Any<CancellationToken>());
@@ -386,7 +386,7 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         gitClient.GetConfigValue("stack.update.strategy").Returns(UpdateStrategy.Merge.ToString().ToLower());
 
         // Act (rebase specified overrides config)
-        await handler.Handle(new UpdateStackCommandInputs(null, true, null), CancellationToken.None);
+        await handler.Handle(new UpdateStackCommandInputs(null, true, null, false), CancellationToken.None);
 
         // Assert
         await stackActions.Received().UpdateStack(Arg.Is<Config.Stack>(s => s.Name == "Stack1"), UpdateStrategy.Rebase, Arg.Any<CancellationToken>());
@@ -430,7 +430,7 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         gitClient.GetConfigValue("stack.update.strategy").Returns((string?)null);
 
         // Act
-        await handler.Handle(new UpdateStackCommandInputs(null, null, null), CancellationToken.None);
+        await handler.Handle(new UpdateStackCommandInputs(null, null, null, false), CancellationToken.None);
 
         // Assert
         await stackActions.Received().UpdateStack(Arg.Is<Config.Stack>(s => s.Name == "Stack1"), UpdateStrategy.Rebase, Arg.Any<CancellationToken>());
@@ -474,7 +474,7 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
         gitClient.GetConfigValue("stack.update.strategy").Returns((string?)null);
 
         // Act
-        await handler.Handle(new UpdateStackCommandInputs(null, null, null), CancellationToken.None);
+        await handler.Handle(new UpdateStackCommandInputs(null, null, null, false), CancellationToken.None);
 
         // Assert
         await stackActions.Received().UpdateStack(Arg.Is<Config.Stack>(s => s.Name == "Stack1"), UpdateStrategy.Merge, Arg.Any<CancellationToken>());
@@ -510,7 +510,7 @@ public class UpdateStackCommandHandlerTests(ITestOutputHelper testOutputHelper)
 
         // Act and assert
         await handler
-            .Invoking(h => h.Handle(new UpdateStackCommandInputs(null, true, true), CancellationToken.None))
+            .Invoking(h => h.Handle(new UpdateStackCommandInputs(null, true, true, false), CancellationToken.None))
             .Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("Cannot specify both rebase and merge.");
     }

--- a/src/Stack.Tests/Helpers/TestGitHubRepositoryBuilder.cs
+++ b/src/Stack.Tests/Helpers/TestGitHubRepositoryBuilder.cs
@@ -5,6 +5,7 @@ namespace Stack.Tests.Helpers;
 public class TestGitHubRepositoryBuilder
 {
     readonly Dictionary<string, GitHubPullRequest> pullRequests = new();
+    bool available = true;
 
     public TestGitHubRepositoryBuilder WithPullRequest(string branch, Action<TestGitHubPullRequestBuilder>? pullRequestBuilder = null)
     {
@@ -15,9 +16,15 @@ public class TestGitHubRepositoryBuilder
         return this;
     }
 
+    public TestGitHubRepositoryBuilder NotAvailable()
+    {
+        available = false;
+        return this;
+    }
+
     public TestGitHubRepository Build()
     {
-        return new TestGitHubRepository(pullRequests);
+        return new TestGitHubRepository(pullRequests, available);
     }
 }
 
@@ -61,7 +68,7 @@ public class TestGitHubPullRequestBuilder
     }
 }
 
-public class TestGitHubRepository(Dictionary<string, GitHubPullRequest> PullRequests) : IGitHubClient
+public class TestGitHubRepository(Dictionary<string, GitHubPullRequest> PullRequests, bool available) : IGitHubClient
 {
     public Dictionary<string, GitHubPullRequest> PullRequests { get; } = PullRequests;
 
@@ -97,5 +104,13 @@ public class TestGitHubRepository(Dictionary<string, GitHubPullRequest> PullRequ
 
     public void OpenPullRequest(GitHubPullRequest pullRequest)
     {
+    }
+
+    public void ThrowIfNotAvailable()
+    {
+        if (!available)
+        {
+            throw new InvalidOperationException("GitHub client not available.");
+        }
     }
 }

--- a/src/Stack.Tests/Integration/StackActionsTests.cs
+++ b/src/Stack.Tests/Integration/StackActionsTests.cs
@@ -1,5 +1,4 @@
 using FluentAssertions;
-using NSubstitute;
 using Meziantou.Extensions.Logging.Xunit;
 using Stack.Commands.Helpers;
 using Stack.Git;
@@ -25,7 +24,6 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
 
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
-        var gitHubClient = Substitute.For<IGitHubClient>();
         var cliExecutionContext = new CliExecutionContext() { WorkingDirectory = repo.LocalDirectoryPath };
         var gitClientFactory = new TestGitClientFactory(testOutputHelper);
         var conflictResolutionDetector = new ConflictResolutionDetector();
@@ -42,7 +40,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
             .WithBranch(b => b.WithName(otherBranch))
             .Build();
 
-        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PullChanges(stack);
@@ -71,7 +69,6 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
 
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
-        var gitHubClient = Substitute.For<IGitHubClient>();
         var cliExecutionContext = new CliExecutionContext() { WorkingDirectory = repo.LocalDirectoryPath };
         var gitClientFactory = new TestGitClientFactory(testOutputHelper);
         var conflictResolutionDetector = new ConflictResolutionDetector();
@@ -90,7 +87,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
             .WithBranch(b => b.WithName(worktreeBranch))
             .Build();
 
-        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PullChanges(stack);
@@ -115,7 +112,6 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
 
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
-        var gitHubClient = Substitute.For<IGitHubClient>();
         var cliExecutionContext = new CliExecutionContext() { WorkingDirectory = repo.LocalDirectoryPath };
         var gitClientFactory = new TestGitClientFactory(testOutputHelper);
         var conflictResolutionDetector = new ConflictResolutionDetector();
@@ -128,7 +124,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
             .WithBranch(b => b.WithName(localOnlyBranch))
             .Build();
 
-        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PullChanges(stack);
@@ -152,7 +148,6 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
 
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
-        var gitHubClient = Substitute.For<IGitHubClient>();
         var cliExecutionContext = new CliExecutionContext() { WorkingDirectory = repo.LocalDirectoryPath };
         var gitClientFactory = new TestGitClientFactory(testOutputHelper);
         var conflictResolutionDetector = new ConflictResolutionDetector();
@@ -168,7 +163,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
             .WithBranch(b => b.WithName(deletedRemoteBranch))
             .Build();
 
-        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PullChanges(stack);
@@ -196,7 +191,6 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
 
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
-        var gitHubClient = Substitute.For<IGitHubClient>();
         var cliExecutionContext = new CliExecutionContext() { WorkingDirectory = repo.LocalDirectoryPath };
         var gitClientFactory = new TestGitClientFactory(testOutputHelper);
         var conflictResolutionDetector = new ConflictResolutionDetector();
@@ -221,7 +215,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
             .WithBranch(b => b.WithName(line2Branch1))
             .Build();
 
-        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         await stackActions.UpdateStack(stack, UpdateStrategy.Merge, CancellationToken.None);
@@ -253,7 +247,6 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
 
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
-        var gitHubClient = Substitute.For<IGitHubClient>();
         var cliExecutionContext = new CliExecutionContext() { WorkingDirectory = repo.LocalDirectoryPath };
         var gitClientFactory = new TestGitClientFactory(testOutputHelper);
         var conflictResolutionDetector = new ConflictResolutionDetector();
@@ -278,7 +271,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
             .WithBranch(b => b.WithName(line2Branch1))
             .Build();
 
-        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         await stackActions.UpdateStack(stack, UpdateStrategy.Rebase, CancellationToken.None);
@@ -312,7 +305,6 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
 
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
-        var gitHubClient = Substitute.For<IGitHubClient>();
         var cliExecutionContext = new CliExecutionContext() { WorkingDirectory = repo.LocalDirectoryPath };
         var gitClientFactory = new TestGitClientFactory(testOutputHelper);
         var conflictResolutionDetector = new ConflictResolutionDetector();
@@ -340,7 +332,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var worktree = repo.CreateWorktree(childBranch);
         worktree.Should().NotBeNull();
 
-        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         await stackActions.UpdateStack(stack, UpdateStrategy.Merge, CancellationToken.None);
@@ -367,7 +359,6 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
 
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
-        var gitHubClient = Substitute.For<IGitHubClient>();
         var cliExecutionContext = new CliExecutionContext() { WorkingDirectory = repo.LocalDirectoryPath };
         var gitClientFactory = new TestGitClientFactory(testOutputHelper);
         var conflictResolutionDetector = new ConflictResolutionDetector();
@@ -395,7 +386,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var worktreePath = repo.CreateWorktree(childBranch);
         worktreePath.Should().NotBeNull();
 
-        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         await stackActions.UpdateStack(stack, UpdateStrategy.Rebase, CancellationToken.None);
@@ -426,7 +417,6 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
 
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
-        var gitHubClient = Substitute.For<IGitHubClient>();
         var cliExecutionContext = new CliExecutionContext() { WorkingDirectory = repo.LocalDirectoryPath };
         var gitClientFactory = new TestGitClientFactory(testOutputHelper);
         var conflictResolutionDetector = new ConflictResolutionDetector();
@@ -448,7 +438,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
                     .WithChildBranch(e => e.WithName(fourthBranch))))
             .Build();
 
-        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         await stackActions.UpdateStack(stack, UpdateStrategy.Rebase, CancellationToken.None);
@@ -499,7 +489,6 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
 
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
-        var gitHubClient = Substitute.For<IGitHubClient>();
         var cliExecutionContext = new CliExecutionContext() { WorkingDirectory = repo.LocalDirectoryPath };
         var gitClientFactory = new TestGitClientFactory(testOutputHelper);
         var conflictResolutionDetector = new ConflictResolutionDetector();
@@ -526,7 +515,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
                     .WithChildBranch(e => e.WithName(fourthBranch))))
             .Build();
 
-        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         await stackActions.UpdateStack(stack, UpdateStrategy.Rebase, CancellationToken.None);
@@ -558,7 +547,6 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
 
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
-        var gitHubClient = Substitute.For<IGitHubClient>();
         var cliExecutionContext = new CliExecutionContext() { WorkingDirectory = repo.LocalDirectoryPath };
         var gitClientFactory = new TestGitClientFactory(testOutputHelper);
         var conflictResolutionDetector = new ConflictResolutionDetector();
@@ -577,7 +565,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
             .WithBranch(b => b.WithName(currentBranch))
             .Build();
 
-        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PushChanges(stack, 5, false);
@@ -602,7 +590,6 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
 
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
-        var gitHubClient = Substitute.For<IGitHubClient>();
         var cliExecutionContext = new CliExecutionContext() { WorkingDirectory = repo.LocalDirectoryPath };
         var gitClientFactory = new TestGitClientFactory(testOutputHelper);
         var conflictResolutionDetector = new ConflictResolutionDetector();
@@ -623,7 +610,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
             .WithBranch(b => b.WithName(nonCurrentBranch))
             .Build();
 
-        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PushChanges(stack, 5, false);
@@ -648,7 +635,6 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
 
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
-        var gitHubClient = Substitute.For<IGitHubClient>();
         var cliExecutionContext = new CliExecutionContext() { WorkingDirectory = repo.LocalDirectoryPath };
         var gitClientFactory = new TestGitClientFactory(testOutputHelper);
         var conflictResolutionDetector = new ConflictResolutionDetector();
@@ -671,7 +657,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
             .WithBranch(b => b.WithName(worktreeBranch))
             .Build();
 
-        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PushChanges(stack, 5, false);
@@ -696,7 +682,6 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
 
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
-        var gitHubClient = Substitute.For<IGitHubClient>();
         var cliExecutionContext = new CliExecutionContext() { WorkingDirectory = repo.LocalDirectoryPath };
         var gitClientFactory = new TestGitClientFactory(testOutputHelper);
         var conflictResolutionDetector = new ConflictResolutionDetector();
@@ -719,7 +704,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
             .WithBranch(b => b.WithName(localOnlyBranch))
             .Build();
 
-        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, logger, displayProvider, conflictResolutionDetector);
 
         // Act - should complete without errors and should actually create the remote tracking branch
         stackActions.PushChanges(stack, 5, false);
@@ -750,7 +735,6 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
 
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
-        var gitHubClient = Substitute.For<IGitHubClient>();
         var cliExecutionContext = new CliExecutionContext() { WorkingDirectory = repo.LocalDirectoryPath };
         var gitClientFactory = new TestGitClientFactory(testOutputHelper);
         var conflictResolutionDetector = new ConflictResolutionDetector();
@@ -773,7 +757,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
             .WithBranch(b => b.WithName(deletedRemoteBranch))
             .Build();
 
-        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, logger, displayProvider, conflictResolutionDetector);
 
         // Act - should complete without errors even with deleted remote
         stackActions.PushChanges(stack, 5, false);

--- a/src/Stack.Tests/Integration/StackActionsTests.cs
+++ b/src/Stack.Tests/Integration/StackActionsTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using NSubstitute;
 using Meziantou.Extensions.Logging.Xunit;
 using Stack.Commands.Helpers;
 using Stack.Git;
@@ -24,6 +25,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
 
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
+        var gitHubClient = Substitute.For<IGitHubClient>();
         var cliExecutionContext = new CliExecutionContext() { WorkingDirectory = repo.LocalDirectoryPath };
         var gitClientFactory = new TestGitClientFactory(testOutputHelper);
         var conflictResolutionDetector = new ConflictResolutionDetector();
@@ -40,7 +42,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
             .WithBranch(b => b.WithName(otherBranch))
             .Build();
 
-        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PullChanges(stack);
@@ -69,6 +71,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
 
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
+        var gitHubClient = Substitute.For<IGitHubClient>();
         var cliExecutionContext = new CliExecutionContext() { WorkingDirectory = repo.LocalDirectoryPath };
         var gitClientFactory = new TestGitClientFactory(testOutputHelper);
         var conflictResolutionDetector = new ConflictResolutionDetector();
@@ -87,7 +90,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
             .WithBranch(b => b.WithName(worktreeBranch))
             .Build();
 
-        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PullChanges(stack);
@@ -112,6 +115,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
 
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
+        var gitHubClient = Substitute.For<IGitHubClient>();
         var cliExecutionContext = new CliExecutionContext() { WorkingDirectory = repo.LocalDirectoryPath };
         var gitClientFactory = new TestGitClientFactory(testOutputHelper);
         var conflictResolutionDetector = new ConflictResolutionDetector();
@@ -124,7 +128,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
             .WithBranch(b => b.WithName(localOnlyBranch))
             .Build();
 
-        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PullChanges(stack);
@@ -148,6 +152,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
 
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
+        var gitHubClient = Substitute.For<IGitHubClient>();
         var cliExecutionContext = new CliExecutionContext() { WorkingDirectory = repo.LocalDirectoryPath };
         var gitClientFactory = new TestGitClientFactory(testOutputHelper);
         var conflictResolutionDetector = new ConflictResolutionDetector();
@@ -163,7 +168,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
             .WithBranch(b => b.WithName(deletedRemoteBranch))
             .Build();
 
-        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PullChanges(stack);
@@ -191,6 +196,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
 
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
+        var gitHubClient = Substitute.For<IGitHubClient>();
         var cliExecutionContext = new CliExecutionContext() { WorkingDirectory = repo.LocalDirectoryPath };
         var gitClientFactory = new TestGitClientFactory(testOutputHelper);
         var conflictResolutionDetector = new ConflictResolutionDetector();
@@ -215,7 +221,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
             .WithBranch(b => b.WithName(line2Branch1))
             .Build();
 
-        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         await stackActions.UpdateStack(stack, UpdateStrategy.Merge, CancellationToken.None);
@@ -247,6 +253,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
 
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
+        var gitHubClient = Substitute.For<IGitHubClient>();
         var cliExecutionContext = new CliExecutionContext() { WorkingDirectory = repo.LocalDirectoryPath };
         var gitClientFactory = new TestGitClientFactory(testOutputHelper);
         var conflictResolutionDetector = new ConflictResolutionDetector();
@@ -271,7 +278,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
             .WithBranch(b => b.WithName(line2Branch1))
             .Build();
 
-        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         await stackActions.UpdateStack(stack, UpdateStrategy.Rebase, CancellationToken.None);
@@ -305,6 +312,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
 
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
+        var gitHubClient = Substitute.For<IGitHubClient>();
         var cliExecutionContext = new CliExecutionContext() { WorkingDirectory = repo.LocalDirectoryPath };
         var gitClientFactory = new TestGitClientFactory(testOutputHelper);
         var conflictResolutionDetector = new ConflictResolutionDetector();
@@ -332,7 +340,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var worktree = repo.CreateWorktree(childBranch);
         worktree.Should().NotBeNull();
 
-        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         await stackActions.UpdateStack(stack, UpdateStrategy.Merge, CancellationToken.None);
@@ -359,6 +367,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
 
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
+        var gitHubClient = Substitute.For<IGitHubClient>();
         var cliExecutionContext = new CliExecutionContext() { WorkingDirectory = repo.LocalDirectoryPath };
         var gitClientFactory = new TestGitClientFactory(testOutputHelper);
         var conflictResolutionDetector = new ConflictResolutionDetector();
@@ -386,7 +395,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
         var worktreePath = repo.CreateWorktree(childBranch);
         worktreePath.Should().NotBeNull();
 
-        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         await stackActions.UpdateStack(stack, UpdateStrategy.Rebase, CancellationToken.None);
@@ -417,6 +426,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
 
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
+        var gitHubClient = Substitute.For<IGitHubClient>();
         var cliExecutionContext = new CliExecutionContext() { WorkingDirectory = repo.LocalDirectoryPath };
         var gitClientFactory = new TestGitClientFactory(testOutputHelper);
         var conflictResolutionDetector = new ConflictResolutionDetector();
@@ -438,7 +448,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
                     .WithChildBranch(e => e.WithName(fourthBranch))))
             .Build();
 
-        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         await stackActions.UpdateStack(stack, UpdateStrategy.Rebase, CancellationToken.None);
@@ -489,6 +499,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
 
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
+        var gitHubClient = Substitute.For<IGitHubClient>();
         var cliExecutionContext = new CliExecutionContext() { WorkingDirectory = repo.LocalDirectoryPath };
         var gitClientFactory = new TestGitClientFactory(testOutputHelper);
         var conflictResolutionDetector = new ConflictResolutionDetector();
@@ -515,7 +526,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
                     .WithChildBranch(e => e.WithName(fourthBranch))))
             .Build();
 
-        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         await stackActions.UpdateStack(stack, UpdateStrategy.Rebase, CancellationToken.None);
@@ -547,6 +558,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
 
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
+        var gitHubClient = Substitute.For<IGitHubClient>();
         var cliExecutionContext = new CliExecutionContext() { WorkingDirectory = repo.LocalDirectoryPath };
         var gitClientFactory = new TestGitClientFactory(testOutputHelper);
         var conflictResolutionDetector = new ConflictResolutionDetector();
@@ -565,7 +577,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
             .WithBranch(b => b.WithName(currentBranch))
             .Build();
 
-        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PushChanges(stack, 5, false);
@@ -590,6 +602,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
 
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
+        var gitHubClient = Substitute.For<IGitHubClient>();
         var cliExecutionContext = new CliExecutionContext() { WorkingDirectory = repo.LocalDirectoryPath };
         var gitClientFactory = new TestGitClientFactory(testOutputHelper);
         var conflictResolutionDetector = new ConflictResolutionDetector();
@@ -610,7 +623,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
             .WithBranch(b => b.WithName(nonCurrentBranch))
             .Build();
 
-        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PushChanges(stack, 5, false);
@@ -635,6 +648,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
 
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
+        var gitHubClient = Substitute.For<IGitHubClient>();
         var cliExecutionContext = new CliExecutionContext() { WorkingDirectory = repo.LocalDirectoryPath };
         var gitClientFactory = new TestGitClientFactory(testOutputHelper);
         var conflictResolutionDetector = new ConflictResolutionDetector();
@@ -657,7 +671,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
             .WithBranch(b => b.WithName(worktreeBranch))
             .Build();
 
-        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         // Act
         stackActions.PushChanges(stack, 5, false);
@@ -682,6 +696,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
 
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
+        var gitHubClient = Substitute.For<IGitHubClient>();
         var cliExecutionContext = new CliExecutionContext() { WorkingDirectory = repo.LocalDirectoryPath };
         var gitClientFactory = new TestGitClientFactory(testOutputHelper);
         var conflictResolutionDetector = new ConflictResolutionDetector();
@@ -704,7 +719,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
             .WithBranch(b => b.WithName(localOnlyBranch))
             .Build();
 
-        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         // Act - should complete without errors and should actually create the remote tracking branch
         stackActions.PushChanges(stack, 5, false);
@@ -735,6 +750,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
 
         var logger = XUnitLogger.CreateLogger<StackActions>(testOutputHelper);
         var displayProvider = new TestDisplayProvider(testOutputHelper);
+        var gitHubClient = Substitute.For<IGitHubClient>();
         var cliExecutionContext = new CliExecutionContext() { WorkingDirectory = repo.LocalDirectoryPath };
         var gitClientFactory = new TestGitClientFactory(testOutputHelper);
         var conflictResolutionDetector = new ConflictResolutionDetector();
@@ -757,7 +773,7 @@ public class StackActionsTests(ITestOutputHelper testOutputHelper)
             .WithBranch(b => b.WithName(deletedRemoteBranch))
             .Build();
 
-        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, logger, displayProvider, conflictResolutionDetector);
+        var stackActions = new StackActions(gitClientFactory, cliExecutionContext, gitHubClient, logger, displayProvider, conflictResolutionDetector);
 
         // Act - should complete without errors even with deleted remote
         stackActions.PushChanges(stack, 5, false);

--- a/src/Stack/Commands/Helpers/StackHelpers.cs
+++ b/src/Stack/Commands/Helpers/StackHelpers.cs
@@ -107,7 +107,7 @@ public static class StackHelpers
         ILogger logger,
         IGitClient gitClient,
         IGitHubClient gitHubClient,
-        bool includePullRequestStatus = true)
+        bool includePullRequestStatus)
     {
         var stacksToReturnStatusFor = new List<StackStatus>();
 
@@ -219,7 +219,7 @@ public static class StackHelpers
         ILogger logger,
         IGitClient gitClient,
         IGitHubClient gitHubClient,
-        bool includePullRequestStatus = true)
+        bool includePullRequestStatus)
     {
         var statuses = GetStackStatus(
             [stack],
@@ -521,7 +521,7 @@ public static class StackHelpers
     public static string[] GetBranchesNeedingCleanup(Config.Stack stack, ILogger logger, IGitClient gitClient, IGitHubClient gitHubClient)
     {
         var currentBranch = gitClient.GetCurrentBranch();
-        var stackStatus = GetStackStatus(stack, currentBranch, logger, gitClient, gitHubClient, true);
+        var stackStatus = GetStackStatus(stack, currentBranch, logger, gitClient, gitHubClient, false);
 
         return [.. stackStatus.GetAllBranches().Where(b => b.CouldBeCleanedUp).Select(b => b.Name)];
     }

--- a/src/Stack/Commands/Helpers/StackHelpers.cs
+++ b/src/Stack/Commands/Helpers/StackHelpers.cs
@@ -109,6 +109,11 @@ public static class StackHelpers
         IGitHubClient gitHubClient,
         bool includePullRequestStatus)
     {
+        if (includePullRequestStatus)
+        {
+            gitHubClient.ThrowIfNotAvailable();
+        }
+
         var stacksToReturnStatusFor = new List<StackStatus>();
 
         var stacksOrderedByCurrentBranch = stacks

--- a/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
+++ b/src/Stack/Commands/PullRequests/CreatePullRequestsCommand.cs
@@ -82,7 +82,8 @@ public class CreatePullRequestsCommandHandler(
             currentBranch,
             logger,
             gitClient,
-            gitHubClient);
+            gitHubClient,
+            true);
 
         var pullRequestCreateActions = new List<PullRequestCreateAction>();
 

--- a/src/Stack/Commands/Remote/SyncStackCommand.cs
+++ b/src/Stack/Commands/Remote/SyncStackCommand.cs
@@ -32,6 +32,7 @@ public class SyncStackCommand : Command
         Add(CommonOptions.Rebase);
         Add(CommonOptions.Merge);
         Add(CommonOptions.Confirm);
+        Add(CommonOptions.CheckPullRequests);
         Add(NoPush);
     }
 
@@ -44,7 +45,8 @@ public class SyncStackCommand : Command
                 parseResult.GetValue(CommonOptions.Rebase),
                 parseResult.GetValue(CommonOptions.Merge),
                 parseResult.GetValue(CommonOptions.Confirm),
-                parseResult.GetValue(NoPush)),
+                parseResult.GetValue(NoPush),
+                parseResult.GetValue(CommonOptions.CheckPullRequests)),
             cancellationToken);
     }
 }
@@ -55,9 +57,10 @@ public record SyncStackCommandInputs(
     bool? Rebase,
     bool? Merge,
     bool Confirm,
-    bool NoPush)
+    bool NoPush,
+    bool CheckPullRequests)
 {
-    public static SyncStackCommandInputs Empty => new(null, 5, null, null, false, false);
+    public static SyncStackCommandInputs Empty => new(null, 5, null, null, false, false, false);
 }
 
 public class SyncStackCommandHandler(
@@ -115,7 +118,7 @@ public class SyncStackCommandHandler(
                     logger,
                     gitClient,
                     gitHubClient,
-                    true);
+                    inputs.CheckPullRequests);
             }, cancellationToken);
 
             await StackHelpers.OutputStackStatus(status, outputProvider, cancellationToken);
@@ -138,7 +141,7 @@ public class SyncStackCommandHandler(
 
         await displayProvider.DisplayStatus("Updating stack...", async (ct) =>
         {
-            await stackActions.UpdateStack(stack, updateStrategy, ct);
+            await stackActions.UpdateStack(stack, updateStrategy, ct, inputs.CheckPullRequests);
         }, cancellationToken);
 
         var forceWithLease = updateStrategy == UpdateStrategy.Rebase;

--- a/src/Stack/Commands/Stack/StackStatusCommand.cs
+++ b/src/Stack/Commands/Stack/StackStatusCommand.cs
@@ -88,9 +88,9 @@ public class StackStatusCommand : CommandWithOutput<StackStatusCommandResponse>
         Description = "Show status of all stacks."
     };
 
-    static readonly Option<bool> Full = new("--full")
+    static readonly Option<bool> CheckPullRequests = new("--check-pull-requests")
     {
-        Description = "Show full status including pull requests."
+        Description = "Include the status of pull requests in output."
     };
 
     private readonly StackStatusCommandHandler handler;
@@ -106,7 +106,7 @@ public class StackStatusCommand : CommandWithOutput<StackStatusCommandResponse>
         this.handler = handler;
         Add(CommonOptions.Stack);
         Add(All);
-        Add(Full);
+        Add(CheckPullRequests);
     }
 
     protected override async Task<StackStatusCommandResponse> ExecuteAndReturnResponse(ParseResult parseResult, CancellationToken cancellationToken)
@@ -115,7 +115,7 @@ public class StackStatusCommand : CommandWithOutput<StackStatusCommandResponse>
             new StackStatusCommandInputs(
                 parseResult.GetValue(CommonOptions.Stack),
                 parseResult.GetValue(All),
-                parseResult.GetValue(Full)),
+                parseResult.GetValue(CheckPullRequests)),
             cancellationToken);
     }
 
@@ -193,7 +193,7 @@ public class StackStatusCommand : CommandWithOutput<StackStatusCommandResponse>
     }
 }
 
-public record StackStatusCommandInputs(string? Stack, bool All, bool Full);
+public record StackStatusCommandInputs(string? Stack, bool All, bool CheckPullRequests);
 public record StackStatusCommandResponse(List<StackStatus> Stacks);
 
 public class StackStatusCommandHandler(
@@ -255,7 +255,7 @@ public class StackStatusCommandHandler(
                 logger,
                 gitClient,
                 gitHubClient,
-                inputs.Full);
+                inputs.CheckPullRequests);
         }, cancellationToken);
 
         return new StackStatusCommandResponse(stackStatusResults);

--- a/src/Stack/Commands/Stack/UpdateStackCommand.cs
+++ b/src/Stack/Commands/Stack/UpdateStackCommand.cs
@@ -24,6 +24,7 @@ public class UpdateStackCommand : Command
         Add(CommonOptions.Stack);
         Add(CommonOptions.Rebase);
         Add(CommonOptions.Merge);
+        Add(CommonOptions.CheckPullRequests);
     }
 
     protected override async Task Execute(ParseResult parseResult, CancellationToken cancellationToken)
@@ -32,14 +33,15 @@ public class UpdateStackCommand : Command
             new UpdateStackCommandInputs(
                 parseResult.GetValue(CommonOptions.Stack),
                 parseResult.GetValue(CommonOptions.Rebase),
-                parseResult.GetValue(CommonOptions.Merge)),
+                parseResult.GetValue(CommonOptions.Merge),
+                parseResult.GetValue(CommonOptions.CheckPullRequests)),
             cancellationToken);
     }
 }
 
-public record UpdateStackCommandInputs(string? Stack, bool? Rebase, bool? Merge)
+public record UpdateStackCommandInputs(string? Stack, bool? Rebase, bool? Merge, bool CheckPullRequests)
 {
-    public static UpdateStackCommandInputs Empty => new(null, null, null);
+    public static UpdateStackCommandInputs Empty => new(null, null, null, false);
 }
 
 public record UpdateStackCommandResponse();
@@ -87,7 +89,7 @@ public class UpdateStackCommandHandler(
 
         await displayProvider.DisplayStatus("Updating stack...", async (ct) =>
         {
-            await stackActions.UpdateStack(stack, updateStrategy, cancellationToken);
+            await stackActions.UpdateStack(stack, updateStrategy, cancellationToken, inputs.CheckPullRequests);
         }, cancellationToken);
 
         if (stack.SourceBranch.Equals(currentBranch, StringComparison.InvariantCultureIgnoreCase) ||

--- a/src/Stack/Git/CachingGitHubClient.cs
+++ b/src/Stack/Git/CachingGitHubClient.cs
@@ -48,5 +48,7 @@ public class CachingGitHubClient : IGitHubClient
         inner.OpenPullRequest(pullRequest);
     }
 
+    public void ThrowIfNotAvailable() => inner.ThrowIfNotAvailable();
+
     static string GetCacheKey(string branch) => $"pr:{branch}";
 }

--- a/src/Stack/Git/ProcessHelpers.cs
+++ b/src/Stack/Git/ProcessHelpers.cs
@@ -86,6 +86,25 @@ public static class ProcessHelpers
 
         return result;
     }
+
+    public static bool DoesCommandExist(string command)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = Environment.OSVersion.Platform == PlatformID.Win32NT ? "where" : "which",
+            Arguments = command,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var process = Process.Start(psi);
+        if (process is null) return false;
+
+        process.WaitForExit();
+        return process.ExitCode == 0;
+    }
 }
 
 public class ProcessException(string message, string filePath, string command, int exitCode) : Exception(message)

--- a/src/Stack/Git/SafeGitHubClient.cs
+++ b/src/Stack/Git/SafeGitHubClient.cs
@@ -38,6 +38,8 @@ public class SafeGitHubClient(IGitHubClient inner, ILogger<SafeGitHubClient> log
 
     public void OpenPullRequest(GitHubPullRequest pullRequest)
         => inner.OpenPullRequest(pullRequest);
+
+    public void ThrowIfNotAvailable() => inner.ThrowIfNotAvailable();
 }
 
 internal static partial class LoggerExtensionMethods

--- a/src/Stack/Infrastructure/CommonOptions.cs
+++ b/src/Stack/Infrastructure/CommonOptions.cs
@@ -70,7 +70,7 @@ public static class CommonOptions
 
     public static Option<bool> CheckPullRequests { get; } = new Option<bool>("--check-pull-requests")
     {
-        Description = "Check the status of pull requests when determining if a branch should be included in updating the stack.",
+        Description = "Check the status of pull requests as part of determining if a branch should be included when updating the stack.",
         Required = false
     };
 }

--- a/src/Stack/Infrastructure/CommonOptions.cs
+++ b/src/Stack/Infrastructure/CommonOptions.cs
@@ -67,4 +67,10 @@ public static class CommonOptions
         Description = "The name of the parent branch to put the branch under.",
         Required = false
     };
+
+    public static Option<bool> CheckPullRequests { get; } = new Option<bool>("--check-pull-requests")
+    {
+        Description = "Check the status of pull requests when determining if a branch should be included in updating the stack.",
+        Required = false
+    };
 }


### PR DESCRIPTION
Currently we always check the status of GitHub pull requests when updating a stack (during the `update` or `sync` command), this slows down the entire operation quite considerably. The default workflow that I use is to delete the remote tracking branch when a PR merges anyway so this is unnecessary.

This PR changes updating a stack to not check GitHub pull requests by default. A new option `--check-pull-requests` has been added to both the `update` and `sync` commands to support this if needed. I've also renamed the `--full` option to `--check-pull-requests` to match in the `status` command.

It also no longer checks the status of branches compared to each other as this isn't needed and only slows things down.